### PR TITLE
Change some of the functions/classes in GAME from public to private/protected

### DIFF
--- a/photon-ml/src/integTest/scala/com/linkedin/photon/ml/cli/game/training/DriverIntegTest.scala
+++ b/photon-ml/src/integTest/scala/com/linkedin/photon/ml/cli/game/training/DriverIntegTest.scala
@@ -20,8 +20,8 @@ import org.apache.spark.{SparkConf, SparkContext}
 import org.testng.annotations.{BeforeMethod, AfterMethod, DataProvider, Test}
 import org.testng.Assert._
 
+import com.linkedin.photon.ml.avro.AvroIOUtils
 import com.linkedin.photon.ml.avro.generated.BayesianLinearModelAvro
-import com.linkedin.photon.ml.io.AvroIOUtils
 import com.linkedin.photon.ml.SparkContextConfiguration
 import com.linkedin.photon.ml.supervised.TaskType
 import com.linkedin.photon.ml.supervised.TaskType.TaskType

--- a/photon-ml/src/integTest/scala/com/linkedin/photon/ml/io/AvroIOUtilsIntegTest.scala
+++ b/photon-ml/src/integTest/scala/com/linkedin/photon/ml/io/AvroIOUtilsIntegTest.scala
@@ -16,6 +16,7 @@ package com.linkedin.photon.ml.io
 
 import java.io.File
 
+import com.linkedin.photon.ml.avro.AvroIOUtils
 import com.linkedin.photon.ml.test.SparkTestUtils
 import com.linkedin.photon.avro.generated.FeatureAvro
 import com.linkedin.photon.ml.test.{TestTemplateWithTmpDir, SparkTestUtils}

--- a/photon-ml/src/integTest/scala/com/linkedin/photon/ml/io/ResponsePredictionAvroBuilderFactory.scala
+++ b/photon-ml/src/integTest/scala/com/linkedin/photon/ml/io/ResponsePredictionAvroBuilderFactory.scala
@@ -21,6 +21,9 @@ import com.linkedin.photon.avro.generated.FeatureAvro
 import org.apache.avro.Schema
 import org.apache.avro.generic.{GenericRecordBuilder, GenericData, GenericRecord}
 
+import com.linkedin.photon.ml.avro.ResponsePredictionFieldNames
+
+
 /**
  * This class is a factory that provides builders for building ResponsePredictionAvroRecord.
  *

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/BroadcastLike.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/BroadcastLike.scala
@@ -18,7 +18,7 @@ package com.linkedin.photon.ml
  * A trait to hold some simple operations on the Broadcasted variables
  * @author xazhang
  */
-trait BroadcastLike {
+protected[ml] trait BroadcastLike {
   /**
    * Asynchronously delete cached copies of this broadcast on the executors
    * @return This object with all its broadcasted variables unpersisted

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/RDDLike.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/RDDLike.scala
@@ -22,7 +22,7 @@ import org.apache.spark.storage.StorageLevel
  * A trait to hold some simple operations on the RDDs
  * @author xazhang
  */
-trait RDDLike {
+protected[ml] trait RDDLike {
 
   /**
    * Get the Spark context

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/algorithm/Coordinate.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/algorithm/Coordinate.scala
@@ -25,7 +25,7 @@ import com.linkedin.photon.ml.optimization.game.OptimizationTracker
  * @param dataSet the training dataset
  * @author xazhang
  */
-abstract class Coordinate[D <: DataSet[D], C <: Coordinate[D, C]](dataSet: D) {
+protected[algorithm] abstract class Coordinate[D <: DataSet[D], C <: Coordinate[D, C]](dataSet: D) {
 
   /**
    * Score the effect-specific data set in the coordinate with the input model
@@ -33,23 +33,23 @@ abstract class Coordinate[D <: DataSet[D], C <: Coordinate[D, C]](dataSet: D) {
    * @param model the input model
    * @return the output scores
    */
-  def score(model: Model): KeyValueScore
+  protected[algorithm] def score(model: Model): KeyValueScore
 
   /**
    * Initialize the model
    *
    * @param seed random seed
    */
-  def initializeModel(seed: Long): Model
+  protected[algorithm] def initializeModel(seed: Long): Model
 
-  def updateModel(model: Model, score: KeyValueScore): (Model, OptimizationTracker) = {
+  protected[algorithm] def updateModel(model: Model, score: KeyValueScore): (Model, OptimizationTracker) = {
     val dataSetWithUpdatedOffsets = dataSet.addScoresToOffsets(score)
     updateCoordinateWithDataSet(dataSetWithUpdatedOffsets).updateModel(model)
   }
 
   protected def updateCoordinateWithDataSet(dataSet: D): C
 
-  def updateModel(model: Model): (Model, OptimizationTracker)
+  protected[algorithm] def updateModel(model: Model): (Model, OptimizationTracker)
 
-  def computeRegularizationTermValue(model: Model): Double
+  protected[algorithm] def computeRegularizationTermValue(model: Model): Double
 }

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/algorithm/FactoredRandomEffectCoordinate.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/algorithm/FactoredRandomEffectCoordinate.scala
@@ -34,7 +34,7 @@ import com.linkedin.photon.ml.util.VectorUtils
  * @param factoredRandomEffectOptimizationProblem the fixed effect optimization problem
  * @author xazhang
  */
-class FactoredRandomEffectCoordinate[F <: TwiceDiffFunction[LabeledPoint]](
+protected[algorithm]  class FactoredRandomEffectCoordinate[F <: TwiceDiffFunction[LabeledPoint]](
     randomEffectDataSet: RandomEffectDataSet,
     factoredRandomEffectOptimizationProblem: FactoredRandomEffectOptimizationProblem[F])
   extends Coordinate[RandomEffectDataSet, FactoredRandomEffectCoordinate[F]](randomEffectDataSet) {
@@ -44,7 +44,7 @@ class FactoredRandomEffectCoordinate[F <: TwiceDiffFunction[LabeledPoint]](
    *
    * @param seed random seed
    */
-  override def initializeModel(seed: Long): Model = {
+  protected[algorithm] override def initializeModel(seed: Long): Model = {
     val latentSpaceDimension = factoredRandomEffectOptimizationProblem.latentSpaceDimension
     FactoredRandomEffectCoordinate.initializeModel(randomEffectDataSet, latentSpaceDimension, seed)
   }
@@ -55,7 +55,7 @@ class FactoredRandomEffectCoordinate[F <: TwiceDiffFunction[LabeledPoint]](
    * @param model the model
    * @return tuple of updated model and optimization tracker
    */
-  override def updateModel(model: Model): (Model, OptimizationTracker) = {
+  protected[algorithm] override def updateModel(model: Model): (Model, OptimizationTracker) = {
     model match {
       case factoredRandomEffectModel: FactoredRandomEffectModel =>
 
@@ -127,7 +127,7 @@ class FactoredRandomEffectCoordinate[F <: TwiceDiffFunction[LabeledPoint]](
    * @param model the model to score
    * @return scores
    */
-  override def score(model: Model): KeyValueScore = {
+  protected[algorithm] override def score(model: Model): KeyValueScore = {
     model match {
       case factoredRandomEffectModel: FactoredRandomEffectModel =>
         val projectionMatrixBroadcast = factoredRandomEffectModel.projectionMatrixBroadcast
@@ -147,7 +147,7 @@ class FactoredRandomEffectCoordinate[F <: TwiceDiffFunction[LabeledPoint]](
    * @param model the model
    * @return regularization term value
    */
-  override def computeRegularizationTermValue(model: Model): Double = {
+  protected[algorithm] override def computeRegularizationTermValue(model: Model): Double = {
     model match {
       case factoredRandomEffectModel: FactoredRandomEffectModel =>
         val coefficientsRDD = factoredRandomEffectModel.coefficientsRDDInProjectedSpace

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/algorithm/FixedEffectCoordinate.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/algorithm/FixedEffectCoordinate.scala
@@ -30,7 +30,7 @@ import com.linkedin.photon.ml.util.PhotonLogger
  * @param optimizationProblem the fixed effect optimization problem
  * @author xazhang
  */
-class FixedEffectCoordinate [F <: TwiceDiffFunction[LabeledPoint]](
+protected[algorithm] class FixedEffectCoordinate [F <: TwiceDiffFunction[LabeledPoint]](
     fixedEffectDataSet: FixedEffectDataSet,
     private var optimizationProblem: OptimizationProblem[F])
   extends Coordinate[FixedEffectDataSet, FixedEffectCoordinate[F]](fixedEffectDataSet) {
@@ -40,7 +40,7 @@ class FixedEffectCoordinate [F <: TwiceDiffFunction[LabeledPoint]](
    *
    * @param seed random seed
    */
-  def initializeModel(seed: Long): FixedEffectModel = {
+  protected[algorithm] def initializeModel(seed: Long): FixedEffectModel = {
     FixedEffectCoordinate.initializeZeroModel(fixedEffectDataSet)
   }
 
@@ -60,7 +60,7 @@ class FixedEffectCoordinate [F <: TwiceDiffFunction[LabeledPoint]](
    *
    * @param model the model to update
    */
-  override def updateModel(model: Model): (Model, OptimizationTracker) = {
+  protected[algorithm] override def updateModel(model: Model): (Model, OptimizationTracker) = {
     model match {
       case fixedEffectModel: FixedEffectModel =>
         val (updatedFixedEffectModel, updatedOptimizationProblem) =
@@ -84,7 +84,7 @@ class FixedEffectCoordinate [F <: TwiceDiffFunction[LabeledPoint]](
    * @param model the model to score
    * @return scores
    */
-  def score(model: Model): KeyValueScore = {
+  protected[algorithm] def score(model: Model): KeyValueScore = {
     model match {
       case fixedEffectModel: FixedEffectModel =>
         FixedEffectCoordinate.updateScore(fixedEffectDataSet, fixedEffectModel)
@@ -100,7 +100,7 @@ class FixedEffectCoordinate [F <: TwiceDiffFunction[LabeledPoint]](
    * @param model the model
    * @return regularization term value
    */
-  def computeRegularizationTermValue(model: Model): Double = {
+  protected[algorithm] def computeRegularizationTermValue(model: Model): Double = {
     model match {
       case fixedEffectModel: FixedEffectModel =>
         optimizationProblem.getRegularizationTermValue(fixedEffectModel.coefficients)
@@ -115,7 +115,7 @@ class FixedEffectCoordinate [F <: TwiceDiffFunction[LabeledPoint]](
    *
    * @param logger a logger instance
    */
-  def summarize(logger: PhotonLogger): Unit = {
+  protected[algorithm] def summarize(logger: PhotonLogger): Unit = {
     logger.logDebug(s"Optimization stats: ${optimizationProblem.optimizer.getStateTracker.get}")
   }
 }
@@ -127,7 +127,7 @@ object FixedEffectCoordinate {
    *
    * @param fixedEffectDataSet the dataset
    */
-  def initializeZeroModel(fixedEffectDataSet: FixedEffectDataSet): FixedEffectModel = {
+  private def initializeZeroModel(fixedEffectDataSet: FixedEffectDataSet): FixedEffectModel = {
     val numFeatures = fixedEffectDataSet.numFeatures
     val coefficients = Coefficients.initializeZeroCoefficients(numFeatures)
     val coefficientsBroadcast = fixedEffectDataSet.sparkContext.broadcast(coefficients)

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/algorithm/RandomEffectCoordinate.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/algorithm/RandomEffectCoordinate.scala
@@ -33,7 +33,8 @@ import com.linkedin.photon.ml.optimization.game.{
  * @param randomEffectOptimizationProblem the random effect optimization problem
  * @author xazhang
  */
-abstract class RandomEffectCoordinate[F <: TwiceDiffFunction[LabeledPoint], R <: RandomEffectCoordinate[F, R]](
+protected[algorithm] abstract class RandomEffectCoordinate[F <: TwiceDiffFunction[LabeledPoint],
+    R <: RandomEffectCoordinate[F, R]](
     randomEffectDataSet: RandomEffectDataSet,
     randomEffectOptimizationProblem: RandomEffectOptimizationProblem[F])
   extends Coordinate[RandomEffectDataSet, RandomEffectCoordinate[F, R]](randomEffectDataSet) {
@@ -44,7 +45,7 @@ abstract class RandomEffectCoordinate[F <: TwiceDiffFunction[LabeledPoint], R <:
    * @param model the model to score
    * @return scores
    */
-  override def score(model: Model): KeyValueScore = {
+  protected[algorithm] override def score(model: Model): KeyValueScore = {
     model match {
       case randomEffectModel: RandomEffectModel => RandomEffectCoordinate.score(randomEffectDataSet, randomEffectModel)
       case _ => throw new UnsupportedOperationException(s"Updating scores with model of type ${model.getClass} " +
@@ -57,7 +58,7 @@ abstract class RandomEffectCoordinate[F <: TwiceDiffFunction[LabeledPoint], R <:
    *
    * @param model the model to update
    */
-  override def updateModel(model: Model): (Model, OptimizationTracker) = {
+  protected[algorithm] override def updateModel(model: Model): (Model, OptimizationTracker) = {
     model match {
       case randomEffectModel: RandomEffectModel =>
         RandomEffectCoordinate.updateModel(randomEffectDataSet, randomEffectOptimizationProblem, randomEffectModel)
@@ -73,7 +74,7 @@ abstract class RandomEffectCoordinate[F <: TwiceDiffFunction[LabeledPoint], R <:
    * @param model the model
    * @return regularization term value
    */
-  override def computeRegularizationTermValue(model: Model): Double = {
+  protected[algorithm] override def computeRegularizationTermValue(model: Model): Double = {
     model match {
       case randomEffectModel: RandomEffectModel =>
         randomEffectOptimizationProblem.getRegularizationTermValue(randomEffectModel.coefficientsRDD)
@@ -91,6 +92,7 @@ abstract class RandomEffectCoordinate[F <: TwiceDiffFunction[LabeledPoint], R <:
    */
   override protected def updateCoordinateWithDataSet(
       updatedRandomEffectDataSet: RandomEffectDataSet): RandomEffectCoordinate[F, R] = {
+
     updateRandomEffectCoordinateWithDataSet(updatedRandomEffectDataSet)
   }
 
@@ -111,9 +113,8 @@ object RandomEffectCoordinate {
    * @param randomEffectModel the model
    * @return scores
    */
-  protected[algorithm] def score(
-      randomEffectDataSet: RandomEffectDataSet,
-      randomEffectModel: RandomEffectModel) : KeyValueScore = {
+  protected[algorithm] def score(randomEffectDataSet: RandomEffectDataSet, randomEffectModel: RandomEffectModel)
+  : KeyValueScore = {
 
     val activeScores = randomEffectDataSet.activeData.join(randomEffectModel.coefficientsRDD)
         .flatMap { case (individualId, (localDataSet, coefficients)) =>

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/algorithm/RandomEffectCoordinateInProjectedSpace.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/algorithm/RandomEffectCoordinateInProjectedSpace.scala
@@ -29,7 +29,7 @@ import com.linkedin.photon.ml.optimization.game.{OptimizationTracker, RandomEffe
  * @param randomEffectOptimizationProblem the fixed effect optimization problem
  * @author xazhang
  */
-class RandomEffectCoordinateInProjectedSpace[F <: TwiceDiffFunction[LabeledPoint]](
+protected[algorithm] class RandomEffectCoordinateInProjectedSpace[F <: TwiceDiffFunction[LabeledPoint]](
     randomEffectDataSetInProjectedSpace: RandomEffectDataSetInProjectedSpace,
     randomEffectOptimizationProblem: RandomEffectOptimizationProblem[F])
   extends RandomEffectCoordinate[F, RandomEffectCoordinateInProjectedSpace[F]](
@@ -40,7 +40,7 @@ class RandomEffectCoordinateInProjectedSpace[F <: TwiceDiffFunction[LabeledPoint
    *
    * @param seed random seed
    */
-  override def initializeModel(seed: Long): Model = {
+  protected[algorithm] override def initializeModel(seed: Long): Model = {
     RandomEffectCoordinateInProjectedSpace.initializeZeroModel(randomEffectDataSetInProjectedSpace)
   }
 
@@ -50,7 +50,7 @@ class RandomEffectCoordinateInProjectedSpace[F <: TwiceDiffFunction[LabeledPoint
    * @param model the model
    * @return tuple of updated model and optimization tracker
    */
-  override def updateModel(model: Model): (Model, OptimizationTracker) = {
+  protected[algorithm] override def updateModel(model: Model): (Model, OptimizationTracker) = {
     model match {
       case randomEffectModelWithProjector: RandomEffectModelInProjectedSpace =>
         val randomEffectModel = randomEffectModelWithProjector.toRandomEffectModel
@@ -71,7 +71,7 @@ class RandomEffectCoordinateInProjectedSpace[F <: TwiceDiffFunction[LabeledPoint
    * @param model the model to score
    * @return scores
    */
-  override def score(model: Model): KeyValueScore = {
+  protected[algorithm] override def score(model: Model): KeyValueScore = {
     model match {
       case randomEffectModelWithProjector: RandomEffectModelInProjectedSpace =>
         val randomEffectModel = randomEffectModelWithProjector.toRandomEffectModel
@@ -88,7 +88,7 @@ class RandomEffectCoordinateInProjectedSpace[F <: TwiceDiffFunction[LabeledPoint
    * @param model the model
    * @return regularization term value
    */
-  override def computeRegularizationTermValue(model: Model): Double = {
+  protected[algorithm] override def computeRegularizationTermValue(model: Model): Double = {
     model match {
       case randomEffectModelWithProjector: RandomEffectModelInProjectedSpace =>
         val randomEffectModel = randomEffectModelWithProjector.toRandomEffectModel

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/avro/AvroFieldNames.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/avro/AvroFieldNames.scala
@@ -12,21 +12,18 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-package com.linkedin.photon.ml.constants
+package com.linkedin.photon.ml.avro
 
 /**
- * Avro field names
+ * Field names in the Avro data set
  *
  * @author xazhang
- * @todo Unify the field names for different applications (feed, jymbii)
  */
 object AvroFieldNames {
-  val FEATURES: String = "features"
-  val NAME: String = "name"
-  val TERM: String = "term"
-  val VALUE: String = "value"
-  val RESPONSE: String = "response"
-  val OFFSET: String = "offset"
-  val WEIGHT: String = "weight"
-  val EMPTY_STRING: String = ""
+  protected[avro] val NAME: String = "name"
+  protected[avro] val TERM: String = "term"
+  protected[avro] val VALUE: String = "value"
+  protected[avro] val RESPONSE: String = "response"
+  protected[avro] val OFFSET: String = "offset"
+  protected[avro] val WEIGHT: String = "weight"
 }

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/avro/AvroIOUtils.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/avro/AvroIOUtils.scala
@@ -12,7 +12,9 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-package com.linkedin.photon.ml.io
+package com.linkedin.photon.ml.avro
+
+import scala.reflect.ClassTag
 
 import org.apache.avro.Schema
 import org.apache.avro.Schema.Parser
@@ -25,8 +27,6 @@ import org.apache.hadoop.io.NullWritable
 import org.apache.hadoop.mapred.JobConf
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
-
-import scala.reflect.ClassTag
 
 /**
  * Utility to write Avro files

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/avro/FieldNames.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/avro/FieldNames.scala
@@ -12,18 +12,20 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-package com.linkedin.photon.ml.io
+package com.linkedin.photon.ml.avro
+
+import com.linkedin.photon.ml.supervised.model.GeneralizedLinearModel
 
 /**
- * Metronome's TrainingExample format fields name
+ * Field names of the Avro formatted file used as input of [[GeneralizedLinearModel]]
  * @author xazhang
  */
-object TrainingExampleFieldNames extends FieldNames {
-  val features: String = "features"
-  val name: String = "name"
-  val term: String = "term"
-  val value: String = "value"
-  val response: String = "label"
-  val offset: String = "offset"
-  val weight: String = "weight"
+trait FieldNames extends Serializable {
+  val features: String
+  val name: String
+  val term: String
+  val value: String
+  val response: String
+  val offset: String
+  val weight: String
 }

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/avro/ResponsePredictionFieldNames.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/avro/ResponsePredictionFieldNames.scala
@@ -12,20 +12,19 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-package com.linkedin.photon.ml.io
+package com.linkedin.photon.ml.avro
 
-import com.linkedin.photon.ml.supervised.model.GeneralizedLinearModel
 
 /**
- * Field names of the Avro formatted file used as input of [[GeneralizedLinearModel]]
+ * ADMM's Response prediction format fields name
  * @author xazhang
  */
-trait FieldNames extends Serializable {
-  val features: String
-  val name: String
-  val term: String
-  val value: String
-  val response: String
-  val offset: String
-  val weight: String
+object ResponsePredictionFieldNames extends FieldNames {
+  val features: String = "features"
+  val name: String = "name"
+  val term: String = "term"
+  val value: String = "value"
+  val response: String = "response"
+  val offset: String = "offset"
+  val weight: String = "weight"
 }

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/avro/data/DataProcessingUtils.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/avro/data/DataProcessingUtils.scala
@@ -22,8 +22,7 @@ import breeze.linalg.Vector
 import org.apache.avro.generic.GenericRecord
 import org.apache.spark.rdd.RDD
 
-import com.linkedin.photon.ml.avro.AvroUtils
-import com.linkedin.photon.ml.constants.AvroFieldNames
+import com.linkedin.photon.ml.avro.{AvroFieldNames, AvroUtils}
 import com.linkedin.photon.ml.data.GameData
 import com.linkedin.photon.ml.util.{Utils, VectorUtils}
 
@@ -32,9 +31,10 @@ import com.linkedin.photon.ml.util.{Utils, VectorUtils}
  * A collection of utility functions on Avro formatted data
  * @author xazhang
  */
-protected[photon] object DataProcessingUtils {
+object DataProcessingUtils {
 
-  def parseAndGenerateGameDataSetFromGenericRecords(
+  //TODO: Change the scope to [[com.linkedin.photon.ml.avro]] after Avro related classes/functons are decoupled from the rest of code
+  protected[ml] def parseAndGenerateGameDataSetFromGenericRecords(
       records: RDD[GenericRecord],
       featureShardIdToFeatureSectionKeysMap: Map[String, Set[String]],
       featureShardIdToFeatureMapMap: Map[String, Map[NameAndTerm, Int]],

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/avro/data/NameAndTerm.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/avro/data/NameAndTerm.scala
@@ -15,9 +15,11 @@
 package com.linkedin.photon.ml.avro.data
 
 /**
+ * A compact way to represent the feature key as (name, term) pair.
  * @author xazhang
  */
-case class NameAndTerm(name: String, term: String) {
+//TODO: Change the scope of this class and all functions in the companion object to [[com.linkedin.photon.ml.avro]] after Avro related classes/functons are decoupled from the rest of code
+protected[ml] case class NameAndTerm(name: String, term: String) {
 
   override def hashCode: Int = {
     (name + NameAndTerm.DELIMITER + term).hashCode
@@ -28,8 +30,8 @@ case class NameAndTerm(name: String, term: String) {
   }
 }
 
-protected[avro] object NameAndTerm {
+object NameAndTerm {
   private val DELIMITER = "\u0000"
 
-  val INTERCEPT_NAME_AND_TERM = NameAndTerm("(INTERCEPT)", "")
+  protected[ml] val INTERCEPT_NAME_AND_TERM = NameAndTerm("(INTERCEPT)", "")
 }

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/avro/data/NameAndTermFeatureSetContainer.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/avro/data/NameAndTermFeatureSetContainer.scala
@@ -36,7 +36,8 @@ import com.linkedin.photon.ml.util._
  * @param nameAndTermFeatureSets A [[Map]] of feature section key to [[NameAndTerm]] feature sets
  * @author xazhang
  */
-protected[photon] class NameAndTermFeatureSetContainer(nameAndTermFeatureSets: Map[String, Set[NameAndTerm]]) {
+//TODO: Change the scope to [[com.linkedin.photon.ml.avro]] after Avro related classes/functons are decoupled from the rest of code
+protected[ml] class NameAndTermFeatureSetContainer(nameAndTermFeatureSets: Map[String, Set[NameAndTerm]]) {
 
   def getFeatureNameAndTermToIndexMap(featureSectionKeys: Set[String], isAddingIntercept: Boolean)
   : Map[NameAndTerm, Int] = {
@@ -64,7 +65,7 @@ protected[photon] class NameAndTermFeatureSetContainer(nameAndTermFeatureSets: M
   }
 }
 
-protected[photon] object NameAndTermFeatureSetContainer {
+object NameAndTermFeatureSetContainer {
 
   /**
    * Generate the [[NameAndTermFeatureSetContainer]] from a [[RDD]] of [[GenericRecord]]s.
@@ -72,7 +73,7 @@ protected[photon] object NameAndTermFeatureSetContainer {
    * @param featureSectionKeys The set of feature section keys of interest in the input generic records
    * @return The generated [[NameAndTermFeatureSetContainer]]
    */
-  def generateFromGenericRecords(
+  private def generateFromGenericRecords(
       genericRecords: RDD[GenericRecord],
       featureSectionKeys: Set[String]): NameAndTermFeatureSetContainer = {
 
@@ -110,7 +111,8 @@ protected[photon] object NameAndTermFeatureSetContainer {
    * @param configuration The Hadoop configuration
    * @return This [[NameAndTermFeatureSetContainer]] parsed from text files on HDFS
    */
-  def loadFromTextFiles(
+  //TODO: Change the scope to [[com.linkedin.photon.ml.avro]] after Avro related classes/functons are decoupled from the rest of code
+  protected[ml] def loadFromTextFiles(
       nameAndTermFeatureSetContainerInputDir: String,
       featureSectionKeys: Set[String],
       configuration: Configuration): NameAndTermFeatureSetContainer = {

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/avro/model/ModelProcessingUtils.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/avro/model/ModelProcessingUtils.scala
@@ -22,24 +22,26 @@ import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.rdd.RDD
 
 import com.linkedin.photon.ml.avro.generated.BayesianLinearModelAvro
-import com.linkedin.photon.ml.avro.AvroUtils
+import com.linkedin.photon.ml.avro.{AvroIOUtils, AvroUtils}
 import com.linkedin.photon.ml.avro.data.NameAndTerm
-import com.linkedin.photon.ml.io.AvroIOUtils
 import com.linkedin.photon.ml.model.{Coefficients, RandomEffectModel, FixedEffectModel, Model}
 import com.linkedin.photon.ml.util.{IOUtils, Utils}
 
 
 /**
+ * Some basic functions to read/write GAME models from/to HDFS. The current implementaion assumes the models are stored
+ * using Avro format.
  * @author xazhang
  */
-protected[photon] object ModelProcessingUtils {
+//TODO: Change the scope of all functions in the object to [[com.linkedin.photon.ml.avro]] after Avro related classes/functons are decoupled from the rest of code
+object ModelProcessingUtils {
   private val DEFAULT_AVRO_FILE_NAME = "part-00000.avro"
   private val ID_INFO = "id-info"
   private val COEFFICIENTS = "coefficients"
   private val FIXED_EFFECT = "fixed-effect"
   private val RANDOM_EFFECT = "random-effect"
 
-  def saveGameModelsToHDFS(
+  protected[ml] def saveGameModelsToHDFS(
       gameModel: Iterable[Model],
       featureShardIdToFeatureMapMap: Map[String, Map[NameAndTerm, Int]],
       outputDir: String,
@@ -89,7 +91,7 @@ protected[photon] object ModelProcessingUtils {
     }
   }
 
-  def loadGameModelFromHDFS(
+  protected[ml] def loadGameModelFromHDFS(
       featureShardIdToFeatureMapMap: Map[String, Map[NameAndTerm, Int]],
       inputDir: String,
       sparkContext: SparkContext): Iterable[Model] = {
@@ -196,7 +198,8 @@ protected[photon] object ModelProcessingUtils {
     Coefficients(combinedMeans, variancesOption = None)
   }
 
-  def collapseGameModel(gameModel: Map[String, Model], sparkContext: SparkContext): Map[(String, String), Model] = {
+  protected[ml] def collapseGameModel(gameModel: Map[String, Model], sparkContext: SparkContext)
+  : Map[(String, String), Model] = {
 
     gameModel.toArray.map {
       case (modelId, fixedEffectModel: FixedEffectModel) =>

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/avro/model/TrainingExampleFieldNames.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/avro/model/TrainingExampleFieldNames.scala
@@ -12,18 +12,21 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-package com.linkedin.photon.ml.io
+package com.linkedin.photon.ml.avro.model
+
+import com.linkedin.photon.ml.avro.FieldNames
+
 
 /**
- * ADMM's Response prediction format fields name
+ * Metronome's TrainingExample format fields name
  * @author xazhang
  */
-object ResponsePredictionFieldNames extends FieldNames {
+object TrainingExampleFieldNames extends FieldNames {
   val features: String = "features"
   val name: String = "name"
   val term: String = "term"
   val value: String = "value"
-  val response: String = "response"
+  val response: String = "label"
   val offset: String = "offset"
   val weight: String = "weight"
 }

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/cli/game/training/Params.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/cli/game/training/Params.scala
@@ -77,7 +77,7 @@ case class Params(
 }
 
 object Params {
-  def parseFromCommandLine(args: Array[String]): Params = {
+  protected[training] def parseFromCommandLine(args: Array[String]): Params = {
     val defaultParams = Params()
     val parser = new OptionParser[Params]("Photon-Game") {
       opt[String]("train-input-dirs")

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/constants/MathConst.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/constants/MathConst.scala
@@ -20,9 +20,9 @@ package com.linkedin.photon.ml.constants
  * @author xazhang
  */
 object MathConst {
-  val HIGH_PRECISION_TOLERANCE_THRESHOLD: Double = 1e-12
-  val MEDIUM_PRECISION_TOLERANCE_THRESHOLD: Double = 1e-8
-  val LOW_PRECISION_TOLERANCE_THRESHOLD: Double = 1e-4
-  val RANDOM_SEED: Long = 1234567890L
-  val POSITIVE_RESPONSE_THRESHOLD = 0.5
+  protected[ml] val HIGH_PRECISION_TOLERANCE_THRESHOLD: Double = 1e-12
+  protected[ml] val MEDIUM_PRECISION_TOLERANCE_THRESHOLD: Double = 1e-8
+  protected[ml] val LOW_PRECISION_TOLERANCE_THRESHOLD: Double = 1e-4
+  protected[ml] val RANDOM_SEED: Long = 1234567890L
+  protected[ml] val POSITIVE_RESPONSE_THRESHOLD = 0.5
 }

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/constants/StorageLevel.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/constants/StorageLevel.scala
@@ -22,6 +22,6 @@ import org.apache.spark.storage.{StorageLevel => SparkStorageLevel}
  * @author xazhang
  */
 object StorageLevel {
-  val FREQUENT_REUSE_RDD_STORAGE_LEVEL = SparkStorageLevel.MEMORY_AND_DISK
-  val INFREQUENT_REUSE_RDD_STORAGE_LEVEL = SparkStorageLevel.DISK_ONLY
+  protected[ml] val FREQUENT_REUSE_RDD_STORAGE_LEVEL = SparkStorageLevel.MEMORY_AND_DISK
+  protected[ml] val INFREQUENT_REUSE_RDD_STORAGE_LEVEL = SparkStorageLevel.DISK_ONLY
 }

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/data/DataSet.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/data/DataSet.scala
@@ -20,7 +20,7 @@ package com.linkedin.photon.ml.data
  *
  * @author xazhang
  */
-trait DataSet[D] {
+protected[ml] trait DataSet[D] {
 
   /**
    * Add scores to data offsets

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/data/FixedEffectDataConfiguration.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/data/FixedEffectDataConfiguration.scala
@@ -19,7 +19,7 @@ package com.linkedin.photon.ml.data
  *
  * @author xazhang
  */
-case class FixedEffectDataConfiguration(featureShardId: String, numPartitions: Int) {
+protected[ml] case class FixedEffectDataConfiguration(featureShardId: String, numPartitions: Int) {
   override def toString: String = s"featureShardId: $featureShardId, numPartitions: $numPartitions"
 }
 
@@ -33,7 +33,7 @@ object FixedEffectDataConfiguration {
    * @param string the string representation
    * @return the configuration object
    */
-  def parseAndBuildFromString(string: String): FixedEffectDataConfiguration = {
+  protected[ml] def parseAndBuildFromString(string: String): FixedEffectDataConfiguration = {
 
     val expectedTokenLength = 2
     val configParams = string.split(SPLITTER)

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/data/FixedEffectDataSet.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/data/FixedEffectDataSet.scala
@@ -28,7 +28,7 @@ import com.linkedin.photon.ml.RDDLike
  * @param featureShardId the feature shard id
  * @author xazhang
  */
-class FixedEffectDataSet(val labeledPoints: RDD[(Long, LabeledPoint)], val featureShardId: String)
+protected[ml] class FixedEffectDataSet(val labeledPoints: RDD[(Long, LabeledPoint)], val featureShardId: String)
   extends DataSet[FixedEffectDataSet] with RDDLike {
 
   lazy val numFeatures = labeledPoints.first()._2.features.length
@@ -36,7 +36,7 @@ class FixedEffectDataSet(val labeledPoints: RDD[(Long, LabeledPoint)], val featu
   /**
    * Add scores to data offsets
    *
-   * @param keyScore the scores
+   * @param scores the scores used throughout the coordinate descent algorithm
    */
   def addScoresToOffsets(scores: KeyValueScore): FixedEffectDataSet = {
     val updatedLabeledPoints = labeledPoints.leftOuterJoin(scores.scores)
@@ -92,7 +92,7 @@ object FixedEffectDataSet {
    * @param fixedEffectDataConfiguration the data configuration
    * @return new dataset with given configuration
    */
-  def buildWithConfiguration(
+  protected[ml] def buildWithConfiguration(
       gameDataSet: RDD[(Long, GameData)],
       fixedEffectDataConfiguration: FixedEffectDataConfiguration): FixedEffectDataSet = {
 

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/data/GameData.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/data/GameData.scala
@@ -26,10 +26,10 @@ import breeze.linalg.Vector
  * @param weight the importance weight
  * @param featureShardContainer the sharded feature vectors
  * @param randomEffectIdToIndividualIdMap a map from random effect type id to actual individual id
- *   (e.g. "memberId" -> "abc123")
+ *   (e.g. "memberId" -> "1234" or "itemId" -> "abcd")
  * @author xazhang
  */
-class GameData(
+protected[ml] class GameData(
     val response: Double,
     val offset: Double,
     val weight: Double,

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/data/KeyValueScore.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/data/KeyValueScore.scala
@@ -22,12 +22,15 @@ import org.apache.spark.storage.StorageLevel
 import com.linkedin.photon.ml.RDDLike
 
 /**
- * Key value score accumulator representation
+ * The scores used throughout [[com.linkedin.photon.ml.algorithm.CoordinateDescent]], in order to carry on both the
+ * offsets and residuals computed during each iteration. In the current implementation, the scores are of form
+ * [[RDD]][([[Long]], [[Double]])], where the [[Long]] typed variable represents the unique ID of each data point,
+ * while the [[Double]] typed variable represents the score.
  *
  * @param scores the scores
  * @author xazhang
  */
-class KeyValueScore(val scores: RDD[(Long, Double)]) extends RDDLike {
+protected[ml] class KeyValueScore(val scores: RDD[(Long, Double)]) extends RDDLike {
 
   override def sparkContext: SparkContext = scores.sparkContext
 
@@ -52,7 +55,7 @@ class KeyValueScore(val scores: RDD[(Long, Double)]) extends RDDLike {
   }
 
   /**
-   * Accumulate key value score values
+   * The plus operation for the key value scores
    *
    * @param that the other key value score instance
    * @return a new key value score instance encapsulating the accumulated values
@@ -66,10 +69,10 @@ class KeyValueScore(val scores: RDD[(Long, Double)]) extends RDDLike {
   }
 
   /**
-   * Remove key value score values
+   * The minus operation for the key value scores
    *
    * @param that the other key value score instance
-   * @return a new key value score instance encapsulating the accumulated values
+   * @return a new key value score instance encapsulating the subtracted values
    */
   def -(that: KeyValueScore): KeyValueScore = {
     val subtractedScores =

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/data/LocalDataSet.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/data/LocalDataSet.scala
@@ -33,7 +33,7 @@ import com.linkedin.photon.ml.projector.Projector
  *       Array: overhead in sorting the entries by key
  *       Map: overhead in accessing value by key
  */
-case class LocalDataSet(dataPoints: Array[(Long, LabeledPoint)]) {
+protected[ml] case class LocalDataSet(dataPoints: Array[(Long, LabeledPoint)]) {
 
   val numDataPoints = dataPoints.length
   val numFeatures = if (numDataPoints > 0) dataPoints.head._2.features.length else 0
@@ -141,7 +141,7 @@ case class LocalDataSet(dataPoints: Array[(Long, LabeledPoint)]) {
    * @param numSamplesToKeep number of samples to keep
    * @return sampled dataset
    */
-  protected[ml] def reservoirSamplingOnAllSamples(numSamplesToKeep: Int): LocalDataSet = {
+  def reservoirSamplingOnAllSamples(numSamplesToKeep: Int): LocalDataSet = {
     if (numSamplesToKeep == 0) {
       LocalDataSet(Array())
     } else if (numSamplesToKeep < numDataPoints) {
@@ -158,7 +158,7 @@ case class LocalDataSet(dataPoints: Array[(Long, LabeledPoint)]) {
 
 object LocalDataSet {
 
-  def apply(dataPoints: Array[(Long, LabeledPoint)], isSortedByFirstIndex: Boolean): LocalDataSet = {
+  protected[ml] def apply(dataPoints: Array[(Long, LabeledPoint)], isSortedByFirstIndex: Boolean): LocalDataSet = {
     if (isSortedByFirstIndex) LocalDataSet(dataPoints)
     else LocalDataSet(dataPoints.sortBy(_._1))
   }

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/data/MinHeapWithFixedCapacity.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/data/MinHeapWithFixedCapacity.scala
@@ -27,7 +27,7 @@ import scala.reflect.ClassTag
  * @param capacity buffer capacity
  * @author xazhang
  */
-class MinHeapWithFixedCapacity[T <: Comparable[T] : ClassTag](capacity: Int) extends Serializable {
+protected[ml] class MinHeapWithFixedCapacity[T <: Comparable[T] : ClassTag](capacity: Int) extends Serializable {
 
   private val arrayBuffer = new mutable.ArrayBuffer[T](2)
   var cumCount = 0
@@ -80,6 +80,7 @@ class MinHeapWithFixedCapacity[T <: Comparable[T] : ClassTag](capacity: Int) ext
       }
       val minSize = math.min(thisHeap.size(), thatHeap.size())
       val maxSize = math.max(thisHeap.size(), thatHeap.size())
+      // Determine which strategy to merge two heaps based on their corresponding heap size.
       if (capacity < minSize * (31 - Integer.numberOfLeadingZeros(maxSize))) {
         val thisArray = thisHeap.toArray.asInstanceOf[Array[T]]
         val thatArray = thatHeap.toArray.asInstanceOf[Array[T]]

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/data/RandomEffectDataConfiguration.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/data/RandomEffectDataConfiguration.scala
@@ -34,8 +34,9 @@ import com.linkedin.photon.ml.projector.ProjectorType._
  * @param numFeaturesToSamplesRatioUpperBound The upper bound on the ratio between number of features and number of
  *                                            samples used for feature selection for each individual-id level local
  *                                            data set in the random effect data set.
+ * @author xazhang
  */
-case class RandomEffectDataConfiguration(
+protected[ml] case class RandomEffectDataConfiguration(
     randomEffectId: String,
     featureShardId: String,
     numPartitions: Int,
@@ -62,13 +63,12 @@ object RandomEffectDataConfiguration {
   private val FIRST_LEVEL_SPLITTER = ","
   private val SECOND_LEVEL_SPLITTER = "="
 
-  //TODO: Need a better way to parse the configuration from a structured string, or better from a text/JSON file
   /**
    * Parse and build the [[RandomEffectDataConfiguration]] from the input [[String]]
    * @param string The input [[String]]
    * @return The parsed and built random effect data configuration
    */
-  def parseAndBuildFromString(string: String): RandomEffectDataConfiguration = {
+  protected[ml] def parseAndBuildFromString(string: String): RandomEffectDataConfiguration = {
 
     val expectedTokenLength = 7
     val configParams = string.split(FIRST_LEVEL_SPLITTER)

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/data/RandomEffectDataSet.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/data/RandomEffectDataSet.scala
@@ -26,7 +26,7 @@ import com.linkedin.photon.ml.{BroadcastLike, RDDLike}
 import com.linkedin.photon.ml.constants.StorageLevel
 
 /**
- * Dataset implementation for random effect datasets. passiveData + activeData = full sharded data set
+ * Data set implementation for random effect datasets. passiveData + activeData = full sharded data set
  *
  * @param activeData Grouped data sets mostly to train the sharded model and score the whole data set.
  * @param globalIdToIndividualIds global id to individual id map
@@ -36,7 +36,7 @@ import com.linkedin.photon.ml.constants.StorageLevel
  * @param featureShardId the feature shard id
  * @author xazhang
  */
-class RandomEffectDataSet(
+protected[ml] class RandomEffectDataSet(
     val activeData: RDD[(String, LocalDataSet)],
     protected[data] val globalIdToIndividualIds: RDD[(Long, String)],
     val passiveDataOption: Option[RDD[(Long, (String, LabeledPoint))]],
@@ -169,7 +169,7 @@ object RandomEffectDataSet {
    * @param randomEffectPartitioner The per random effect partitioner used to generated the grouped active data
    * @return
    */
-  def buildWithConfiguration(
+  protected[ml] def buildWithConfiguration(
       gameDataSet: RDD[(Long, GameData)],
       randomEffectDataConfiguration: RandomEffectDataConfiguration,
       randomEffectPartitioner: Partitioner): RandomEffectDataSet = {

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/data/RandomEffectIdPartitioner.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/data/RandomEffectIdPartitioner.scala
@@ -21,12 +21,13 @@ import org.apache.spark.{HashPartitioner, Partitioner}
 import org.apache.spark.rdd.RDD
 
 /**
- * Spark partitioner implementation for random effect datasets
+ * Spark partitioner implementation for random effect datasets, that takes the imbalanced data size across different
+ * random effects into account (e.g., a popular item may be associated with more data points than a less popular one)
  *
  * @param idToPartitionMap random effect id to partition map
  * @author xazhang
  */
-class RandomEffectIdPartitioner(idToPartitionMap: Broadcast[Map[String, Int]]) extends Partitioner {
+protected[ml] class RandomEffectIdPartitioner(idToPartitionMap: Broadcast[Map[String, Int]]) extends Partitioner {
 
   val partitions = idToPartitionMap.value.values.max + 1
 

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/evaluation/BinaryClassificationEvaluator.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/evaluation/BinaryClassificationEvaluator.scala
@@ -24,13 +24,14 @@ import org.apache.spark.rdd.RDD
  * @param defaultScore default score
  * @author xazhang
  */
-class BinaryClassificationEvaluator(labelAndOffsets: RDD[(Long, (Double, Double))], defaultScore: Double = 0.0)
-  extends Evaluator {
+protected[ml] class BinaryClassificationEvaluator(
+    labelAndOffsets: RDD[(Long, (Double, Double))],
+    defaultScore: Double = 0.0) extends Evaluator {
 
   /**
-   * Evaluate scores
+   * Evaluate the scores of the model
    *
-   * @param score the scores to evaluate
+   * @param scores the scores to evaluate
    * @return score metric value
    */
   override def evaluate(scores: RDD[(Long, Double)]): Double = {

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/evaluation/Evaluator.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/evaluation/Evaluator.scala
@@ -21,12 +21,12 @@ import org.apache.spark.rdd.RDD
  *
  * @author xazhang
  */
-trait Evaluator {
+protected[ml] trait Evaluator {
 
   /**
-   * Evaluate scores
+   * Evaluate the scores of the model
    *
-   * @param score the scores to evaluate
+   * @param scores the scores to evaluate
    * @return score metric value
    */
   def evaluate(scores: RDD[(Long, Double)]): Double

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/evaluation/LogisticLossEvaluator.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/evaluation/LogisticLossEvaluator.scala
@@ -27,14 +27,14 @@ import com.linkedin.photon.ml.util.Utils
  * @param defaultScore default score
  * @author xazhang
  */
-class LogisticLossEvaluator(
+protected[ml] class LogisticLossEvaluator(
     labelAndOffsetAndWeights: RDD[(Long, (Double, Double, Double))],
     defaultScore: Double = 0.0) extends Evaluator {
 
   /**
-   * Evaluate scores
+   * Evaluate the scores of the model
    *
-   * @param score the scores to evaluate
+   * @param scores the scores to evaluate
    * @return score metric value
    */
   def evaluate(scores: RDD[(Long, Double)]): Double = {

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/evaluation/RMSEEvaluator.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/evaluation/RMSEEvaluator.scala
@@ -24,16 +24,16 @@ import org.apache.spark.rdd.RDD
  * @param defaultScore default score
  * @author xazhang
  */
-class RMSEEvaluator(
+protected[ml] class RMSEEvaluator(
     labelAndOffsetAndWeights: RDD[(Long, (Double, Double, Double))],
     defaultScore: Double = 0.0) extends Evaluator {
 
   val squaredLossEvaluator = new SquaredLossEvaluator(labelAndOffsetAndWeights, defaultScore)
 
   /**
-   * Evaluate scores
+   * Evaluate the scores of the model
    *
-   * @param score the scores to evaluate
+   * @param scores the scores to evaluate
    * @return score metric value
    */
   override def evaluate(scores: RDD[(Long, Double)]): Double = {

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/evaluation/SquaredLossEvaluator.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/evaluation/SquaredLossEvaluator.scala
@@ -26,14 +26,14 @@ import com.linkedin.photon.ml.util.Utils
  * @param defaultScore default score
  * @author xazhang
  */
-class SquaredLossEvaluator(
+protected[ml] class SquaredLossEvaluator(
     labelAndOffsetAndWeights: RDD[(Long, (Double, Double, Double))],
     defaultScore: Double = 0.0) extends Evaluator {
 
   /**
-   * Evaluate scores
+   * Evaluate the scores of the model
    *
-   * @param score the scores to evaluate
+   * @param scores the scores to evaluate
    * @return score metric value
    */
   override def evaluate(scores: RDD[(Long, Double)]): Double = {

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/io/GLMSuite.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/io/GLMSuite.scala
@@ -21,6 +21,8 @@ import java.util.{List => JList, Map => JMap}
 import breeze.linalg.SparseVector
 import FieldNamesType._
 import com.linkedin.photon.avro.generated.FeatureSummarizationResultAvro
+import com.linkedin.photon.ml.avro.{ResponsePredictionFieldNames, AvroIOUtils}
+import com.linkedin.photon.ml.avro.model.TrainingExampleFieldNames
 import com.linkedin.photon.ml.data
 import com.linkedin.photon.ml.data.LabeledPoint
 import com.linkedin.photon.ml.stat.BasicStatisticalSummary

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/model/Coefficients.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/model/Coefficients.scala
@@ -24,7 +24,7 @@ import breeze.stats.meanAndVariance
  * @param variancesOption optional variance of the model coefficients
  * @author xazhang
  */
-case class Coefficients(means: Vector[Double], variancesOption: Option[Vector[Double]]) {
+protected[ml] case class Coefficients(means: Vector[Double], variancesOption: Option[Vector[Double]]) {
 
   lazy val meansL2Norm: Double = norm(means, 2)
   lazy val variancesL2NormOption: Option[Double] = variancesOption.map(variances => norm(variances, 2))
@@ -55,7 +55,7 @@ case class Coefficients(means: Vector[Double], variancesOption: Option[Vector[Do
   }
 }
 
-object Coefficients {
+protected[ml] object Coefficients {
 
   /**
    * Create a zero coefficient vector

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/model/FactoredRandomEffectModel.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/model/FactoredRandomEffectModel.scala
@@ -24,7 +24,7 @@ import com.linkedin.photon.ml.projector.ProjectionMatrixBroadcast
  *
  * @author xazhang
  */
-class FactoredRandomEffectModel(
+protected[ml] class FactoredRandomEffectModel(
     override val coefficientsRDDInProjectedSpace: RDD[(String, Coefficients)],
     val projectionMatrixBroadcast: ProjectionMatrixBroadcast,
     override val randomEffectId: String,

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/model/FixedEffectModel.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/model/FixedEffectModel.scala
@@ -28,7 +28,7 @@ import com.linkedin.photon.ml.data.{KeyValueScore, GameData}
  * @param featureShardId the feature shard id
  * @author xazhang
  */
-class FixedEffectModel(val coefficientsBroadcast: Broadcast[Coefficients], val featureShardId: String)
+protected[ml] class FixedEffectModel(val coefficientsBroadcast: Broadcast[Coefficients], val featureShardId: String)
   extends Model with BroadcastLike {
 
   def coefficients: Coefficients = coefficientsBroadcast.value

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/model/Model.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/model/Model.scala
@@ -23,7 +23,7 @@ import com.linkedin.photon.ml.data.{KeyValueScore, GameData}
  *
  * @author xazhang
  */
-trait Model {
+protected[ml] trait Model {
 
   /**
    * Compute the score for the GAME data set.

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/model/RandomEffectModel.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/model/RandomEffectModel.scala
@@ -30,7 +30,7 @@ import com.linkedin.photon.ml.data.{KeyValueScore, GameData}
  * @param featureShardId the feature shard id
  * @author xazhang
  */
-class RandomEffectModel(
+protected[ml] class RandomEffectModel(
     val coefficientsRDD: RDD[(String, Coefficients)],
     val randomEffectId: String,
     val featureShardId: String)

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/model/RandomEffectModelInProjectedSpace.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/model/RandomEffectModelInProjectedSpace.scala
@@ -28,7 +28,7 @@ import com.linkedin.photon.ml.projector.RandomEffectProjector
  * @param featureShardId the feature shard id
  * @author xazhang
  */
-class RandomEffectModelInProjectedSpace(
+protected[ml] class RandomEffectModelInProjectedSpace(
     val coefficientsRDDInProjectedSpace: RDD[(String, Coefficients)],
     val randomEffectProjector: RandomEffectProjector,
     override val randomEffectId: String,
@@ -78,7 +78,7 @@ class RandomEffectModelInProjectedSpace(
    *
    * @return the random effect model
    */
-  protected[ml] def toRandomEffectModel: RandomEffectModel = {
+  def toRandomEffectModel: RandomEffectModel = {
     new RandomEffectModel(coefficientsRDDInProjectedSpace, randomEffectId, featureShardId)
   }
 

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/optimization/game/FactoredRandomEffectOptimizationProblem.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/optimization/game/FactoredRandomEffectOptimizationProblem.scala
@@ -33,7 +33,7 @@ import com.linkedin.photon.ml.supervised.TaskType._
  * @param latentSpaceDimension dimensionality of latent space
  * @author xazhang
  */
-class FactoredRandomEffectOptimizationProblem[F <: TwiceDiffFunction[LabeledPoint]](
+protected[ml] class FactoredRandomEffectOptimizationProblem[F <: TwiceDiffFunction[LabeledPoint]](
     val randomEffectOptimizationProblem: RandomEffectOptimizationProblem[F],
     val latentFactorOptimizationProblem: OptimizationProblem[F],
     val numIterations: Int,
@@ -65,7 +65,8 @@ class FactoredRandomEffectOptimizationProblem[F <: TwiceDiffFunction[LabeledPoin
   /**
    * Compute the regularization term value
    *
-   * @param model the model
+   * @param coefficientsRDD the coefficients
+   * @param projectionMatrix the projection matrix
    * @return regularization term value
    */
   def getRegularizationTermValue(
@@ -90,7 +91,7 @@ object FactoredRandomEffectOptimizationProblem {
    * @param randomEffectDataSet the dataset
    * @return the new optimization problem
    */
-  def buildFactoredRandomEffectOptimizationProblem(
+  protected[ml] def buildFactoredRandomEffectOptimizationProblem(
       taskType: TaskType,
       randomEffectOptimizationConfiguration: GLMOptimizationConfiguration,
       latentFactorOptimizationConfiguration: GLMOptimizationConfiguration,

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/optimization/game/FactoredRandomEffectOptimizationTracker.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/optimization/game/FactoredRandomEffectOptimizationTracker.scala
@@ -69,7 +69,3 @@ protected[ml] class FactoredRandomEffectOptimizationTracker(
     }.mkString("\n")
   }
 }
-
-object FactoredRandomEffectOptimizationTracker {
-
-}

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/optimization/game/FixedEffectOptimizationTracker.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/optimization/game/FixedEffectOptimizationTracker.scala
@@ -19,10 +19,11 @@ import com.linkedin.photon.ml.optimization._
 /**
  * Optimization tracker for factored randon effect optimization problems
  *
- * @param optimizationStatesTracker original state tracker for the optimization problem
+ * @param optimizationStateTracker original state tracker for the optimization problem
  * @author xazhang
  */
-class FixedEffectOptimizationTracker(optimizationStateTracker: OptimizationStatesTracker) extends OptimizationTracker {
+protected[ml] class FixedEffectOptimizationTracker(optimizationStateTracker: OptimizationStatesTracker)
+    extends OptimizationTracker {
 
   /**
    * Build a summary string for the tracker

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/optimization/game/GLMOptimizationConfiguration.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/optimization/game/GLMOptimizationConfiguration.scala
@@ -29,7 +29,7 @@ import com.linkedin.photon.ml.optimization.RegularizationType.RegularizationType
  * @param regularizationType regularization type
  * @author xazhang
  */
-case class GLMOptimizationConfiguration(
+protected[ml] case class GLMOptimizationConfiguration(
     maxNumberIterations: Int = 20,
     convergenceTolerance: Double = 1e-5,
     regularizationWeight: Double = 50,
@@ -55,7 +55,7 @@ object GLMOptimizationConfiguration {
    * @param string the string representation
    * @todo Add assert and meaningful parsing error message here
    */
-  def parseAndBuildFromString(string: String): GLMOptimizationConfiguration = {
+  protected[ml] def parseAndBuildFromString(string: String): GLMOptimizationConfiguration = {
     val Array(maxNumberIterationsStr, convergenceToleranceStr, regularizationWeightStr, downSamplingRateStr,
     optimizerTypeStr, regularizationTypeStr) = string.split(",")
     val maxNumberIterations = maxNumberIterationsStr.toInt

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/optimization/game/MFOptimizationConfiguration.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/optimization/game/MFOptimizationConfiguration.scala
@@ -21,7 +21,7 @@ package com.linkedin.photon.ml.optimization.game
  * @param numFactors number of factors
  * @author xazhang
  */
-case class MFOptimizationConfiguration(maxNumberIterations: Int, numFactors: Int) {
+protected[ml] case class MFOptimizationConfiguration(maxNumberIterations: Int, numFactors: Int) {
   override def toString: String = {
     s"maxNumberIterations: $maxNumberIterations\tnumFactors: $numFactors"
   }
@@ -35,7 +35,7 @@ object MFOptimizationConfiguration {
    * @param string the string representation
    * @todo Add assert and meaningful parsing error message here
    */
-  def parseAndBuildFromString(string: String): MFOptimizationConfiguration = {
+  protected[ml] def parseAndBuildFromString(string: String): MFOptimizationConfiguration = {
     val Array(maxNumberIterations, numFactors) = string.split(",").map(_.toInt)
     MFOptimizationConfiguration(maxNumberIterations, numFactors)
   }

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/optimization/game/OptimizationProblem.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/optimization/game/OptimizationProblem.scala
@@ -35,7 +35,7 @@ import com.linkedin.photon.ml.supervised.TaskType._
  * @tparam F The type of objective/loss function
  * @author xazhang
  */
-case class OptimizationProblem[F <: TwiceDiffFunction[LabeledPoint]](
+protected[ml] case class OptimizationProblem[F <: TwiceDiffFunction[LabeledPoint]](
     optimizer: AbstractOptimizer[LabeledPoint, F],
     objectiveFunction: F,
     lossFunction: F,
@@ -126,7 +126,7 @@ object OptimizationProblem {
    * @return optimization problem instance
    * @todo build optimization problem with more general type of functions
    */
-  def buildOptimizationProblem(
+  protected[ml] def buildOptimizationProblem(
       taskType: TaskType,
       configuration: GLMOptimizationConfiguration): OptimizationProblem[TwiceDiffFunction[LabeledPoint]] = {
 

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/optimization/game/OptimizationTracker.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/optimization/game/OptimizationTracker.scala
@@ -19,7 +19,7 @@ package com.linkedin.photon.ml.optimization.game
  *
  * @author xazhang
  */
-trait OptimizationTracker {
+protected[ml] trait OptimizationTracker {
 
   /**
    * Build a summary string for the tracker

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/optimization/game/RandomEffectOptimizationProblem.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/optimization/game/RandomEffectOptimizationProblem.scala
@@ -37,7 +37,7 @@ import com.linkedin.photon.ml.supervised.TaskType.TaskType
  * @param optimizationProblems the component optimization problems for each random effect type
  * @author xazhang
  */
-class RandomEffectOptimizationProblem[F <: TwiceDiffFunction[LabeledPoint]](
+protected[ml] class RandomEffectOptimizationProblem[F <: TwiceDiffFunction[LabeledPoint]](
     val optimizationProblems: RDD[(String, OptimizationProblem[F])])
   extends RDDLike {
 
@@ -70,7 +70,7 @@ class RandomEffectOptimizationProblem[F <: TwiceDiffFunction[LabeledPoint]](
   /**
    * Compute the regularization term value
    *
-   * @param model the model
+   * @param coefficientsRDD the model coefficients
    * @return regularization term value
    */
   def getRegularizationTermValue(coefficientsRDD: RDD[(String, Coefficients)]): Double = {
@@ -94,7 +94,7 @@ object RandomEffectOptimizationProblem {
    * @param randomEffectDataSet the training dataset
    * @return a new optimization problem instance
    */
-  def buildRandomEffectOptimizationProblem(
+  protected[ml] def buildRandomEffectOptimizationProblem(
       taskType: TaskType,
       configuration: GLMOptimizationConfiguration,
       randomEffectDataSet: RandomEffectDataSet): RandomEffectOptimizationProblem[TwiceDiffFunction[LabeledPoint]] = {

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/optimization/game/RandomEffectOptimizationTracker.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/optimization/game/RandomEffectOptimizationTracker.scala
@@ -27,7 +27,7 @@ import com.linkedin.photon.ml.optimization._
  * @param optimizationStatesTrackers state trackers for the inidividual optimization problems
  * @author xazhang
  */
-class RandomEffectOptimizationTracker(val optimizationStatesTrackers: RDD[OptimizationStatesTracker])
+protected[ml] class RandomEffectOptimizationTracker(val optimizationStatesTrackers: RDD[OptimizationStatesTracker])
   extends OptimizationTracker with RDDLike {
 
   override def sparkContext: SparkContext = optimizationStatesTrackers.sparkContext

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/projector/IndexMapProjector.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/projector/IndexMapProjector.scala
@@ -41,7 +41,7 @@ import scala.collection.Map
  * @author xazhang
  * @author nkatariy
  */
-class IndexMapProjector private (
+protected[ml] class IndexMapProjector private (
     val originalToProjectedSpaceMap: Map[Int, Int],
     override val originalSpaceDimension: Int,
     override val projectedSpaceDimension: Int) extends Projector {
@@ -82,7 +82,7 @@ object IndexMapProjector {
    * @param features An [[Iterable]] of feature vectors
    * @return The generated projection map
    */
-  def buildIndexMapProjector(features: Iterable[Vector[Double]]): IndexMapProjector = {
+  protected[ml] def buildIndexMapProjector(features: Iterable[Vector[Double]]): IndexMapProjector = {
     val originalToProjectedSpaceMap = features.flatMap(_.activeKeysIterator).toSet[Int].zipWithIndex.toMap
     val originalSpaceDimension = features.head.length
     val projectedSpaceDimension = originalToProjectedSpaceMap.values.max + 1

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/projector/IndexMapProjectorRDD.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/projector/IndexMapProjectorRDD.scala
@@ -27,7 +27,7 @@ import com.linkedin.photon.ml.model.Coefficients
  *
  * @param indexMapProjectorRDD The projectors
  */
-class IndexMapProjectorRDD private (indexMapProjectorRDD: RDD[(String, IndexMapProjector)])
+protected[ml] class IndexMapProjectorRDD private (indexMapProjectorRDD: RDD[(String, IndexMapProjector)])
   extends RandomEffectProjector with RDDLike {
 
   /**
@@ -115,7 +115,7 @@ object IndexMapProjectorRDD {
    * @param randomEffectDataSet The input random effect data set
    * @return The generated index map based RDD projectors
    */
-  def buildIndexMapProjector(randomEffectDataSet: RandomEffectDataSet): IndexMapProjectorRDD = {
+  protected[ml] def buildIndexMapProjector(randomEffectDataSet: RandomEffectDataSet): IndexMapProjectorRDD = {
     val indexMapProjectors = randomEffectDataSet.activeData.mapValues(localDataSet =>
       IndexMapProjector.buildIndexMapProjector(localDataSet.dataPoints.map(_._2.features))
     )

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/projector/ProjectionMatrix.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/projector/ProjectionMatrix.scala
@@ -30,7 +30,7 @@ import com.linkedin.photon.ml.constants.MathConst
  * @author xazhang
  * @author nkatariy
  */
-case class ProjectionMatrix(matrix: Matrix[Double]) extends Projector {
+protected[ml] case class ProjectionMatrix(matrix: Matrix[Double]) extends Projector {
   matrix match {
     case x: DenseMatrix[Double] =>
     case _ => throw new UnsupportedOperationException(s"Projection matrix of class ${matrix.getClass} for features " +
@@ -94,7 +94,7 @@ object ProjectionMatrix {
    * @param seed The seed of random number generator
    * @return The dense Gaussian random projection matrix
    */
-  def buildGaussianRandomProjectionMatrix(
+  protected[ml] def buildGaussianRandomProjectionMatrix(
       projectedSpaceDimension: Int,
       originalSpaceDimension: Int,
       isKeepingInterceptTerm: Boolean,

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/projector/ProjectionMatrixBroadcast.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/projector/ProjectionMatrixBroadcast.scala
@@ -28,7 +28,7 @@ import com.linkedin.photon.ml.model.Coefficients
  * @param projectionMatrixBroadcast the projection matrix
  * @author xazhang
  */
-class ProjectionMatrixBroadcast(projectionMatrixBroadcast: Broadcast[ProjectionMatrix])
+protected[ml] class ProjectionMatrixBroadcast(projectionMatrixBroadcast: Broadcast[ProjectionMatrix])
     extends RandomEffectProjector with BroadcastLike with Serializable {
 
   val projectionMatrix = projectionMatrixBroadcast.value
@@ -85,7 +85,7 @@ object ProjectionMatrixBroadcast {
    * @param seed The seed of random number generator
    * @return The generated random projection based broadcast projector
    */
-  def buildRandomProjectionBroadcastProjector(
+  protected[ml] def buildRandomProjectionBroadcastProjector(
       randomEffectDataSet: RandomEffectDataSet,
       projectedSpaceDimension: Int,
       isKeepingInterceptTerm: Boolean,

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/projector/ProjectorType.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/projector/ProjectorType.scala
@@ -17,13 +17,13 @@ package com.linkedin.photon.ml.projector
 /**
  * Represents a projector type
  */
-trait ProjectorType
+protected[ml] trait ProjectorType
 
 object ProjectorType extends Enumeration {
-  val RANDOM, INDEX_MAP, IDENTITY = Value
+  protected[ml] val RANDOM, INDEX_MAP, IDENTITY = Value
 }
 
-case class RandomProjection(projectedSpaceDimension: Int) extends ProjectorType
+protected[ml] case class RandomProjection(projectedSpaceDimension: Int) extends ProjectorType
 
 case object IndexMapProjection extends ProjectorType
 

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/projector/RandomEffectProjector.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/projector/RandomEffectProjector.scala
@@ -34,7 +34,7 @@ import com.linkedin.photon.ml.model.Coefficients
  * </ul>
  * @author xazhang
  */
-trait RandomEffectProjector {
+protected[ml] trait RandomEffectProjector {
   /**
    * Project the sharded data set from the original space to the projected space
    * @param randomEffectDataSet The input sharded data set in the original space
@@ -59,7 +59,7 @@ object RandomEffectProjector {
    * @param projectorType
    * @return the projector
    */
-  def buildRandomEffectProjector(
+  protected[ml] def buildRandomEffectProjector(
       randomEffectDataSet: RandomEffectDataSet,
       projectorType: ProjectorType): RandomEffectProjector = {
 

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/sampler/BinaryClassificationDownSampler.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/sampler/BinaryClassificationDownSampler.scala
@@ -33,7 +33,7 @@ import com.linkedin.photon.ml.data.LabeledPoint
  * @author xazhang
  * @author nkatariy
  */
-class BinaryClassificationDownSampler(downSamplingRate: Double) extends DownSampler with Serializable {
+protected[ml] class BinaryClassificationDownSampler(downSamplingRate: Double) extends DownSampler with Serializable {
 
   // TODO nkatariy We should have an assert on downsampling rate being > 0 and < 1 at runtime
   /**

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/sampler/DefaultDownSampler.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/sampler/DefaultDownSampler.scala
@@ -28,7 +28,7 @@ import com.linkedin.photon.ml.data.LabeledPoint
  * @author xazhang
  * @author nkatariy
  */
-class DefaultDownSampler(downSamplingRate: Double) extends DownSampler with Serializable {
+protected[ml] class DefaultDownSampler(downSamplingRate: Double) extends DownSampler with Serializable {
 
   // TODO nkatariy We should have an assert on downsampling rate being > 0 and < 1 at runtime
   /**

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/sampler/DownSampler.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/sampler/DownSampler.scala
@@ -27,7 +27,7 @@ import com.linkedin.photon.ml.data.LabeledPoint
  * @author xazhang
  * @author nkatariy
  */
-trait DownSampler {
+protected[ml] trait DownSampler {
 
   /**
    * Down-sample the dataset

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/util/IOUtils.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/util/IOUtils.scala
@@ -24,9 +24,11 @@ import org.joda.time.Days
 import org.joda.time.format.DateTimeFormat
 
 /**
+ * Some basic IO util functions to be merged with the other util functions
+ * @todo merge this class with the IOUtil function in Photon
  * @author xazhang
  */
-object IOUtils {
+protected[ml] object IOUtils {
 
   def getInputPathsWithinDateRange(
       inputDirs: Seq[String],

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/util/LongHashPartitioner.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/util/LongHashPartitioner.scala
@@ -19,9 +19,10 @@ import org.apache.spark.Partitioner
 
 
 /**
+ * The partitioner for [[Long]] typed keys with given number of partitions
  * @author xazhang
  */
-class LongHashPartitioner(partitions: Int) extends Partitioner {
+protected[ml] class LongHashPartitioner(partitions: Int) extends Partitioner {
   def getPartition(key: Any): Int = key match {
     case long: Long => (math.abs(long) % partitions).toInt
     case any =>

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/util/ObjectiveFunctionValue.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/util/ObjectiveFunctionValue.scala
@@ -15,9 +15,10 @@
 package com.linkedin.photon.ml.util
 
 /**
+ * A compact representation of the objective function's value.
  * @author xazhang
  */
-case class ObjectiveFunctionValue(lossFunctionValue: Double, regularizationTermValue: Double) {
+protected[ml] case class ObjectiveFunctionValue(lossFunctionValue: Double, regularizationTermValue: Double) {
   val objectiveFunctionValue: Double = lossFunctionValue + regularizationTermValue
 
   override def toString: String = {

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/util/PhotonLogger.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/util/PhotonLogger.scala
@@ -22,9 +22,10 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, Path}
 
 /**
+ * A temporary logger that persist the logs onto HDFS with different levels.
  * @author xazhang
  */
-class PhotonLogger(logDir: Path, configuration: Configuration) {
+protected[ml] class PhotonLogger(logDir: Path, configuration: Configuration) {
 
   def this(logDir: String, configuration: Configuration) = this(new Path(logDir), configuration)
 

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/util/VectorUtils.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/util/VectorUtils.scala
@@ -24,9 +24,9 @@ import scala.collection.mutable
  * A utility object that contains some operations on [[Vector]].
  * @author xazhang
  */
-protected[ml] object VectorUtils {
+object VectorUtils {
 
-  val SPARSE_VECTOR_ACTIVE_SIZE_TO_SIZE_RATIO: Double = 1.0 / 3
+  private val SPARSE_VECTOR_ACTIVE_SIZE_TO_SIZE_RATIO: Double = 1.0 / 3
 
   /**
    * Convert an [[Array]] of ([[Int]], [[Double]]) pairs into a [[Vector]].
@@ -40,10 +40,11 @@ protected[ml] object VectorUtils {
    *                                          [[DenseVector]] is chosen.
    * @return The converted [[Vector]]
    */
-  def convertIndexAndValuePairArrayToVector(
+  protected[ml] def convertIndexAndValuePairArrayToVector(
       indexAndData: Array[(Int, Double)],
       length: Int,
       sparseVectorActiveSizeToSizeRatio: Double = SPARSE_VECTOR_ACTIVE_SIZE_TO_SIZE_RATIO): Vector[Double] = {
+
     if (length * SPARSE_VECTOR_ACTIVE_SIZE_TO_SIZE_RATIO < indexAndData.length) {
       convertIndexAndValuePairArrayToDenseVector(indexAndData, length)
     } else {
@@ -57,8 +58,9 @@ protected[ml] object VectorUtils {
    * @param length The length of the resulting sparse vector
    * @return The converted [[SparseVector]]
    */
-  def convertIndexAndValuePairArrayToSparseVector(indexAndData: Array[(Int, Double)], length: Int)
+  protected[ml] def convertIndexAndValuePairArrayToSparseVector(indexAndData: Array[(Int, Double)], length: Int)
   : SparseVector[Double] = {
+
     val sortedIndexAndData = indexAndData.sortBy(_._1)
     val index = new Array[Int](sortedIndexAndData.length)
     val data = new Array[Double](sortedIndexAndData.length)
@@ -77,7 +79,7 @@ protected[ml] object VectorUtils {
    * @param length The length of the resulting dense vector
    * @return The converted [[DenseVector]]
    */
-  def convertIndexAndValuePairArrayToDenseVector(indexAndData: Array[(Int, Double)], length: Int)
+  protected[ml] def convertIndexAndValuePairArrayToDenseVector(indexAndData: Array[(Int, Double)], length: Int)
   : DenseVector[Double] = {
 
     val dataArray = new Array[Double](length)
@@ -98,7 +100,8 @@ protected[ml] object VectorUtils {
    * @param threshold Threshold of the cross value
    * @return The resulting Kronecker product between vector1 and vector2
    */
-  def kroneckerProduct(vector1: Vector[Double], vector2: Vector[Double], threshold: Double): Vector[Double] = {
+  protected[ml] def kroneckerProduct(vector1: Vector[Double], vector2: Vector[Double], threshold: Double)
+  : Vector[Double] = {
 
     assert(vector1.isInstanceOf[SparseVector[Double]] || vector2.isInstanceOf[SparseVector[Double]],
       "Kronecker product between two dense vectors is currently not supported!")


### PR DESCRIPTION
GAME is still under active development, and the APIs may change. However, currently most of the functions/classes in GAME are with scope public, and many of them are not supposed to be called or used outside of some certain context.

For example, the functions provided within each coordinate will not be used anywhere other than the coordinate descent algorithm.

As a result, be more conservative on the scope of the functions during the early stage of Photon-ML might be helpful, because we could change the scope from private to protected all the way to public later without breaking the public APIs, but not the other way around.

However, note that this pull request only targets the GAME related code, and  the changes made on the Photon-ML are minimized, for example, the class/function scope for most parts of Photon-ML hasn't been touched. Although I think some of them may also benefit from a more conservative scope.
