### PR TITLE
Change the way of specifying jar versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -186,4 +186,12 @@ task wrapper(type: Wrapper) {
 // For LinkedIn internal builds, apply the LinkedIn-specific build file
 if (project.hasProperty('overrideBuildEnvironment')) {
   apply from: project.overrideBuildEnvironment
+} else {
+  // Specify Jar versions here instead of within gradle.properties
+  // This will provide overriding ability for internal builds
+  subprojects {
+    tasks.withType(Jar) {
+      version '1.0.0'
+    }
+  }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,3 @@
-# Current version
-version=1.0.0
-
 # long-running Gradle process speeds up local builds
 # to stop the daemon run './gradlew --stop'
 org.gradle.daemon=true


### PR DESCRIPTION
We need the ability to control the version number we want to publish differently between internal and external builds. gradle.properties isn't so easy to override via an adapt script in internal builds. Changing it to using specific configuration in jar tasks seems to be doing the trick. Tested both in this build and internally.