### PR TITLE
Avoid creating in-memory arrayBuffer for label points writing

### DIFF
--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/io/GLMSuite.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/io/GLMSuite.scala
@@ -339,14 +339,8 @@ class GLMSuite(
     }
 
     avroRDD.mapPartitions { iter =>
-      val res = new ArrayBuffer[LabeledPoint]
       val map = _indexMapLoader.indexMapForRDD()
-      while (iter.hasNext) {
-        val r = parseAvroRecord(iter.next(), map)
-        r.foreach(k => res += k)
-      }
-
-      res.iterator
+      iter.flatMap { r => parseAvroRecord(r, map) }
     }
   }
 


### PR DESCRIPTION
I made a mistake in the previous PR for offheap indexmap that I'm using an ArrayBuffer to convert Avro records to labeled points. This will introduce unnecessary memory overheads and will blow up executor's memory when feature dimension and data number are both large. (Found a case using 1TB, 10M unique features input).
