### PR TITLE
Enable integration tests on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 os:
   - linux
-language: java
+language: scala
 jdk:
   - oraclejdk8
 before_cache:
@@ -9,8 +9,6 @@ cache:
   directories:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
-install:
-  - ./gradlew assemble
 before_script:
   - sudo service postgresql stop || true
   - sudo service mysql stop || true
@@ -23,5 +21,8 @@ before_script:
   - sudo service riak stop || true
   - sudo service rsync stop || true
   - sudo service x11-common stop || true
+env:
+  - TESTS=unit
+  - TESTS=integration
 script:
-  - ./gradlew check -x integTest
+  - ./tests.sh $TESTS

--- a/build.gradle
+++ b/build.gradle
@@ -86,7 +86,8 @@ rat {
     'photon-ml/LINEAR_REGRESSION*/**',
     'photon-ml/LOGISTIC_REGRESSION*/**',
     'photon-ml/POISSON_REGRESSION*/**',
-    'photon-test/src/test/resources/**'
+    'photon-test/src/test/resources/**',
+    'tests.sh'
   ]
 }
 

--- a/photon-ml/src/integTest/scala/com/linkedin/photon/ml/util/PhotonLoggerIntegTest.scala
+++ b/photon-ml/src/integTest/scala/com/linkedin/photon/ml/util/PhotonLoggerIntegTest.scala
@@ -26,13 +26,20 @@ class PhotonLoggerIntegTest extends SparkTestUtils with TestTemplateWithTmpDir {
 
   class TestException extends Exception
 
+  private val LOG_REGEX_BASE = "^[0-9\\-]{10}T[0-9\\:\\.]{12}[\\-\\+][0-9]{4} \\[%s\\] %s$"
+  private val DEBUG_MESSAGE = "test message 1"
+  private val ERROR_MESSAGE = "test message 2"
+  private val INFO_MESSAGE = "test message 3"
+  private val TRACE_MESSAGE = "test message 4"
+  private val WARN_MESSAGE = "test message 5"
+
   @Test
   def testSingleLogMessage() = sparkTest("singleLogMessage") {
     val logFile = s"$getTmpDir/singleLogMessage"
     val logger = new PhotonLogger(logFile, sc)
 
     try {
-      logger.error("test message")
+      logger.error(ERROR_MESSAGE)
 
     } finally {
       logger.close()
@@ -43,7 +50,7 @@ class PhotonLoggerIntegTest extends SparkTestUtils with TestTemplateWithTmpDir {
 
     val lines = Source.fromFile(logFile).getLines().toArray
     assertEquals(lines.length, 1)
-    assertTrue(lines(0).matches("^[0-9T\\-\\:\\.]* \\[ERROR\\] test message$"))
+    assertTrue(lines(0).matches(LOG_REGEX_BASE.format("ERROR", ERROR_MESSAGE)))
   }
 
   @Test
@@ -55,12 +62,11 @@ class PhotonLoggerIntegTest extends SparkTestUtils with TestTemplateWithTmpDir {
     logger.setLogLevel(PhotonLogger.LogLevelTrace)
 
     try {
-      logger.debug("test message 1")
-      logger.error("test message 2")
-      logger.info("test message 3")
-      logger.trace("test message 4")
-      logger.warn("test message 5")
-
+      logger.debug(DEBUG_MESSAGE)
+      logger.error(ERROR_MESSAGE)
+      logger.info(INFO_MESSAGE)
+      logger.trace(TRACE_MESSAGE)
+      logger.warn(WARN_MESSAGE)
     } finally {
       logger.close()
     }
@@ -70,11 +76,11 @@ class PhotonLoggerIntegTest extends SparkTestUtils with TestTemplateWithTmpDir {
 
     val lines = Source.fromFile(logFile).getLines().toArray
     assertEquals(lines.length, 5)
-    assertTrue(lines(0).matches("^[0-9T\\-\\:\\.]* \\[DEBUG\\] test message 1$"))
-    assertTrue(lines(1).matches("^[0-9T\\-\\:\\.]* \\[ERROR\\] test message 2$"))
-    assertTrue(lines(2).matches("^[0-9T\\-\\:\\.]* \\[INFO\\] test message 3$"))
-    assertTrue(lines(3).matches("^[0-9T\\-\\:\\.]* \\[TRACE\\] test message 4$"))
-    assertTrue(lines(4).matches("^[0-9T\\-\\:\\.]* \\[WARN\\] test message 5$"))
+    assertTrue(lines(0).matches(LOG_REGEX_BASE.format("DEBUG", DEBUG_MESSAGE)))
+    assertTrue(lines(1).matches(LOG_REGEX_BASE.format("ERROR", ERROR_MESSAGE)))
+    assertTrue(lines(2).matches(LOG_REGEX_BASE.format("INFO", INFO_MESSAGE)))
+    assertTrue(lines(3).matches(LOG_REGEX_BASE.format("TRACE", TRACE_MESSAGE)))
+    assertTrue(lines(4).matches(LOG_REGEX_BASE.format("WARN", WARN_MESSAGE)))
   }
 
   @DataProvider
@@ -95,11 +101,11 @@ class PhotonLoggerIntegTest extends SparkTestUtils with TestTemplateWithTmpDir {
     logger.setLogLevel(level)
 
     try {
-      logger.debug("test message 1")
-      logger.error("test message 2")
-      logger.info("test message 3")
-      logger.trace("test message 4")
-      logger.warn("test message 5")
+      logger.debug(DEBUG_MESSAGE)
+      logger.error(ERROR_MESSAGE)
+      logger.info(INFO_MESSAGE)
+      logger.trace(TRACE_MESSAGE)
+      logger.warn(WARN_MESSAGE)
 
     } finally {
       logger.close()
@@ -125,7 +131,7 @@ class PhotonLoggerIntegTest extends SparkTestUtils with TestTemplateWithTmpDir {
 
     } catch {
       case e: TestException =>
-        logger.error("test message 2", e)
+        logger.error(ERROR_MESSAGE, e)
 
     } finally {
       logger.close()
@@ -136,7 +142,7 @@ class PhotonLoggerIntegTest extends SparkTestUtils with TestTemplateWithTmpDir {
 
     val lines = Source.fromFile(logFile).getLines().toArray
     assertEquals(lines.length, 19)
-    assertTrue(lines(0).matches("^[0-9T\\-\\:\\.]* \\[ERROR\\] test message 2$"))
+    assertTrue(lines(0).matches(LOG_REGEX_BASE.format("ERROR", ERROR_MESSAGE)))
     assertEquals(lines(1), "com.linkedin.photon.ml.util.PhotonLoggerIntegTest$TestException")
   }
 }

--- a/tests.sh
+++ b/tests.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+#
+# This script is used to customize Travis CI testing as follows:
+# - Wrapper for gradle call to run unit and integration tests in parallel
+# - Redirect integTest output to tmp file to avoid Travis CI 4MB log file limit. In addition, ping Travis CI while
+#   testing to avoid the 10 minute no-output timeout. This code modified from the base script found here:
+#   http://stackoverflow.com/questions/26082444/how-to-work-around-travis-cis-4mb-output-limit
+#
+
+NUM_LINES=500
+
+# Helper functions
+dump_output() {
+  echo "Dumping the last $NUM_LINES lines of output:"
+  tail -${NUM_LINES} ${BUILD_OUTPUT}
+}
+
+kill_ping_loop() {
+  kill ${PING_LOOP_PID}
+}
+
+clean_up() {
+  # The build finished without returning an error so dump a tail of the output
+  dump_output
+  # Nicely terminate the ping output loop
+  kill_ping_loop
+}
+
+error_handler() {
+  echo "ERROR: An error was encountered with the build."
+  clean_up
+  exit 1
+}
+
+
+# Abort on error
+set -e
+
+if [[ $# -ne 1 ]]; then
+  echo "ERROR: Wrong # of arguments"
+  exit 1
+fi
+
+if [[ "$1" == "integration" ]]; then
+  # Redirect output to file, ping Travis intermittently so it doesn't kill the test.
+  PING_SLEEP=30s
+  BUILD_OUTPUT=/tmp/build.out
+
+  touch ${BUILD_OUTPUT}
+
+  # If an error occurs, run our error handler to output a tail of the build
+  trap 'error_handler' ERR
+
+  # Set up a repeating loop to send some output to Travis.
+  bash -c "while true; do echo \"\$(date) - testing ...\"; sleep $PING_SLEEP; done" &
+  PING_LOOP_PID=$!
+
+  # Run integration tests, redirect output to tmp file
+  ./gradlew check -x test &> ${BUILD_OUTPUT}
+
+  # Kill ping process, output final
+  clean_up
+
+elif [[ "$1" == "unit" ]]; then
+  ./gradlew check -x integTest
+
+else
+  echo "ERROR: Invalid test type specified; must be either 'unit' or 'integration'"
+  exit 1
+fi


### PR DESCRIPTION
- Modified PhotonLoggerIntegTest to have a more accurate regex (previously it assumed the time zone would always be West of GMT)
- Added custom script for testing on Travis CI
- Split unit tests and integration tests to run in parallel
- Integration test output is redirected to a tmp file, to get around the 4MB log file size issue. Setup up a dummy process to ping Travis every 30s so it doesn't kill the test process for inactivity. Dump the last 500 lines whenever tests complete successfully or an error occurs.

Much of the script comes from here:
http://stackoverflow.com/questions/26082444/how-to-work-around-travis-cis-4mb-output-limit