### PR TITLE
Fixed the scopes for classes in algorithm package.

### DIFF
--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/algorithm/Coordinate.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/algorithm/Coordinate.scala
@@ -25,7 +25,7 @@ import com.linkedin.photon.ml.optimization.game.OptimizationTracker
  * @param dataSet the training dataset
  * @author xazhang
  */
-protected[algorithm] abstract class Coordinate[D <: DataSet[D], C <: Coordinate[D, C]](dataSet: D) {
+protected[ml] abstract class Coordinate[D <: DataSet[D], C <: Coordinate[D, C]](dataSet: D) {
 
   /**
    * Score the effect-specific data set in the coordinate with the input model

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/algorithm/FactoredRandomEffectCoordinate.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/algorithm/FactoredRandomEffectCoordinate.scala
@@ -34,7 +34,7 @@ import com.linkedin.photon.ml.util.VectorUtils
  * @param factoredRandomEffectOptimizationProblem the fixed effect optimization problem
  * @author xazhang
  */
-protected[algorithm]  class FactoredRandomEffectCoordinate[F <: TwiceDiffFunction[LabeledPoint]](
+protected[ml]  class FactoredRandomEffectCoordinate[F <: TwiceDiffFunction[LabeledPoint]](
     randomEffectDataSet: RandomEffectDataSet,
     factoredRandomEffectOptimizationProblem: FactoredRandomEffectOptimizationProblem[F])
   extends Coordinate[RandomEffectDataSet, FactoredRandomEffectCoordinate[F]](randomEffectDataSet) {

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/algorithm/FixedEffectCoordinate.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/algorithm/FixedEffectCoordinate.scala
@@ -30,7 +30,7 @@ import com.linkedin.photon.ml.util.PhotonLogger
  * @param optimizationProblem the fixed effect optimization problem
  * @author xazhang
  */
-protected[algorithm] class FixedEffectCoordinate [F <: TwiceDiffFunction[LabeledPoint]](
+protected[ml] class FixedEffectCoordinate [F <: TwiceDiffFunction[LabeledPoint]](
     fixedEffectDataSet: FixedEffectDataSet,
     private var optimizationProblem: OptimizationProblem[F])
   extends Coordinate[FixedEffectDataSet, FixedEffectCoordinate[F]](fixedEffectDataSet) {

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/algorithm/RandomEffectCoordinate.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/algorithm/RandomEffectCoordinate.scala
@@ -33,7 +33,7 @@ import com.linkedin.photon.ml.optimization.game.{
  * @param randomEffectOptimizationProblem the random effect optimization problem
  * @author xazhang
  */
-protected[algorithm] abstract class RandomEffectCoordinate[F <: TwiceDiffFunction[LabeledPoint],
+protected[ml] abstract class RandomEffectCoordinate[F <: TwiceDiffFunction[LabeledPoint],
     R <: RandomEffectCoordinate[F, R]](
     randomEffectDataSet: RandomEffectDataSet,
     randomEffectOptimizationProblem: RandomEffectOptimizationProblem[F])

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/algorithm/RandomEffectCoordinateInProjectedSpace.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/algorithm/RandomEffectCoordinateInProjectedSpace.scala
@@ -29,7 +29,7 @@ import com.linkedin.photon.ml.optimization.game.{OptimizationTracker, RandomEffe
  * @param randomEffectOptimizationProblem the fixed effect optimization problem
  * @author xazhang
  */
-protected[algorithm] class RandomEffectCoordinateInProjectedSpace[F <: TwiceDiffFunction[LabeledPoint]](
+protected[ml] class RandomEffectCoordinateInProjectedSpace[F <: TwiceDiffFunction[LabeledPoint]](
     randomEffectDataSetInProjectedSpace: RandomEffectDataSetInProjectedSpace,
     randomEffectOptimizationProblem: RandomEffectOptimizationProblem[F])
   extends RandomEffectCoordinate[F, RandomEffectCoordinateInProjectedSpace[F]](


### PR DESCRIPTION
A patch to the pull request https://github.com/linkedin/photon-ml/pull/9.

As @namitk pointed out, after the above pull requested being merged, photon-ml can no longer being built successfully due to the scope for classes in algorithm package is wrong.

This patch addresses the above problem by setting those classes to a proper scope.

@joshvfleming please take a look at this PR again, thanks!
