### PR TITLE
Add jacoco and coverall integration which provides test-coverage check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,4 +24,6 @@ before_script:
   - sudo service rsync stop || true
   - sudo service x11-common stop || true
 script:
-  - ./gradlew check -x integTest
+  - travis_wait 60 ./gradlew check -x integTest
+after_success:
+  - ./gradlew jacocoTestReport coveralls -x integTest

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Photon Machine Learning (Photon-ML)
 
 [![Build Status](https://travis-ci.org/linkedin/photon-ml.svg?branch=master)](https://travis-ci.org/linkedin/photon-ml)
+[![Coverage Status](https://coveralls.io/repos/github/linkedin/photon-ml/badge.svg?branch=master)](https://coveralls.io/github/linkedin/photon-ml?branch=master)
 
 **Photon Machine Learning (Photon-ML)** is a machine learning library based upon [Apache Spark](http://spark.apache.org/) originally developed by the LinkedIn Machine Learning Algorithms team.
 

--- a/build.gradle
+++ b/build.gradle
@@ -36,12 +36,14 @@ buildscript {
     classpath "com.commercehub.gradle.plugin:gradle-avro-plugin:0.7.0"
     classpath "org.github.ngbinh.scalastyle:gradle-scalastyle-plugin_2.10:0.8.2"
     classpath 'com.github.jengelman.gradle.plugins:shadow:1.2.3'
+    classpath "org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.6.3"
   }
 }
 
 allprojects {
   apply plugin: 'eclipse'
   apply plugin: 'idea'
+
   repositories {
     jcenter()
   }
@@ -51,6 +53,8 @@ apply from: 'build-scripts/rat.gradle'
 
 rat {
   excludes = [
+    '.*',
+    '*.log',
     '*.patch',
     '**/*.avsc',
     '**/*.acl',

--- a/photon-ml/build.gradle
+++ b/photon-ml/build.gradle
@@ -15,6 +15,16 @@
 apply plugin: 'scala'
 apply from: '../build-scripts/integration-test.gradle'
 
+apply plugin: "jacoco"
+apply plugin: 'com.github.kt3k.coveralls'
+jacocoTestReport {
+  reports {
+      xml.enabled = true // coveralls plugin depends on xml format report
+      html.enabled = true
+  }
+}
+
+
 dependencies {
   compile('joda-time:joda-time:2.7')
 


### PR DESCRIPTION
I'm still experimenting via this PR to make sure all set ups are correct. (Because PR could help me trigger Travis CI build : P)

Hopefully, if this goes well, we could have test-coverage tag in addition to build pass tag.
