### PR TITLE
Coefficients type should be flexible when loaded from Avro model file

### DIFF
--- a/photon-ml/src/integTest/scala/com/linkedin/photon/ml/avro.model/ModelProcessingUtilsTest.scala
+++ b/photon-ml/src/integTest/scala/com/linkedin/photon/ml/avro.model/ModelProcessingUtilsTest.scala
@@ -76,8 +76,8 @@ class ModelProcessingUtilsTest extends SparkTestUtils with TestTemplateWithTmpDi
     val loadedGameModel = ModelProcessingUtils.loadGameModelFromHDFS(featureShardIdToFeatureNameAndTermToIndexMapMap,
       outputDir, sc)
     loadedGameModel.foreach {
-      case loadedFixedEffectModel: FixedEffectModel => assertTrue(loadedFixedEffectModel.equals(fixedEffectModel))
-      case loadedRandomEffectModel: RandomEffectModel => assertTrue(loadedRandomEffectModel.equals(randomEffectModel))
+      case loadedFixedEffectModel: FixedEffectModel => assertEquals(loadedFixedEffectModel, fixedEffectModel)
+      case loadedRandomEffectModel: RandomEffectModel => assertEquals(loadedRandomEffectModel, randomEffectModel)
     }
   }
 }

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/cli/game/scoring/Driver.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/cli/game/scoring/Driver.scala
@@ -52,7 +52,7 @@ class Driver(val params: Params, val sparkContext: SparkContext, val logger: Pho
    *
    * @return a map of shard id to feature map
    */
-  def prepareFeatureMaps(): Map[String, Map[NameAndTerm, Int]] = {
+  protected def prepareFeatureMaps(): Map[String, Map[NameAndTerm, Int]] = {
 
     val allFeatureSectionKeys = featureShardIdToFeatureSectionKeysMap.values.reduce(_ ++ _)
     val nameAndTermFeatureSetContainer = NameAndTermFeatureSetContainer.loadFromTextFiles(
@@ -76,7 +76,8 @@ class Driver(val params: Params, val sparkContext: SparkContext, val logger: Pho
    * @param featureShardIdToFeatureMapMap a map of shard id to feature map
    * @return the prepared GAME dataset
    */
-  def prepareGameDataSet(featureShardIdToFeatureMapMap: Map[String, Map[NameAndTerm, Int]]): RDD[(Long, GameDatum)] = {
+  protected def prepareGameDataSet(featureShardIdToFeatureMapMap: Map[String, Map[NameAndTerm, Int]])
+  : RDD[(Long, GameDatum)] = {
 
     val recordsPath = dateRangeOpt match {
       case Some(dateRange) =>
@@ -126,7 +127,7 @@ class Driver(val params: Params, val sparkContext: SparkContext, val logger: Pho
    * @return the scores
    */
   //todo: make the number of files written to HDFS to be configurable
-  def scoreAndWriteScoreToHDFS(
+  protected def scoreAndWriteScoreToHDFS(
       featureShardIdToFeatureMapMap: Map[String, Map[NameAndTerm, Int]],
       gameDataSet: RDD[(Long, GameDatum)]): RDD[(Long, Double)] = {
 
@@ -163,7 +164,7 @@ class Driver(val params: Params, val sparkContext: SparkContext, val logger: Pho
    * @param gameDataSet the input dataset
    * @param scores the scores
    */
-  def evaluateAndLog(gameDataSet: RDD[(Long, GameDatum)], scores: RDD[(Long, Double)]) {
+  protected def evaluateAndLog(gameDataSet: RDD[(Long, GameDatum)], scores: RDD[(Long, Double)]) {
 
     val validatingLabelAndOffsets = gameDataSet.mapValues(gameData => (gameData.response, gameData.offset))
     val metric =  taskType match {

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/util/VectorUtils.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/util/VectorUtils.scala
@@ -26,7 +26,7 @@ import scala.collection.mutable
  */
 object VectorUtils {
 
-  private val SPARSE_VECTOR_ACTIVE_SIZE_TO_SIZE_RATIO: Double = 1.0 / 3
+  protected[ml] val SPARSE_VECTOR_ACTIVE_SIZE_TO_SIZE_RATIO: Double = 1.0 / 3
 
   /**
    * Convert an [[Array]] of ([[Int]], [[Double]]) pairs into a [[Vector]].

--- a/photon-ml/src/test/scala/com/linkedin/photon/ml/avro/AvroUtilsTest.scala
+++ b/photon-ml/src/test/scala/com/linkedin/photon/ml/avro/AvroUtilsTest.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2016 LinkedIn Corp. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linkedin.photon.ml.avro
+
+import scala.collection.Map
+
+import breeze.linalg.{SparseVector, DenseVector}
+import org.testng.Assert.assertEquals
+import org.testng.annotations.Test
+
+import com.linkedin.photon.ml.avro.data.NameAndTerm
+import com.linkedin.photon.ml.model.Coefficients
+
+
+/**
+ * Simple tests for functions in [[AvroUtils]]
+ */
+class AvroUtilsTest {
+
+  @Test
+  def testCoefficientsAndBayesianLinearModelAvroRecordConversion(): Unit = {
+
+    // Initialize the coefficients and related meta data
+    val length = 4
+    val sparseVector = new SparseVector[Double](index = Array(1), data = Array(1.0), length = length)
+    val sparseCoefficients = Coefficients(sparseVector)
+    val denseVector = new DenseVector[Double](data = Array(0.0, 1.0, 2.0, 3.0))
+    val denseCoefficients = Coefficients(denseVector)
+    val modelId = "modelId"
+    val intToNameAndTermMap = Map(0 -> NameAndTerm("0", "0"), 1 -> NameAndTerm("1", "1"), 2 -> NameAndTerm("2", "2"),
+      3 -> NameAndTerm("3", "3"))
+    val nameAndTermToIntMap = intToNameAndTermMap.map(_.swap)
+
+    // Convert the sparse coefficients to Avro record, and convert it back to coefficients
+    val sparseCoefficientsAvro = AvroUtils.convertCoefficientsToBayesianLinearModelAvroRecord(sparseCoefficients,
+      modelId, intToNameAndTermMap)
+    val recoveredSparseVector = AvroUtils.parseMeanVectorFromBayesianLinearModelAvroRecord(sparseCoefficientsAvro,
+      nameAndTermToIntMap)
+    val recoveredSparseCoefficients = Coefficients(recoveredSparseVector)
+    assertEquals(sparseCoefficients, recoveredSparseCoefficients)
+
+    // Convert the dense coefficients to Avro record, and convert it back to coefficients
+    val denseCoefficientsAvro = AvroUtils.convertCoefficientsToBayesianLinearModelAvroRecord(denseCoefficients,
+      modelId, intToNameAndTermMap)
+    val recoveredDenseVector = AvroUtils.parseMeanVectorFromBayesianLinearModelAvroRecord(denseCoefficientsAvro,
+      nameAndTermToIntMap)
+    val recoveredDenseCoefficients = Coefficients(recoveredDenseVector)
+    assertEquals(denseCoefficients, recoveredDenseCoefficients)
+  }
+}

--- a/photon-ml/src/test/scala/com/linkedin/photon/ml/util/VectorUtilsTest.scala
+++ b/photon-ml/src/test/scala/com/linkedin/photon/ml/util/VectorUtilsTest.scala
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2016 LinkedIn Corp. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linkedin.photon.ml.util
+
+import breeze.linalg.{DenseVector, SparseVector}
+import org.testng.Assert._
+import org.testng.annotations.Test
+
+/**
+ * Simple tests for functions in [[VectorUtils]]
+ * @todo Test [[VectorUtils.kroneckerProduct()]]
+ */
+class VectorUtilsTest {
+  @Test
+  def testConvertIndexAndValuePairArrayToSparseVector() = {
+    val length = 6
+
+    // With empty data
+    val emptyIndexAndData = Array[(Int, Double)]()
+    val emptySparseVector = VectorUtils.convertIndexAndValuePairArrayToSparseVector(emptyIndexAndData, length)
+    assertEquals(emptySparseVector.length, length)
+    assertEquals(emptySparseVector.activeSize, emptyIndexAndData.length)
+
+    // Normal case
+    val normalIndexAndData = Array[(Int, Double)](0 -> 0.0, 3 -> 3.0, 5 -> 5.0)
+    val normalSparseVector = VectorUtils.convertIndexAndValuePairArrayToSparseVector(normalIndexAndData, length)
+    assertEquals(normalSparseVector.length, length)
+    assertEquals(normalSparseVector.activeSize, normalIndexAndData.length)
+    normalIndexAndData.foreach { case (index, data) =>
+      assertEquals(data, normalSparseVector(index))
+    }
+  }
+
+  @Test
+  def testConvertIndexAndValuePairArrayToDenseVector() = {
+    val length = 6
+
+    // With empty data
+    val emptyIndexAndData = Array[(Int, Double)]()
+    val emptyDenseVector = VectorUtils.convertIndexAndValuePairArrayToDenseVector(emptyIndexAndData, length)
+    assertEquals(emptyDenseVector.length, length)
+    assertEquals(emptyDenseVector.activeSize, length)
+
+    // Normal case
+    val normalIndexAndData = Array[(Int, Double)](0 -> 0.0, 3 -> 3.0, 5 -> 5.0)
+    val normalDenseVector = VectorUtils.convertIndexAndValuePairArrayToDenseVector(normalIndexAndData, length)
+    assertEquals(normalDenseVector.length, length)
+    assertEquals(normalDenseVector.activeSize, length)
+    normalIndexAndData.foreach { case (index, data) =>
+      assertEquals(data, normalDenseVector(index))
+    }
+  }
+
+  @Test
+  def testConvertIndexAndValuePairArrayToVector() = {
+    val length = 6
+
+    // For sparse vector
+    val activeSizeForSparseVector = math.floor(length * VectorUtils.SPARSE_VECTOR_ACTIVE_SIZE_TO_SIZE_RATIO - 1).toInt
+    val indexAndDataForSparseVector = Array.tabulate[(Int, Double)](activeSizeForSparseVector)(i => (i, 1.0))
+    val sparseVector = VectorUtils.convertIndexAndValuePairArrayToVector(indexAndDataForSparseVector, length)
+    assertTrue(sparseVector.isInstanceOf[SparseVector[Double]])
+    assertEquals(sparseVector.activeSize, activeSizeForSparseVector)
+    assertEquals(sparseVector.length, length)
+
+    // For dense vector
+    val activeSizeForDenseVector = math.floor(length * VectorUtils.SPARSE_VECTOR_ACTIVE_SIZE_TO_SIZE_RATIO + 1).toInt
+    val indexAndDataForDenseVector = Array.tabulate[(Int, Double)](activeSizeForDenseVector)(i => (i, 1.0))
+    val denseVector = VectorUtils.convertIndexAndValuePairArrayToVector(indexAndDataForDenseVector, length)
+    assertTrue(denseVector.isInstanceOf[DenseVector[Double]])
+    assertEquals(denseVector.activeSize, length)
+    assertEquals(denseVector.length, length)
+  }
+}


### PR DESCRIPTION
As discussed in Issue #45, it would be helpful if the coefficients type can be flexible when loaded from Avro model file, instead of always being a ```DenseVector[Double]```, for example, the coefficient type could be either dense vector or sparse vector based on the sparsity of the underlying array. 

This will be helpful in cases when the underlying dimension of the coefficient space (array length) is large, but the actual support (active size) is small.

Also some unit tests are added in this PR.