### PR TITLE
Fix utf8 string output in IOUtils

### DIFF
--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/util/IOUtils.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/util/IOUtils.scala
@@ -14,7 +14,7 @@
  */
 package com.linkedin.photon.ml.util
 
-import java.io.{BufferedReader, InputStreamReader}
+import java.io._
 
 import scala.collection.mutable
 
@@ -97,7 +97,15 @@ protected[ml] object IOUtils {
 
     val fs = outputPath.getFileSystem(configuration)
     val stream = fs.create(outputPath, forceOverwrite)
-    stringMsgs.foreach(stringMsg => stream.writeBytes(stringMsg + "\n"))
-    stream.close()
+    val writer = new PrintWriter(
+      new BufferedWriter(
+        new OutputStreamWriter(stream)
+      )
+    )
+    try {
+      stringMsgs.foreach { stringMsg => writer.println(stringMsg)}
+    } finally {
+      writer.close()
+    }
   }
 }

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/util/IOUtils.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/util/IOUtils.scala
@@ -103,7 +103,7 @@ protected[ml] object IOUtils {
       )
     )
     try {
-      stringMsgs.foreach { stringMsg => writer.println(stringMsg)}
+      stringMsgs.foreach(stringMsg => writer.println(stringMsg))
     } finally {
       writer.close()
     }

--- a/photon-ml/src/test/scala/com/linkedin/photon/ml/util/IOUtilsTest.scala
+++ b/photon-ml/src/test/scala/com/linkedin/photon/ml/util/IOUtilsTest.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2016 LinkedIn Corp. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linkedin.photon.ml.util
+
+import com.linkedin.photon.ml.test.TestTemplateWithTmpDir
+import org.apache.hadoop.conf.Configuration
+import org.testng.Assert
+import org.testng.annotations.{DataProvider, Test}
+
+import scala.collection.mutable.ArrayBuffer
+
+
+/**
+ * This class tests [[IOUtils]] can correctly read and write primitive/ASCII strings and
+ * international/UTF-8 strings.
+ */
+class IOUtilsTest extends TestTemplateWithTmpDir {
+  @Test(dataProvider = "dataProvider")
+  def testReadAndWrite(dir: String, testString: String): Unit = {
+    val tmpDir = getTmpDir + "/" + dir
+    val conf = new Configuration()
+    IOUtils.writeStringsToHDFS(List(testString).iterator, tmpDir, conf, true)
+    val strings = IOUtils.readStringsFromHDFS(tmpDir, conf)
+    Assert.assertEquals(strings, ArrayBuffer(testString))
+  }
+
+  @DataProvider
+  def dataProvider(): Array[Array[Any]] = {
+    Array(
+      Array("ASCII", "Test string"),
+      Array("UTF-8", "测试字符串") // Literally "Test string" in Chinese characters
+    )
+  }
+}


### PR DESCRIPTION
The current implementation uses DataOutputStream.writeBytes interface which casts char to byte and write only one byte per char. 

`   public final void writeBytes(String s) throws IOException {
        int len = s.length();
        for (int i = 0 ; i < len ; i++) {
            out.write((byte)s.charAt(i));
        }
        incCount(len);
    }
`
But Java char uses UTF encoding so sizeof(char) = 2 bytes (https://docs.oracle.com/javase/8/docs/api/java/lang/Character.html) and the casting will cause troubles for international languages used in feature names and terms.