### PR TITLE
Fix feature name collision / strictness issues in box constraints

### DIFF
--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/io/GLMSuite.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/io/GLMSuite.scala
@@ -240,7 +240,7 @@ class GLMSuite(
                 }
               } else if (term == GLMSuite.WILDCARD) {
                 featureKeyToIdMap
-                  .filter(x => x._1.startsWith(name))
+                  .filter(x => x._1.startsWith(name + GLMSuite.DELIMITER))
                   .foreach(x => {
                     if (constraintMap.containsKey(x._2)) {
                       throw new IllegalArgumentException(s"Please avoid specifying potentially " +

--- a/photon-ml/src/test/scala/com/linkedin/photon/ml/io/GLMSuiteTest.scala
+++ b/photon-ml/src/test/scala/com/linkedin/photon/ml/io/GLMSuiteTest.scala
@@ -65,7 +65,8 @@ class GLMSuiteTest {
         """[
              {"name": "foo", "term": "bar", "lowerBound": 0, "upperBound": 1},
              {"name": "foo", "term": "bar", "lowerBound": 0, "upperBound": 5}
-           ]""")
+           ]"""),
+      Array(featureKeyToIdMap, """[{"name": "foo", "lowerbound": 0, "upperbound": 1}]""")
     )
   }
 
@@ -84,7 +85,9 @@ class GLMSuiteTest {
       Utils.getFeatureKey("foo", "baz")->2,
       Utils.getFeatureKey("qux", "bar")->3,
       GLMSuite.INTERCEPT_NAME_TERM->4,
-      Utils.getFeatureKey("qux", "baz")->5)
+      Utils.getFeatureKey("qux", "baz")->5,
+      Utils.getFeatureKey("qux", "")->6,
+      Utils.getFeatureKey("quxl", "")->7)
     Array(
       Array(featureKeyToIdMap, """[{"name": "foo", "term": "baz", "lowerBound": 0, "upperBound": 1}]""",
         Some(Map[Int, (Double, Double)](2->(0.0, 1.0)))),
@@ -95,15 +98,15 @@ class GLMSuiteTest {
       Array(featureKeyToIdMap, """[{"name": "foo", "term": "bar", "upperBound": 1}]""",
         Some(Map[Int, (Double, Double)](1->(Double.NegativeInfinity, 1.0)))),
       Array(featureKeyToIdMap, """[{"name": "*", "term": "*", "lowerBound": 0, "upperBound": 1}]""",
-        Some(Map[Int, (Double, Double)](0->(0.0, 1.0), 1->(0.0, 1.0), 2->(0.0, 1.0), 3->(0.0, 1.0), 5->(0.0, 1.0)))),
+        Some(Map[Int, (Double, Double)](0->(0.0, 1.0), 1->(0.0, 1.0), 2->(0.0, 1.0), 3->(0.0, 1.0), 5->(0.0, 1.0), 6->(0.0, 1.0), 7->(0.0, 1.0)))),
       Array(featureKeyToIdMap, """[{"name": "qux", "term": "*", "lowerBound": 0, "upperBound": 1}]""",
-        Some(Map[Int, (Double, Double)](3->(0.0, 1.0), 4->(0.0, 1.0)))),
+        Some(Map[Int, (Double, Double)](3->(0.0, 1.0), 5->(0.0, 1.0), 6->(0.0, 1.0)))),
       Array(featureKeyToIdMap,
         """[
              {"name": "foo", "term": "bar", "lowerBound": 0, "upperBound": 1},
              {"name": "qux", "term": "baz", "lowerBound": 0, "upperBound": 1}
            ]""",
-        Some(Map[Int, (Double, Double)](1->(0.0, 1.0), 4->(0.0, 1.0))))
+        Some(Map[Int, (Double, Double)](1->(0.0, 1.0), 5->(0.0, 1.0))))
     )
   }
 

--- a/photon-test/src/main/scala/com/linkedin/photon/ml/test/CommonTestUtils.scala
+++ b/photon-test/src/main/scala/com/linkedin/photon/ml/test/CommonTestUtils.scala
@@ -49,17 +49,13 @@ object CommonTestUtils {
         if (x.size != y.size) {
           false
         } else {
-          x.foreach{
+          x.filter {
             case (id, bounds) =>
               y.get(id) match {
-                case Some(w: (Double, Double)) =>
-                  if (w != bounds) {
-                    false
-                  }
+                case Some(w: (Double, Double)) => w == bounds
                 case None => false
               }
-          }
-          true
+          }.size == x.size
         }
       case (None, None) => true
       case (None, _) => false


### PR DESCRIPTION
This pull request addresses the following two issues:

 * A bug in box constraints where we'd incorrectly treat two features as identical if there was a substring match between the feature names
 * A minor issue where we'd allow users to specify empty constraints (e.g. for typos in upperBound, lowerBound or both)