### PR TITLE
Adding local AUC computation to the evaluation package

### DIFF
--- a/photon-ml/src/integTest/scala/com/linkedin/photon/ml/DriverIntegTest.scala
+++ b/photon-ml/src/integTest/scala/com/linkedin/photon/ml/DriverIntegTest.scala
@@ -60,7 +60,7 @@ class DriverIntegTest extends SparkTestUtils with TestTemplateWithTmpDir {
       expectedNumFeatures = 14, expectedNumTrainingData = 250, expectedIsSummarized = false)
 
     val models = loadAllModels(tmpDir + "/output/" + Driver.LEARNED_MODELS_TEXT)
-    assertEquals(models.size, 4)
+    assertEquals(models.length, 4)
     // Verify lambdas
     assertEquals(models.map(_._1), Array(0.1, 1, 10, 100))
 
@@ -84,7 +84,7 @@ class DriverIntegTest extends SparkTestUtils with TestTemplateWithTmpDir {
       expectedNumFeatures = 13, expectedNumTrainingData = 250, expectedIsSummarized = false)
 
     val models = loadAllModels(tmpDir + "/output/" + Driver.LEARNED_MODELS_TEXT)
-    assertEquals(models.size, 4)
+    assertEquals(models.length, 4)
     // Verify lambdas
     assertEquals(models.map(_._1), Array(0.1, 1, 10, 100))
 
@@ -106,7 +106,7 @@ class DriverIntegTest extends SparkTestUtils with TestTemplateWithTmpDir {
       expectedNumFeatures = 14, expectedNumTrainingData = 250, expectedIsSummarized = false)
 
     val models = loadAllModels(tmpDir + "/output/" + Driver.LEARNED_MODELS_TEXT)
-    assertEquals(models.size, 4)
+    assertEquals(models.length, 4)
     // Verify lambdas
     assertEquals(models.map(_._1), Array(0.1, 1, 10, 100))
 
@@ -122,7 +122,7 @@ class DriverIntegTest extends SparkTestUtils with TestTemplateWithTmpDir {
     appendCommonJobArgs(args, tmpDir, isValidating = true)
 
     args += CommonTestUtils.fromOptionNameToArg(VALIDATE_PER_ITERATION)
-    args += true.toString()
+    args += true.toString
     args += CommonTestUtils.fromOptionNameToArg(INTERCEPT_OPTION)
     args += "false"
     appendOffHeapConfig(args, addIntercept = false)
@@ -132,13 +132,13 @@ class DriverIntegTest extends SparkTestUtils with TestTemplateWithTmpDir {
       expectedNumFeatures = 13, expectedNumTrainingData = 250, expectedIsSummarized = false)
 
     val models = loadAllModels(tmpDir + "/output/" + Driver.LEARNED_MODELS_TEXT)
-    assertEquals(models.size, 4)
+    assertEquals(models.length, 4)
     // Verify lambdas
     assertEquals(models.map(_._1), Array(0.1, 1, 10, 100))
 
     // The selected best model is supposed to be of lambda 0.1
     val bestModel = loadAllModels(tmpDir + "/output/" + Driver.BEST_MODEL_TEXT)
-    assertEquals(bestModel.size, 1)
+    assertEquals(bestModel.length, 1)
     // Verify lambda
     assertEquals(bestModel(0)._1, 0.1)
   }
@@ -151,7 +151,7 @@ class DriverIntegTest extends SparkTestUtils with TestTemplateWithTmpDir {
     appendCommonJobArgs(args, tmpDir, isValidating = true)
 
     args += CommonTestUtils.fromOptionNameToArg(VALIDATE_PER_ITERATION)
-    args += true.toString()
+    args += true.toString
     appendOffHeapConfig(args, addIntercept = true)
 
     MockDriver.runLocally(args = args.toArray,
@@ -159,13 +159,13 @@ class DriverIntegTest extends SparkTestUtils with TestTemplateWithTmpDir {
       expectedNumFeatures = 14, expectedNumTrainingData = 250, expectedIsSummarized = false)
 
     val models = loadAllModels(tmpDir + "/output/" + Driver.LEARNED_MODELS_TEXT)
-    assertEquals(models.size, 4)
+    assertEquals(models.length, 4)
     // Verify lambdas
     assertEquals(models.map(_._1), Array(0.1, 1, 10, 100))
 
     // The selected best model is supposed to be of lambda 0.1
     val bestModel = loadAllModels(tmpDir + "/output/" + Driver.BEST_MODEL_TEXT)
-    assertEquals(bestModel.size, 1)
+    assertEquals(bestModel.length, 1)
     // Verify lambda
     assertEquals(bestModel(0)._1, 0.1)
   }
@@ -176,14 +176,14 @@ class DriverIntegTest extends SparkTestUtils with TestTemplateWithTmpDir {
     val args = mutable.ArrayBuffer[String]()
     appendCommonJobArgs(args, tmpDir)
     args += CommonTestUtils.fromOptionNameToArg(OPTIMIZER_TYPE_OPTION)
-    args += OptimizerType.TRON.toString()
+    args += OptimizerType.TRON.toString
 
     MockDriver.runLocally(args = args.toArray,
       expectedStages = Array(DriverStage.INIT, DriverStage.PREPROCESSED, DriverStage.TRAINED),
       expectedNumFeatures = 14, expectedNumTrainingData = 250, expectedIsSummarized = false)
 
     val models = loadAllModels(tmpDir + "/output/" + Driver.LEARNED_MODELS_TEXT)
-    assertEquals(models.size, 4)
+    assertEquals(models.length, 4)
     // Verify lambdas
     assertEquals(models.map(_._1), Array(0.1, 1, 10, 100))
 
@@ -197,14 +197,14 @@ class DriverIntegTest extends SparkTestUtils with TestTemplateWithTmpDir {
     val args = mutable.ArrayBuffer[String]()
     appendCommonJobArgs(args, tmpDir)
     args += CommonTestUtils.fromOptionNameToArg(OPTIMIZER_TYPE_OPTION)
-    args += OptimizerType.LBFGS.toString()
+    args += OptimizerType.LBFGS.toString
 
     MockDriver.runLocally(args = args.toArray,
       expectedStages = Array(DriverStage.INIT, DriverStage.PREPROCESSED, DriverStage.TRAINED),
       expectedNumFeatures = 14, expectedNumTrainingData = 250, expectedIsSummarized = false)
 
     val models = loadAllModels(tmpDir + "/output/" + Driver.LEARNED_MODELS_TEXT)
-    assertEquals(models.size, 4)
+    assertEquals(models.length, 4)
     // Verify lambdas
     assertEquals(models.map(_._1), Array(0.1, 1, 10, 100))
 
@@ -236,7 +236,7 @@ class DriverIntegTest extends SparkTestUtils with TestTemplateWithTmpDir {
 
     val models = loadAllModels(tmpDir + "/output/" + Driver.LEARNED_MODELS_TEXT)
 
-    assertEquals(models.size, lambdas.length)
+    assertEquals(models.length, lambdas.length)
     // Verify lambdas
     assertEquals(models.map(_._1), lambdas)
 
@@ -278,7 +278,7 @@ class DriverIntegTest extends SparkTestUtils with TestTemplateWithTmpDir {
       expectedNumFeatures = 14, expectedNumTrainingData = 250, expectedIsSummarized = false)
 
     val models = loadAllModels(tmpDir + "/output/" + Driver.LEARNED_MODELS_TEXT)
-    assertEquals(models.size, lambdas.length)
+    assertEquals(models.length, lambdas.length)
     // Verify lambdas
     assertEquals(models.map(_._1), lambdas)
 
@@ -307,14 +307,14 @@ class DriverIntegTest extends SparkTestUtils with TestTemplateWithTmpDir {
     appendCommonJobArgs(args, tmpDir)
 
     args += CommonTestUtils.fromOptionNameToArg(NORMALIZATION_TYPE)
-    args += NormalizationType.SCALE_WITH_STANDARD_DEVIATION.toString()
+    args += NormalizationType.SCALE_WITH_STANDARD_DEVIATION.toString
 
     MockDriver.runLocally(args = args.toArray,
       expectedStages = Array(DriverStage.INIT, DriverStage.PREPROCESSED, DriverStage.TRAINED),
       expectedNumFeatures = 14, expectedNumTrainingData = 250, expectedIsSummarized = true)
 
     val models = loadAllModels(tmpDir + "/output/" + Driver.LEARNED_MODELS_TEXT)
-    assertEquals(models.size, 4)
+    assertEquals(models.length, 4)
     // Verify lambdas
     assertEquals(models.map(_._1), Array(0.1, 1, 10, 100))
 
@@ -328,13 +328,13 @@ class DriverIntegTest extends SparkTestUtils with TestTemplateWithTmpDir {
     val args = mutable.ArrayBuffer[String]()
     appendCommonJobArgs(args, tmpDir)
     args += CommonTestUtils.fromOptionNameToArg(NORMALIZATION_TYPE)
-    args += NormalizationType.STANDARDIZATION.toString()
+    args += NormalizationType.STANDARDIZATION.toString
 
     MockDriver.runLocally(args = args.toArray,
       expectedStages = Array(DriverStage.INIT, DriverStage.PREPROCESSED, DriverStage.TRAINED),
       expectedNumFeatures = 14, expectedNumTrainingData = 250, expectedIsSummarized = true)
     val models = loadAllModels(tmpDir + "/output/" + Driver.LEARNED_MODELS_TEXT)
-    assertEquals(models.size, 4)
+    assertEquals(models.length, 4)
     // Verify lambdas
     assertEquals(models.map(_._1), Array(0.1, 1, 10, 100))
 
@@ -356,7 +356,7 @@ class DriverIntegTest extends SparkTestUtils with TestTemplateWithTmpDir {
                           expectedNumFeatures = 14, expectedNumTrainingData = 250, expectedIsSummarized = false)
 
     val models = loadAllModels(tmpDir + "/output/" + Driver.LEARNED_MODELS_TEXT)
-    assertEquals(models.size, 4)
+    assertEquals(models.length, 4)
     // Verify lambdas
     assertEquals(models.map(_._1), Array(0.1, 1, 10, 100))
 
@@ -378,7 +378,7 @@ class DriverIntegTest extends SparkTestUtils with TestTemplateWithTmpDir {
       expectedNumFeatures = 14, expectedNumTrainingData = 250, expectedIsSummarized = true)
 
     val models = loadAllModels(tmpDir + "/output/" + Driver.LEARNED_MODELS_TEXT)
-    assertEquals(models.size, 4)
+    assertEquals(models.length, 4)
     // Verify lambdas
     assertEquals(models.map(_._1), Array(0.1, 1, 10, 100))
 
@@ -398,20 +398,20 @@ class DriverIntegTest extends SparkTestUtils with TestTemplateWithTmpDir {
     args += tmpDir + "/summary"
 
     args += CommonTestUtils.fromOptionNameToArg(NORMALIZATION_TYPE)
-    args += NormalizationType.SCALE_WITH_STANDARD_DEVIATION.toString()
+    args += NormalizationType.SCALE_WITH_STANDARD_DEVIATION.toString
 
     MockDriver.runLocally(args = args.toArray,
       expectedStages = Array(DriverStage.INIT, DriverStage.PREPROCESSED, DriverStage.TRAINED, DriverStage.VALIDATED, DriverStage.DIAGNOSED),
       expectedNumFeatures = 14, expectedNumTrainingData = 250, expectedIsSummarized = true)
 
     val models = loadAllModels(tmpDir + "/output/" + Driver.LEARNED_MODELS_TEXT)
-    assertEquals(models.size, 4)
+    assertEquals(models.length, 4)
     // Verify lambdas
     assertEquals(models.map(_._1), Array(0.1, 1, 10, 100))
 
     // The selected best model is supposed to be of lambda 100.0 with features scaling with standard deviation
     val bestModel = loadAllModels(tmpDir + "/output/" + Driver.BEST_MODEL_TEXT)
-    assertEquals(bestModel.size, 1)
+    assertEquals(bestModel.length, 1)
     // Verify lambda
     assertEquals(bestModel(0)._1, 100.0)
   }
@@ -424,20 +424,20 @@ class DriverIntegTest extends SparkTestUtils with TestTemplateWithTmpDir {
     appendCommonJobArgs(args, tmpDir, isValidating = true)
 
     args += CommonTestUtils.fromOptionNameToArg(VALIDATE_PER_ITERATION)
-    args += true.toString()
+    args += true.toString
 
     MockDriver.runLocally(args = args.toArray,
       expectedStages = Array(DriverStage.INIT, DriverStage.PREPROCESSED, DriverStage.TRAINED, DriverStage.VALIDATED, DriverStage.DIAGNOSED),
       expectedNumFeatures = 14, expectedNumTrainingData = 250, expectedIsSummarized = false)
 
     val models = loadAllModels(tmpDir + "/output/" + Driver.LEARNED_MODELS_TEXT)
-    assertEquals(models.size, 4)
+    assertEquals(models.length, 4)
     // Verify lambdas
     assertEquals(models.map(_._1), Array(0.1, 1, 10, 100))
 
     // The selected best model is supposed to be of lambda 0.1
     val bestModel = loadAllModels(tmpDir + "/output/" + Driver.BEST_MODEL_TEXT)
-    assertEquals(bestModel.size, 1)
+    assertEquals(bestModel.length, 1)
     // Verify lambda
     assertEquals(bestModel(0)._1, 0.1)
   }
@@ -488,9 +488,9 @@ class DriverIntegTest extends SparkTestUtils with TestTemplateWithTmpDir {
       (m._1, m._2._1, m._2._2, r._1, r._2._1, r._2._2, m._2._3, m._2._4)
     }).map(x => {
       val (taskType, trainData, testData, regType, optimType, lambdas, numDim, numSamp) = x
-      val trainEnabled = (TaskType.SMOOTHED_HINGE_LOSS_LINEAR_SVM != taskType)
+      val trainEnabled = TaskType.SMOOTHED_HINGE_LOSS_LINEAR_SVM != taskType
 
-      val outputDir = s"${taskType}_${regType}_${trainEnabled}"
+      val outputDir = s"${taskType}_${regType}_$trainEnabled"
 
       val args = mutable.ArrayBuffer[String]()
       args += CommonTestUtils.fromOptionNameToArg(TOLERANCE_OPTION)
@@ -565,10 +565,10 @@ object DriverIntegTest {
     args += testRoot + "/output"
 
     args += CommonTestUtils.fromOptionNameToArg(TASK_TYPE_OPTION)
-    args += TaskType.LOGISTIC_REGRESSION.toString()
+    args += TaskType.LOGISTIC_REGRESSION.toString
 
     args += CommonTestUtils.fromOptionNameToArg(FORMAT_TYPE_OPTION)
-    args += FieldNamesType.TRAINING_EXAMPLE.toString()
+    args += FieldNamesType.TRAINING_EXAMPLE.toString
   }
 
   def appendOffHeapConfig(args: mutable.ArrayBuffer[String], addIntercept: Boolean = true): Unit = {
@@ -589,7 +589,7 @@ object DriverIntegTest {
   def loadAllModels(modelsDir: String): Array[(Double, GeneralizedLinearModel)] = {
     val models = mutable.ArrayBuffer[(Double, GeneralizedLinearModel)]()
     val files = new File(modelsDir).listFiles()
-    for (file <- files.filter { f => !f.getName().startsWith("_") && !f.getName().startsWith(".") }) {
+    for (file <- files.filter { f => !f.getName.startsWith("_") && !f.getName.startsWith(".") }) {
       models += loadModelFromText(file.getPath, TaskType.LOGISTIC_REGRESSION)
     }
     models.sortWith(_._1 < _._1).toArray

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/constants/MathConst.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/constants/MathConst.scala
@@ -25,4 +25,6 @@ object MathConst {
   protected[ml] val LOW_PRECISION_TOLERANCE_THRESHOLD: Double = 1e-4
   protected[ml] val RANDOM_SEED: Long = 1234567890L
   protected[ml] val POSITIVE_RESPONSE_THRESHOLD = 0.5
+  protected[ml] val DEFAULT_WEIGHT = 1.0
+  protected[ml] val DEFAULT_OFFSET = 0.0
 }

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/evaluation/AreaUnderROCCurveLocalEvaluator.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/evaluation/AreaUnderROCCurveLocalEvaluator.scala
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2016 LinkedIn Corp. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linkedin.photon.ml.evaluation
+
+import java.util.{Comparator => JComparator, Arrays => JArrays}
+import java.lang.{Double => JDouble}
+
+import scala.collection.Map
+
+import com.linkedin.photon.ml.constants.MathConst._
+
+
+/**
+ * Local evaluator for binary classification problems
+ *
+ * @param labelAndOffsetAndWeights a (id -> (label, offset, weight)) map
+ * @param defaultScore the default score used to compute the metric
+ */
+protected[ml] class AreaUnderROCCurveLocalEvaluator(
+    labelAndOffsetAndWeights: Map[Long, (Double, Double, Double)],
+    defaultScore: Double = 0.0) extends LocalEvaluator {
+
+  def this(labels: Map[Long, Double]) = this(labels.mapValues(label => (label, DEFAULT_OFFSET, DEFAULT_WEIGHT)))
+
+  val numLabels = labelAndOffsetAndWeights.size
+
+  /**
+   * Evaluate the scores of the model
+   *
+   * @param scores the scores to evaluate
+   * @return score metric value
+   */
+  override def evaluate(scores: Map[Long, Double]): Double = {
+    val scoresAndLabelAndWeight = new Array[(Double, Double, Double)](numLabels)
+    var pos = 0
+    labelAndOffsetAndWeights.foreach { case (id, (label, offset, weight)) =>
+      val score = scores.getOrElse(id, defaultScore) + offset
+      scoresAndLabelAndWeight(pos) = (score, label, weight)
+      pos += 1
+    }
+
+    // directly calling scoresAndLabelAndWeight.sort would cause some performance issue with large arrays
+    val comparator = new JComparator[(Double, Double, Double)]() {
+      override def compare(tuple1: (Double, Double, Double), tuple2: (Double, Double, Double)): Int = {
+        JDouble.compare(tuple1._1, tuple2._1)
+      }
+    }
+    JArrays.sort(scoresAndLabelAndWeight, comparator.reversed())
+
+    var aucAccum = 0.0
+    var positiveCount = 0.0
+    var negativeCount = 0.0
+
+    scoresAndLabelAndWeight.foreach { case (score, label, weight) =>
+      if (label > POSITIVE_RESPONSE_THRESHOLD) {
+        positiveCount += weight
+      } else {
+        aucAccum += positiveCount
+        negativeCount += weight
+      }
+    }
+
+    //normalize AUC over the total area
+    aucAccum / (positiveCount * negativeCount)
+  }
+}

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/evaluation/BinaryClassificationEvaluator.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/evaluation/BinaryClassificationEvaluator.scala
@@ -20,8 +20,8 @@ import org.apache.spark.rdd.RDD
 /**
  * Evaluator for binary classification problems
  *
- * @param labelAndOffsets sequence of labels and offsets
- * @param defaultScore default score
+ * @param labelAndOffsets a [[RDD]] of (id, (label, offset)) pairs
+ * @param defaultScore the default score used to compute the metric
  * @author xazhang
  */
 protected[ml] class BinaryClassificationEvaluator(

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/evaluation/Evaluator.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/evaluation/Evaluator.scala
@@ -17,7 +17,7 @@ package com.linkedin.photon.ml.evaluation
 import org.apache.spark.rdd.RDD
 
 /**
- * Interface for evaluation implementations
+ * Interface for evaluation implementations at the [[RDD]] level
  *
  * @author xazhang
  */

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/evaluation/LocalEvaluator.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/evaluation/LocalEvaluator.scala
@@ -14,29 +14,17 @@
  */
 package com.linkedin.photon.ml.evaluation
 
-import org.apache.spark.rdd.RDD
-
+import scala.collection.Map
 
 /**
- * Evaluator for root mean squared error
- *
- * @param labelAndOffsetAndWeights a [[RDD]] of (id, (labels, offsets, weights)) pairs
- * @param defaultScore the default score used to compute the metric
- * @author xazhang
+ * Interface for evaluation implementations at the local level
  */
-protected[ml] class RMSEEvaluator(
-    labelAndOffsetAndWeights: RDD[(Long, (Double, Double, Double))],
-    defaultScore: Double = 0.0) extends Evaluator {
-
-  val squaredLossEvaluator = new SquaredLossEvaluator(labelAndOffsetAndWeights, defaultScore)
-
+trait LocalEvaluator {
   /**
    * Evaluate the scores of the model
    *
    * @param scores the scores to evaluate
    * @return score metric value
    */
-  override def evaluate(scores: RDD[(Long, Double)]): Double = {
-    math.sqrt(squaredLossEvaluator.evaluate(scores) / labelAndOffsetAndWeights.count())
-  }
+  def evaluate(scores: Map[Long, Double]): Double
 }

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/evaluation/LogisticLossEvaluator.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/evaluation/LogisticLossEvaluator.scala
@@ -23,8 +23,8 @@ import com.linkedin.photon.ml.util.Utils
 /**
  * Evaluator for logistic loss
  *
- * @param labelAndOffsetAndWeights label and offset weights
- * @param defaultScore default score
+ * @param labelAndOffsetAndWeights a [[RDD]] of (id, (labels, offsets, weights)) pairs
+ * @param defaultScore the default score used to compute the metric
  * @author xazhang
  */
 protected[ml] class LogisticLossEvaluator(

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/evaluation/SquaredLossEvaluator.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/evaluation/SquaredLossEvaluator.scala
@@ -16,14 +16,11 @@ package com.linkedin.photon.ml.evaluation
 
 import org.apache.spark.rdd.RDD
 
-import com.linkedin.photon.ml.constants.MathConst
-import com.linkedin.photon.ml.util.Utils
-
 /**
  * Evaluator for squared loss
  *
- * @param labelAndOffsetAndWeights label and offset weights
- * @param defaultScore default score
+ * @param labelAndOffsetAndWeights a [[RDD]] of (id, (labels, offsets, weights)) pairs
+ * @param defaultScore the default score used to compute the metric
  * @author xazhang
  */
 protected[ml] class SquaredLossEvaluator(

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/projector/RandomEffectProjector.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/projector/RandomEffectProjector.scala
@@ -56,7 +56,7 @@ object RandomEffectProjector {
    * Builds a random effect projector instance
    *
    * @param randomEffectDataSet the dataset
-   * @param projectorType
+   * @param projectorType the type of the projector
    * @return the projector
    */
   protected[ml] def buildRandomEffectProjector(

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/sampler/DefaultDownSampler.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/sampler/DefaultDownSampler.scala
@@ -16,7 +16,6 @@ package com.linkedin.photon.ml.sampler
 
 import org.apache.spark.rdd.RDD
 
-import com.linkedin.photon.ml.constants.MathConst
 import com.linkedin.photon.ml.data.LabeledPoint
 
 /**

--- a/photon-ml/src/test/scala/com/linkedin/photon/ml/evaluation/AreaUnderROCCurveLocalEvaluatorTest.scala
+++ b/photon-ml/src/test/scala/com/linkedin/photon/ml/evaluation/AreaUnderROCCurveLocalEvaluatorTest.scala
@@ -35,12 +35,20 @@ class AreaUnderROCCurveLocalEvaluatorTest {
   def testEvaluate(): Unit = {
 
     // normal cases
-    val labelsInNormalCase = arrayToIndexedMap(Array[Double](0, 1, 0, 0, 1, 1, 1))
-    val scoresInNormalCase = arrayToIndexedMap(Array[Double](-0.1, -1, 0, 1, 2, 6, 8))
+    val labelsInNormalCase = arrayToIndexedMap(Array[Double](1, 0, 0, 0, 1, 1, 1))
+    val scoresInNormalCase = arrayToIndexedMap(Array[Double](-1, -0.1, 0, 1, 2, 6, 8))
     val groundTruthFromRInNormalCase = 0.75
     val computedAUCInNormalCase = new AreaUnderROCCurveLocalEvaluator(labelsInNormalCase)
         .evaluate(scoresInNormalCase)
-    assertEquals(groundTruthFromRInNormalCase, computedAUCInNormalCase, MathConst.HIGH_PRECISION_TOLERANCE_THRESHOLD)
+    assertEquals(computedAUCInNormalCase, groundTruthFromRInNormalCase, MathConst.MEDIUM_PRECISION_TOLERANCE_THRESHOLD)
+
+    // if we have two identical scores with conflicting ground-truth labels
+    val labelsInCornerCase1 = arrayToIndexedMap(Array[Double](0, 1, 0, 0, 1, 1, 1))
+    val scoresInCornerCase1 = arrayToIndexedMap(Array[Double](-0.1, -1, 0, -1, 2, 6, 8))
+    val groundTruthFromRnCornerCase1 = 0.79166667
+    val computedAUCInCornerCase1 = new AreaUnderROCCurveLocalEvaluator(labelsInCornerCase1)
+        .evaluate(scoresInCornerCase1)
+    assertEquals(computedAUCInCornerCase1, groundTruthFromRnCornerCase1, MathConst.MEDIUM_PRECISION_TOLERANCE_THRESHOLD)
 
     // where all examples have positive label
     val positiveLabelsOnly = arrayToIndexedMap(Array[Double](1, 1))

--- a/photon-ml/src/test/scala/com/linkedin/photon/ml/evaluation/AreaUnderROCCurveLocalEvaluatorTest.scala
+++ b/photon-ml/src/test/scala/com/linkedin/photon/ml/evaluation/AreaUnderROCCurveLocalEvaluatorTest.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2016 LinkedIn Corp. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linkedin.photon.ml.evaluation
+
+import scala.collection.Map
+
+import org.testng.Assert._
+import org.testng.annotations.Test
+
+import com.linkedin.photon.ml.constants.MathConst
+
+
+/**
+ * Test functions in [[AreaUnderROCCurveLocalEvaluator]]
+ */
+class AreaUnderROCCurveLocalEvaluatorTest {
+
+  private def arrayToIndexedMap(array: Array[Double]): Map[Long, Double] = {
+    array.zipWithIndex.map { case (label, index) => (index.toLong, label) }.toMap
+  }
+
+  @Test
+  def testEvaluate(): Unit = {
+
+    // normal cases
+    val labelsInNormalCase = arrayToIndexedMap(Array[Double](0, 1, 0, 0, 1, 1, 1))
+    val scoresInNormalCase = arrayToIndexedMap(Array[Double](-0.1, -1, 0, 1, 2, 6, 8))
+    val groundTruthFromRInNormalCase = 0.75
+    val computedAUCInNormalCase = new AreaUnderROCCurveLocalEvaluator(labelsInNormalCase)
+        .evaluate(scoresInNormalCase)
+    assertEquals(groundTruthFromRInNormalCase, computedAUCInNormalCase, MathConst.HIGH_PRECISION_TOLERANCE_THRESHOLD)
+
+    // where all examples have positive label
+    val positiveLabelsOnly = arrayToIndexedMap(Array[Double](1, 1))
+    val scoresWithPositiveLabelsOnly = arrayToIndexedMap(Array[Double](0.5, 0.5))
+    val computedAUCWithPositiveLabelsOnly = new AreaUnderROCCurveLocalEvaluator(positiveLabelsOnly)
+        .evaluate(scoresWithPositiveLabelsOnly)
+    assertTrue(computedAUCWithPositiveLabelsOnly.isNaN)
+
+    // where all examples have negative label
+    val negativeLabelsOnly = arrayToIndexedMap(Array[Double](0, 0))
+    val scoresWithNegativeLabelsOnly = arrayToIndexedMap(Array[Double](0.5, 0.5))
+    val computedAUCWithNegativeLabelsOnly = new AreaUnderROCCurveLocalEvaluator(negativeLabelsOnly)
+        .evaluate(scoresWithNegativeLabelsOnly)
+    assertTrue(computedAUCWithNegativeLabelsOnly.isNaN)
+  }
+}


### PR DESCRIPTION
As discussed in issue #42, currently the only AUC computation supported in Photon/GAME is ```RDD``` based, e.g., the input scores and labels are in the ```RDD[(Double, Double)]``` format.

However, in order to enable per random effect AUC computation as in issue #41, computing AUC locally in the ```Array[(Double, Double)]``` or ```Seq[(Double, Double)]``` format will be a useful feature to have.

Besides, the local AUC computation will be helpful to our effort in evaluating different matrix factorization packages as well.

One more change made in this PR is that, now the local AUC computation will take the weight of each data point into consideration when computing AUC.