### PR TITLE
Add tests for IndexMapProjector, ProjectionMatrix

### DIFF
--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/projector/IndexMapProjector.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/projector/IndexMapProjector.scala
@@ -14,26 +14,39 @@
  */
 package com.linkedin.photon.ml.projector
 
-import scala.collection.Map
-
-import breeze.linalg.{SparseVector, Vector}
-
+import breeze.linalg.Vector
 import com.linkedin.photon.ml.util.VectorUtils
+
+import scala.collection.Map
 
 /**
  * A projection map that maintains the one-to-one mapping of indices between the original and projected space
  *
+ * This is expected to be used in cases where we are training models on a subset of features so that it would not make
+ * sense to deal with vectors of the size of the original dimension.
+ *
+ * e.g. If one is training a per-item model, the instances in the training set that is used for this task might only
+ *      have a small subset of the features active. In such a case, we can train a model in the smaller space for
+ *      better efficiency but we need to also map the coefficients back to the original space eventually. This class
+ *      does the projection of features to the smaller sub-space as well as projecting the features back to the
+ *      original dimensions
+ *
+ * Given the intended use case, no primary constructor is provided. It can only be constructed via the companion
+ * object's builder method
+ *
  * @param originalToProjectedSpaceMap map from original to projected space
  * @param originalSpaceDimension dimensionality of the original space
  * @param projectedSpaceDimension dimensionality of the projected space
+ *
  * @author xazhang
+ * @author nkatariy
  */
-class IndexMapProjector(
-    originalToProjectedSpaceMap: Map[Int, Int],
+class IndexMapProjector private (
+    val originalToProjectedSpaceMap: Map[Int, Int],
     override val originalSpaceDimension: Int,
     override val projectedSpaceDimension: Int) extends Projector {
 
-  private val projectedToOriginalSpaceMap = originalToProjectedSpaceMap.map(_.swap)
+  val projectedToOriginalSpaceMap = originalToProjectedSpaceMap.map(_.swap)
 
   assert(originalToProjectedSpaceMap.size == projectedToOriginalSpaceMap.size, s"The size of " +
       s"originalToProjectedSpaceMap (${originalToProjectedSpaceMap.size}) and the size of " +

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/projector/IndexMapProjectorRDD.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/projector/IndexMapProjectorRDD.scala
@@ -27,7 +27,7 @@ import com.linkedin.photon.ml.model.Coefficients
  *
  * @param indexMapProjectorRDD The projectors
  */
-class IndexMapProjectorRDD(indexMapProjectorRDD: RDD[(String, IndexMapProjector)])
+class IndexMapProjectorRDD private (indexMapProjectorRDD: RDD[(String, IndexMapProjector)])
   extends RandomEffectProjector with RDDLike {
 
   /**

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/projector/ProjectionMatrix.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/projector/ProjectionMatrix.scala
@@ -22,13 +22,20 @@ import breeze.linalg.{norm, Vector, DenseMatrix, Matrix}
 import com.linkedin.photon.ml.constants.MathConst
 
 /**
- * A class for projection matrix that is used to project the features from their original space to a different (usually
- * with lower dimension) space
+ * A class for projection matrix that is used to project the features from their original space to a different
+ * (usually, a lower dimensional) space
  *
- * @param matrix projection matrix
+ * @param matrix The projection matrix. Currently, only dense matrices are supported for projection. An exception
+ *               is thrown if any other type of matrix is passed
  * @author xazhang
+ * @author nkatariy
  */
-case class ProjectionMatrix(matrix: Matrix[Double]) extends Projector{
+case class ProjectionMatrix(matrix: Matrix[Double]) extends Projector {
+  matrix match {
+    case x: DenseMatrix[Double] =>
+    case _ => throw new UnsupportedOperationException(s"Projection matrix of class ${matrix.getClass} for features " +
+      s"projection operation is not supported")
+  }
 
   override val projectedSpaceDimension = matrix.rows
   override val originalSpaceDimension = matrix.cols
@@ -40,12 +47,7 @@ case class ProjectionMatrix(matrix: Matrix[Double]) extends Projector{
    * @return projected features
    */
   override def projectFeatures(features: Vector[Double]): Vector[Double] = {
-    matrix match {
-      case denseMatrix: DenseMatrix[Double] =>
-        matrix * features
-      case _ => throw new UnsupportedOperationException(s"Projection matrix of class ${matrix.getClass} for features " +
-          s"projection operation is not supported")
-    }
+    matrix * features
   }
 
   /**
@@ -56,9 +58,8 @@ case class ProjectionMatrix(matrix: Matrix[Double]) extends Projector{
    */
   override def projectCoefficients(coefficients: Vector[Double]): Vector[Double] = {
     matrix match {
-      case denseMatrix: DenseMatrix[Double] => denseMatrix.t * coefficients
-      case _ => throw new UnsupportedOperationException(s"Projection matrix of class ${matrix.getClass} for " +
-          s"coefficients projection operation is not supported")
+      case dm: DenseMatrix[Double] =>  dm.t * coefficients
+      case _ => throw new RuntimeException("Should never reach here! Matrix should already be validated to be dense")
     }
   }
 

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/util/VectorUtils.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/util/VectorUtils.scala
@@ -15,9 +15,9 @@
 package com.linkedin.photon.ml.util
 
 
-import scala.collection.mutable
-
 import breeze.linalg.{DenseVector, SparseVector, Vector}
+
+import scala.collection.mutable
 
 
 /**

--- a/photon-ml/src/test/scala/com/linkedin/photon/ml/projector/IndexMapProjectorTest.scala
+++ b/photon-ml/src/test/scala/com/linkedin/photon/ml/projector/IndexMapProjectorTest.scala
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2016 LinkedIn Corp. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linkedin.photon.ml.projector
+
+import breeze.linalg.{DenseVector, SparseVector, Vector}
+import org.testng.Assert
+import org.testng.annotations.Test
+
+/**
+ * @author nkatariy
+ */
+class IndexMapProjectorTest {
+  val projector = IndexMapProjector.buildIndexMapProjector(
+    List[Vector[Double]](
+      new SparseVector[Double](Array(0, 4, 6, 7, 9), Array(1.0, 4.0, 6.0, 7.0, 9.0), 10),
+      new SparseVector[Double](Array(0, 1), Array(1.0, 1.0), 10),
+      new SparseVector[Double](Array(4, 5, 7), Array(4.0, 5.0, 7.0), 10)).toIterable)
+
+  @Test
+  def testBuilder() = {
+    Assert.assertEquals(projector.originalToProjectedSpaceMap.size, 7)
+    Assert.assertEquals(projector.originalToProjectedSpaceMap.keySet, Set[Int](0, 1, 4, 5, 6, 7, 9))
+    Assert.assertEquals(projector.originalSpaceDimension, 10)
+    Assert.assertEquals(projector.projectedSpaceDimension, 7)
+  }
+
+  @Test
+  def testProjectFeatures() = {
+    val fv = new SparseVector[Double](Array(0, 2, 4, 5, 8), Array(1.0, 2.0, 4.0, 5.0, 8.0), 10)
+    val expectedActiveTuples = Set[(Int, Double)]((projector.originalToProjectedSpaceMap(0), 1.0),
+      (projector.originalToProjectedSpaceMap(4), 4.0),
+      (projector.originalToProjectedSpaceMap(5), 5.0))
+    val projected = projector.projectFeatures(fv)
+
+    // ensure it is in the expected space
+    Assert.assertEquals(projected.length, 7)
+
+    // ensure active tuples are the ones expected and non-existent features are ignored
+    Assert.assertEquals(projected.iterator
+      .filter(x => math.abs(x._2) > 0.0)
+      .toSet, expectedActiveTuples)
+  }
+
+  @Test
+  def testProjectCoefficients() = {
+    val coefficients = new DenseVector[Double](Array(0.0, 0.1, 0.2, 0.3, 0.0, 0.5, 0.6))
+    val expectedActiveTuples = Set[(Int, Double)]((projector.projectedToOriginalSpaceMap(1), 0.1),
+      (projector.projectedToOriginalSpaceMap(2), 0.2),
+      (projector.projectedToOriginalSpaceMap(3), 0.3),
+      (projector.projectedToOriginalSpaceMap(5), 0.5),
+      (projector.projectedToOriginalSpaceMap(6), 0.6))
+    val projected = projector.projectCoefficients(coefficients)
+
+    // ensure it is back in the original space
+    Assert.assertEquals(projected.length, 10)
+    // ensure active tuples are the ones expected
+    Assert.assertEquals(projected.iterator
+      .filter(x => math.abs(x._2) > 0.0)
+      .toSet, expectedActiveTuples)
+  }
+}

--- a/photon-ml/src/test/scala/com/linkedin/photon/ml/projector/ProjectionMatrixTest.scala
+++ b/photon-ml/src/test/scala/com/linkedin/photon/ml/projector/ProjectionMatrixTest.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2016 LinkedIn Corp. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linkedin.photon.ml.projector
+
+import breeze.linalg.{CSCMatrix, DenseMatrix, DenseVector}
+import org.testng.Assert
+import org.testng.annotations.Test
+
+/**
+  * @author nkatariy
+  */
+class ProjectionMatrixTest {
+   // matrix is [[1.0, 0.0, 3.0], [0.0, 2.0, 4.0]]
+   val projectionMatrix = new ProjectionMatrix(new DenseMatrix[Double](2, 3, Array(1.0, 0.0, 0.0, 2.0, 3.0, 4.0)))
+
+   @Test(expectedExceptions = Array(classOf[UnsupportedOperationException]))
+   def testConstructorWithUnsupportedMatrixType() = {
+     val _ = new ProjectionMatrix(CSCMatrix.zeros[Double](2, 3))
+   }
+
+   @Test
+   def testProjectFeatures() = {
+     // projection should be [10.0, 16.0]
+     val v = new DenseVector[Double](Array(1.0, 2.0, 3.0))
+     Assert.assertEquals(projectionMatrix.projectFeatures(v).iterator.toSet, Set[(Int, Double)]((0, 10.0), (1, 16.0)))
+   }
+
+   @Test
+   def testProjectCoefficients() = {
+     // projection should be [-2, 8, 10]
+     val coefficients = new DenseVector[Double](Array(-2.0, 4.0))
+     Assert.assertEquals(projectionMatrix.projectCoefficients(coefficients).iterator.toSet,
+       Set[(Int, Double)]((0, -2.0), (1, 8.0), (2, 10.0)))
+   }
+
+   // TODO Test gaussian random projection matrix. Current impl looks strange w.r.t the conventional way of creating
+   // random projection matrices and there are no references for how it has actually been implemented.
+ }


### PR DESCRIPTION
Copy of https://github.com/linkedin/photon-ml/pull/2. Mistakenly closed it. 
1. Test for Co-ordinateDescent will be written by Xianxing
2. The integTests for the equivalents of IndexMapProjector and ProjectionMatrix for RandomEffectDatasets are also a bit tricky due to the input being a random effect dataset. I'm still thinking through how to do that.
3. Coming soon: Tests for OptimizationProblem
