### PR TITLE
Set the default Photon log level to DEBUG

### DIFF
--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/Driver.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/Driver.scala
@@ -515,6 +515,8 @@ object Driver {
     // A temporary solution to save log into HDFS.
     val logPath = new Path(params.outputDir, "log-message.txt")
     val logger = new PhotonLogger(logPath, sc)
+    //TODO: This Photon log level should be made configurable
+    logger.setLogLevel(PhotonLogger.LogLevelDebug)
 
     try {
       val job = new Driver(params, sc, logger)

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/SparkContextConfiguration.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/SparkContextConfiguration.scala
@@ -83,6 +83,8 @@ object SparkContextConfiguration {
       sparkConf.set(CONF_SPARK_SERIALIZER, classOf[KryoSerializer].getName)
       sparkConf.registerKryoClasses(KRYO_CLASSES_TO_REGISTER)
     }
+    //TODO: This Spark log level should be made configurable, please note that this log level may be different from
+    // Photon log level
     Logger.getRootLogger.setLevel(Level.INFO)
     new SparkContext(sparkConf)
   }

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/cli/game/scoring/Driver.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/cli/game/scoring/Driver.scala
@@ -228,6 +228,8 @@ object Driver {
     val logsDir = new Path(outputDir, LOGS).toString
     Utils.createHDFSDir(logsDir, sc.hadoopConfiguration)
     val logger = new PhotonLogger(logsDir, sc)
+    //TODO: This Photon log level should be made configurable
+    logger.setLogLevel(PhotonLogger.LogLevelDebug)
 
     try {
       logger.debug(params.toString + "\n")

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/cli/game/training/Driver.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/cli/game/training/Driver.scala
@@ -484,6 +484,8 @@ object Driver {
     val logsDir = new Path(outputDir, LOGS).toString
     Utils.createHDFSDir(logsDir, sc.hadoopConfiguration)
     val logger = new PhotonLogger(logsDir, sc)
+    //TODO: This Photon log level should be made configurable
+    logger.setLogLevel(PhotonLogger.LogLevelDebug)
 
     try {
       logger.debug(params.toString + "\n")


### PR DESCRIPTION
This PR addresses #64. This should serve as a temporary fix for this problem, in the long run, we may want to have the log level for Photon and Spark to be configurable. @ashelkovnykov, I added a few TODOs in the code, do you think we can take them into account during our Photon/GAME refactoring?