### PR TITLE
Adding MatrixFactorizationModel to GAME's model package, with other relevant integTest improvement.

### DIFF
--- a/photon-ml/src/integTest/scala/com/linkedin/photon/ml/data/KeyValueScoreTest.scala
+++ b/photon-ml/src/integTest/scala/com/linkedin/photon/ml/data/KeyValueScoreTest.scala
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2016 LinkedIn Corp. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linkedin.photon.ml.data
+
+import org.testng.Assert._
+import org.testng.annotations.Test
+
+import com.linkedin.photon.ml.test.SparkTestUtils
+
+
+/**
+ * Simple tests for [[KeyValueScore]]
+ */
+class KeyValueScoreTest extends SparkTestUtils {
+
+  /**
+   * Generate a [[KeyValueScore]] with the given scores
+   * @param scores the given scores
+   * @return the [[KeyValueScore]] generated with the given scores
+   */
+  private def generateKeyValueScore(scores: Array[Double]): KeyValueScore = {
+    new KeyValueScore(sc.parallelize(scores.zipWithIndex.map { case (score, uniqueId) => (uniqueId.toLong, score) }))
+  }
+
+  /**
+   * Generate a [[KeyValueScore]] with the given keys and values
+   * @param keys the given keys
+   * @param values the given values
+   * @return the [[KeyValueScore]] generated with the given keys and values
+   */
+  private def generateKeyValueScore(keys: Array[Long], values: Array[Double]): KeyValueScore = {
+    new KeyValueScore(sc.parallelize(keys.zip(values)))
+  }
+
+  @Test
+  def testEquals(): Unit = sparkTest("testEqualsForKeyValueScores") {
+    //case 1: key value scores of length 0
+    val emptyScores1 = generateKeyValueScore(scores = Array[Double]())
+    val emptyScores2 = generateKeyValueScore(scores = Array[Double]())
+    assertEquals(emptyScores1, emptyScores2)
+
+    //case 2: key value scores with different length
+    val nonEmptyScores1 = generateKeyValueScore(scores = Array[Double](1, 2))
+    val nonEmptyScores2 = generateKeyValueScore(scores = Array[Double](1, 2, 3))
+    assertTrue(!nonEmptyScores1.equals(nonEmptyScores2))
+
+    //case 3: key value scores with same keys but different values
+    val sharedKeys = Array[Long](1, 3, 5)
+    val values1 = Array[Double](0, 0, 0)
+    val values2 = Array[Double](0, 1, 0)
+    val keyValueScore1 = generateKeyValueScore(sharedKeys, values1)
+    val keyValueScore2 = generateKeyValueScore(sharedKeys, values2)
+    assertTrue(!keyValueScore1.equals(keyValueScore2))
+
+    //case 4: key value scores with different keys but same values
+    val keys1 = Array[Long](0, 1, 2)
+    val keys2 = Array[Long](1, 2, 3)
+    val sharedValues = Array[Double](1, 2, 3)
+    val keyValueScore3 = generateKeyValueScore(keys1, sharedValues)
+    val keyValueScore4 = generateKeyValueScore(keys2, sharedValues)
+    assertTrue(!keyValueScore3.equals(keyValueScore4))
+
+    //case 5: same keys and same values, but the order of key/value pairs are different
+    val keys3 = Array[Long](0, 1, 2)
+    val keys4 = Array[Long](2, 1, 0)
+    val values3 = Array[Double](4, 5, 6)
+    val values4 = Array[Double](6, 5, 4)
+    val keyValueScore5 = generateKeyValueScore(keys3, values3)
+    val keyValueScore6 = generateKeyValueScore(keys4, values4)
+    assertEquals(keyValueScore5, keyValueScore6)
+  }
+
+  @Test
+  def testPlus(): Unit = sparkTest("testPlusForKeyValueScores") {
+    //case 1: both key value scores are of length 0
+    val emptyScores = generateKeyValueScore(scores = Array[Double]())
+    assertEquals(emptyScores - emptyScores, emptyScores)
+
+    //case 2: one of the scores are empty
+    val nonEmptyScores = generateKeyValueScore(scores = Array[Double](1, 2))
+    assertEquals(emptyScores + nonEmptyScores, nonEmptyScores)
+
+    //case 3: when both scores are non-empty
+    val keys1 = Array[Long](0, 1, 2)
+    val keys2 = Array[Long](2, 3, 4)
+    val values1 = Array[Double](1, -1, 1)
+    val values2 = Array[Double](-1, 0, 1)
+    val keyValueScore1 = generateKeyValueScore(keys1, values1)
+    val keyValueScore2 = generateKeyValueScore(keys2, values2)
+    val expectedKeys = Array[Long](0, 1, 2, 3, 4)
+    val expectedValues = Array[Double](1, -1, 0, 0, 1)
+    val expectedKeyValueScore = generateKeyValueScore(expectedKeys, expectedValues)
+    assertEquals(keyValueScore1 + keyValueScore2, expectedKeyValueScore)
+  }
+
+  @Test
+  def testMinus(): Unit = sparkTest("testMinusForKeyValueScores") {
+    //case 1: both key value scores are of length 0
+    val emptyScores = generateKeyValueScore(scores = Array[Double]())
+    assertEquals(emptyScores - emptyScores, emptyScores)
+
+    //case 2: one of the scores are empty
+    val nonEmptyScores = generateKeyValueScore(scores = Array[Double](1, 2))
+    assertEquals(nonEmptyScores - emptyScores, nonEmptyScores)
+    val expectedNonEmptyScores = generateKeyValueScore(scores = Array[Double](-1, -2))
+    assertEquals(emptyScores - nonEmptyScores, expectedNonEmptyScores)
+
+    //case 3: when both scores are non-empty
+    val keys1 = Array[Long](0, 1, 2)
+    val keys2 = Array[Long](2, 3, 4)
+    val values1 = Array[Double](1, -1, 1)
+    val values2 = Array[Double](-1, 0, 1)
+    val keyValueScore1 = generateKeyValueScore(keys1, values1)
+    val keyValueScore2 = generateKeyValueScore(keys2, values2)
+    val expectedKeys1 = Array[Long](0, 1, 2, 3, 4)
+    val expectedValues1 = Array[Double](1, -1, 2, 0, -1)
+    val expectedKeyValueScore1 = generateKeyValueScore(expectedKeys1, expectedValues1)
+    assertEquals(keyValueScore1 - keyValueScore2, expectedKeyValueScore1)
+    val expectedKeys2 = Array[Long](0, 1, 2, 3, 4)
+    val expectedValues2 = Array[Double](-1, 1, -2, 0, 1)
+    val expectedKeyValueScore2 = generateKeyValueScore(expectedKeys2, expectedValues2)
+    assertEquals(keyValueScore2 - keyValueScore1, expectedKeyValueScore2)
+  }
+}

--- a/photon-ml/src/integTest/scala/com/linkedin/photon/ml/data/KeyValueScoreTest.scala
+++ b/photon-ml/src/integTest/scala/com/linkedin/photon/ml/data/KeyValueScoreTest.scala
@@ -54,7 +54,7 @@ class KeyValueScoreTest extends SparkTestUtils {
     //case 2: key value scores with different length
     val nonEmptyScores1 = generateKeyValueScore(scores = Array[Double](1, 2))
     val nonEmptyScores2 = generateKeyValueScore(scores = Array[Double](1, 2, 3))
-    assertTrue(!nonEmptyScores1.equals(nonEmptyScores2))
+    assertNotEquals(nonEmptyScores1, nonEmptyScores2)
 
     //case 3: key value scores with same keys but different values
     val sharedKeys = Array[Long](1, 3, 5)
@@ -62,7 +62,7 @@ class KeyValueScoreTest extends SparkTestUtils {
     val values2 = Array[Double](0, 1, 0)
     val keyValueScore1 = generateKeyValueScore(sharedKeys, values1)
     val keyValueScore2 = generateKeyValueScore(sharedKeys, values2)
-    assertTrue(!keyValueScore1.equals(keyValueScore2))
+    assertNotEquals(keyValueScore1, keyValueScore2)
 
     //case 4: key value scores with different keys but same values
     val keys1 = Array[Long](0, 1, 2)
@@ -70,7 +70,7 @@ class KeyValueScoreTest extends SparkTestUtils {
     val sharedValues = Array[Double](1, 2, 3)
     val keyValueScore3 = generateKeyValueScore(keys1, sharedValues)
     val keyValueScore4 = generateKeyValueScore(keys2, sharedValues)
-    assertTrue(!keyValueScore3.equals(keyValueScore4))
+    assertNotEquals(keyValueScore3, keyValueScore4)
 
     //case 5: same keys and same values, but the order of key/value pairs are different
     val keys3 = Array[Long](0, 1, 2)

--- a/photon-ml/src/integTest/scala/com/linkedin/photon/ml/model/FixedEffectModelTest.scala
+++ b/photon-ml/src/integTest/scala/com/linkedin/photon/ml/model/FixedEffectModelTest.scala
@@ -15,7 +15,7 @@
 package com.linkedin.photon.ml.model
 
 import org.testng.annotations.Test
-import org.testng.Assert.assertTrue
+import org.testng.Assert._
 
 import com.linkedin.photon.ml.test.SparkTestUtils
 
@@ -38,21 +38,21 @@ class FixedEffectModelTest extends SparkTestUtils {
     val fixedEffectModel = new FixedEffectModel(sc.broadcast(coefficients), featureShardId)
 
     // Should equal to itself
-    assertTrue(fixedEffectModel.equals(fixedEffectModel))
+    assertEquals(fixedEffectModel, fixedEffectModel)
 
     // Should equal to the fixed effect model with same featureShardId and coefficientsBroadcast
     val fixedEffectModelCopy = new FixedEffectModel(sc.broadcast(coefficients), featureShardId)
-    assertTrue(fixedEffectModel.equals(fixedEffectModelCopy))
+    assertEquals(fixedEffectModel, fixedEffectModelCopy)
 
     // Should not equal to the fixed effect model with different featureShardId
     val featureShardId1 = "featureShardId1"
     val fixedEffectModelWithDiffFeatureShardId = new FixedEffectModel(sc.broadcast(coefficients), featureShardId1)
-    assertTrue(!fixedEffectModel.equals(fixedEffectModelWithDiffFeatureShardId))
+    assertNotEquals(fixedEffectModel, fixedEffectModelWithDiffFeatureShardId)
 
     // Should not equal to the fixed effect model with different coefficientsBroadcast
     val coefficientDimension1 = coefficientDimension + 1
     val coefficients1 = Coefficients.initializeZeroCoefficients(coefficientDimension1)
     val fixedEffectModelWithDiffCoefficientsRDD = new FixedEffectModel(sc.broadcast(coefficients1), featureShardId)
-    assertTrue(!fixedEffectModel.equals(fixedEffectModelWithDiffCoefficientsRDD))
+    assertNotEquals(fixedEffectModel, fixedEffectModelWithDiffCoefficientsRDD)
   }
 }

--- a/photon-ml/src/integTest/scala/com/linkedin/photon/ml/model/FixedEffectModelTest.scala
+++ b/photon-ml/src/integTest/scala/com/linkedin/photon/ml/model/FixedEffectModelTest.scala
@@ -21,7 +21,7 @@ import com.linkedin.photon.ml.test.SparkTestUtils
 
 
 /**
- * @author xazhang
+ * Test the fixed effect model
  */
 class FixedEffectModelTest extends SparkTestUtils {
 

--- a/photon-ml/src/integTest/scala/com/linkedin/photon/ml/model/MatrixFactorizationModelTest.scala
+++ b/photon-ml/src/integTest/scala/com/linkedin/photon/ml/model/MatrixFactorizationModelTest.scala
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2016 LinkedIn Corp. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linkedin.photon.ml.model
+
+import java.util.Random
+
+import breeze.linalg.Vector
+import org.apache.spark.SparkContext
+import org.testng.Assert._
+import org.testng.annotations.{DataProvider, Test}
+
+import com.linkedin.photon.ml.data.{KeyValueScore, GameDatum}
+import com.linkedin.photon.ml.constants.MathConst
+import com.linkedin.photon.ml.test.SparkTestUtils
+
+
+/**
+ * test the matrix factorization model
+ */
+class MatrixFactorizationModelTest extends SparkTestUtils {
+
+  // Generate a latent factor of zeros
+  private def generateZerosLatentFactor(numLatentFactors: Int): Vector[Double] = {
+    Vector.zeros[Double](numLatentFactors)
+  }
+
+  // Generate a latent factor with random numbers
+  private def generateRandomLatentFactor(numLatentFactors: Int, random: Random): Vector[Double] = {
+    Vector.fill(numLatentFactors)(random.nextDouble())
+  }
+
+  // Generate a matrix factorization model with the given specs
+  private def generateMatrixFactorizationModel(
+    numRows: Int,
+    numCols: Int,
+    rowEffectType: String,
+    colEffectType: String,
+    rowFactorGenerator: => Vector[Double],
+    colFactorGenerator: => Vector[Double],
+    sparkContext: SparkContext): MatrixFactorizationModel = {
+
+    val rowLatentFactors =
+      sparkContext.parallelize(Seq.tabulate(numRows)(i => (i.toString, rowFactorGenerator)))
+    val colLatentFactors =
+      sparkContext.parallelize(Seq.tabulate(numRows)(j => (j.toString, colFactorGenerator)))
+    new MatrixFactorizationModel(rowEffectType, colEffectType, rowLatentFactors, colLatentFactors)
+  }
+
+  @DataProvider
+  def matrixFactorizationConfigProvider():Array[Array[Any]] = {
+    Array(
+      Array(1, 2, 2),
+      Array(5, 10, 10)
+    )
+  }
+
+  @Test(dataProvider = "matrixFactorizationConfigProvider")
+  def testScore(numLatentFactors: Int, numRows: Int, numCols: Int)
+  : Unit = sparkTest("testScoreForMatrixFactorizationModel") {
+
+    // Meta data, the actual value doesn't matter for this test
+    val rowEffectType = "rowEffectType"
+    val colEffectType = "colEffectType"
+
+    // The row and column latent factor generator
+    val random = new Random(MathConst.RANDOM_SEED)
+    def randomRowLatentFactorGenerator = generateRandomLatentFactor(numLatentFactors, random)
+    def randomColLatentFactorGenerator = generateRandomLatentFactor(numLatentFactors, random)
+
+    val rowLatentFactors = Array.tabulate(numRows)(i => (i.toString, randomRowLatentFactorGenerator))
+    val colLatentFactors = Array.tabulate(numCols)(j => (j.toString, randomColLatentFactorGenerator))
+    val rowRange = 0 until numRows
+    val colRange = 0 until numCols
+
+    // generate the synthetic game data and scores
+    val (gameData, syntheticScores) = rowRange.zip(colRange).map { case (row, col) =>
+      val rowId = row.toString
+      val colId = col.toString
+      val randomEffectIdToIndividualIdMap = Map(rowEffectType -> rowId, colEffectType -> colId)
+      val gameDatum = new GameDatum(response = 1.0, offset = 0.0, weight = 0.0, featureShardContainer = Map(),
+        randomEffectIdToIndividualIdMap = randomEffectIdToIndividualIdMap)
+      val score = rowLatentFactors(row)._2.dot(colLatentFactors(col)._2)
+      (gameDatum, score)
+    }
+      .zipWithIndex
+      .map { case ((gameDatum, score), uniqueId) => ((uniqueId.toLong, gameDatum), (uniqueId.toLong, score)) }
+      .unzip
+
+    // Construct the matrix
+    val randomMFModel = new MatrixFactorizationModel(rowEffectType, colEffectType,
+      rowLatentFactors = sc.parallelize(rowLatentFactors), colLatentFactors = sc.parallelize(colLatentFactors))
+
+    val expectedScores = new KeyValueScore(sc.parallelize(syntheticScores))
+    val computedScores = randomMFModel.score(sc.parallelize(gameData))
+
+    assertEquals(computedScores, expectedScores)
+  }
+
+  @Test(dataProvider = "matrixFactorizationConfigProvider")
+  def testEquals(numLatentFactors: Int, numRows: Int, numCols: Int)
+  : Unit = sparkTest("testEqualsForMatrixFactorizationModel") {
+
+    // A random matrix factorization model
+    val rowEffectType = "rowEffectType"
+    val colEffectType = "colEffectType"
+    val random = new Random(MathConst.RANDOM_SEED)
+    def randomRowLatentFactorGenerator = generateRandomLatentFactor(numLatentFactors, random)
+    def randomColLatentFactorGenerator = generateRandomLatentFactor(numLatentFactors, random)
+    val randomMFModel = generateMatrixFactorizationModel(numRows, numCols, rowEffectType, colEffectType,
+      randomRowLatentFactorGenerator, randomColLatentFactorGenerator, sc)
+
+    // Should equal to itself
+    assertEquals(randomMFModel, randomMFModel)
+
+    // Should equal to the matrix factorization model with same meta data and latent factors
+    val randomMFModelCopy = new MatrixFactorizationModel(randomMFModel.rowEffectType, randomMFModel.colEffectType,
+      randomMFModel.rowLatentFactors, randomMFModel.colLatentFactors)
+    assertEquals(randomMFModel, randomMFModelCopy)
+
+    // Should not equal to the matrix factorization model with different row effect Id
+    val rowEffectType1 = "rowEffectType1"
+    val randomMFModelWithDiffRowEffectId = new MatrixFactorizationModel(rowEffectType1, randomMFModel.colEffectType,
+      randomMFModel.rowLatentFactors, randomMFModel.colLatentFactors)
+    assertNotEquals(randomMFModel, randomMFModelWithDiffRowEffectId)
+
+    // Should not equal to the matrix factorization model with different col effect Id
+    val colEffectType1 = "colEffectType1"
+    val randomMFModelWithDiffColEffectId = new MatrixFactorizationModel(randomMFModel.rowEffectType, colEffectType1,
+      randomMFModel.rowLatentFactors, randomMFModel.colLatentFactors)
+    assertNotEquals(randomMFModel, randomMFModelWithDiffColEffectId)
+
+    // Should not equal to the matrix factorization model with different latent factors
+    val zeroMFModel = generateMatrixFactorizationModel(numRows, numCols, rowEffectType, colEffectType,
+      generateZerosLatentFactor(numLatentFactors), generateZerosLatentFactor(numLatentFactors), sc)
+    assertNotEquals(randomMFModel, zeroMFModel)
+  }
+}

--- a/photon-ml/src/integTest/scala/com/linkedin/photon/ml/model/RandomEffectModelTest.scala
+++ b/photon-ml/src/integTest/scala/com/linkedin/photon/ml/model/RandomEffectModelTest.scala
@@ -52,19 +52,19 @@ class RandomEffectModelTest extends SparkTestUtils {
     val featureShardId1 = "featureShardId1"
     val randomEffectModelWithDiffFeatureShardId =
       new RandomEffectModel(coefficientsRDD, randomEffectId, featureShardId1)
-    assertTrue(!randomEffectModel.equals(randomEffectModelWithDiffFeatureShardId))
+    assertNotEquals(randomEffectModel, randomEffectModelWithDiffFeatureShardId)
 
     // Should not equal to the random effect model with different randomEffectId
     val randomEffectId1 = "randomEffectId1"
     val randomEffectModelWithDiffRandomEffectShardId =
       new RandomEffectModel(coefficientsRDD, randomEffectId1, featureShardId)
-    assertTrue(!randomEffectModel.equals(randomEffectModelWithDiffRandomEffectShardId))
+    assertNotEquals(randomEffectModel, randomEffectModelWithDiffRandomEffectShardId)
 
     // Should not equal to the random effect model with different coefficientsRDD
     val numCoefficients1 = numCoefficients + 1
     val coefficientsRDD1 = sc.parallelize(Seq.tabulate(numCoefficients1)(i => (i.toString, coefficients)))
     val randomEffectModelWithDiffCoefficientsRDD =
       new RandomEffectModel(coefficientsRDD1, randomEffectId, featureShardId)
-    assertTrue(!randomEffectModel.equals(randomEffectModelWithDiffCoefficientsRDD))
+    assertNotEquals(randomEffectModel, randomEffectModelWithDiffCoefficientsRDD)
   }
 }

--- a/photon-ml/src/integTest/scala/com/linkedin/photon/ml/model/RandomEffectModelTest.scala
+++ b/photon-ml/src/integTest/scala/com/linkedin/photon/ml/model/RandomEffectModelTest.scala
@@ -15,13 +15,13 @@
 package com.linkedin.photon.ml.model
 
 import org.testng.annotations.Test
-import org.testng.Assert.assertTrue
+import org.testng.Assert._
 
 import com.linkedin.photon.ml.test.SparkTestUtils
 
 
 /**
- * @author xazhang
+ * Test the random effect model
  */
 class RandomEffectModelTest extends SparkTestUtils {
 
@@ -42,11 +42,11 @@ class RandomEffectModelTest extends SparkTestUtils {
     val randomEffectModel = new RandomEffectModel(coefficientsRDD, randomEffectId, featureShardId)
 
     // Should equal to itself
-    assertTrue(randomEffectModel.equals(randomEffectModel))
+    assertEquals(randomEffectModel, randomEffectModel)
 
     // Should equal to the random effect model with same featureShardId, randomEffectId and coefficientsRDD
     val randomEffectModelCopy = new RandomEffectModel(coefficientsRDD, randomEffectId, featureShardId)
-    assertTrue(randomEffectModel.equals(randomEffectModelCopy))
+    assertEquals(randomEffectModel, randomEffectModelCopy)
 
     // Should not equal to the random effect model with different featureShardId
     val featureShardId1 = "featureShardId1"

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/data/GameDatum.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/data/GameDatum.scala
@@ -34,7 +34,7 @@ protected[ml] class GameDatum(
     val offset: Double,
     val weight: Double,
     val featureShardContainer: Map[String, Vector[Double]],
-    val randomEffectIdToIndividualIdMap: Map[String, String]) {
+    val randomEffectIdToIndividualIdMap: Map[String, String]) extends Serializable {
 
   /**
    * Build a labeled point with sharded feature container

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/model/MatrixFactorizationModel.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/model/MatrixFactorizationModel.scala
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2016 LinkedIn Corp. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linkedin.photon.ml.model
+
+import breeze.linalg.{Vector, norm}
+import org.apache.spark.rdd.RDD
+
+import com.linkedin.photon.ml.data.{GameDatum, KeyValueScore}
+
+
+/**
+ * Representation of a matrix factorization model
+ * @param rowEffectType The type of the row effect (or the matrix row's name)
+ * @param colEffectType The type of the column effect (or the matrix col's name)
+ * @param rowLatentFactors Latent factors for row effect
+ * @param colLatentFactors Latent factors for column effect
+ */
+class MatrixFactorizationModel(
+  val rowEffectType: String,
+  val colEffectType: String,
+  val rowLatentFactors: RDD[(String, Vector[Double])],
+  val colLatentFactors: RDD[(String, Vector[Double])]) extends Model {
+
+  /**
+   * Number of latent factors of the matrix factorization model (or the rank)
+   */
+  lazy val numLatentFactors = rowLatentFactors.first()._2.length
+
+  override def score(dataPoints: RDD[(Long, GameDatum)]): KeyValueScore = {
+    MatrixFactorizationModel.score(dataPoints, rowEffectType, colEffectType, rowLatentFactors, colLatentFactors)
+  }
+
+  override def toSummaryString: String = {
+    val stringBuilder = new StringBuilder(s"Summary of matrix factorization model with rowEffectType $rowEffectType " +
+      s"and colEffectType $colEffectType:")
+    val rowLatentFactorsL2NormStats =
+      rowLatentFactors.map { case (_, rowLatentFactor) => norm(rowLatentFactor, 2) } .stats()
+    val colLatentFactorsL2NormStats =
+      colLatentFactors.map { case (_, colLatentFactor) => norm(colLatentFactor, 2) } .stats()
+    stringBuilder.append(s"\numLatentFactors: $numLatentFactors")
+    stringBuilder.append(s"\nrowLatentFactors L2 norm: $rowLatentFactorsL2NormStats")
+    stringBuilder.append(s"\ncolLatentFactors L2 norm: $colLatentFactorsL2NormStats")
+    stringBuilder.toString()
+  }
+
+  override def equals(that: Any): Boolean = {
+    that match {
+      case other: MatrixFactorizationModel =>
+        val sameMetaData = this.rowEffectType == other.rowEffectType && this.colEffectType == other.colEffectType &&
+          this.numLatentFactors == other.numLatentFactors
+        val sameRowLatentFactors = this.rowLatentFactors.fullOuterJoin(other.rowLatentFactors).mapPartitions(iterator =>
+          Iterator.single(iterator.forall { case (_, (rowLatentFactor1, rowLatentFactor2)) =>
+            rowLatentFactor1.isDefined && rowLatentFactor2.isDefined &&
+              rowLatentFactor1.get.equals(rowLatentFactor2.get)
+          })
+        ).filter(!_).count() == 0
+        val sameColLatentFactors = this.colLatentFactors.fullOuterJoin(other.colLatentFactors).mapPartitions(iterator =>
+          Iterator.single(iterator.forall { case (_, (colLatentFactor1, colLatentFactor2)) =>
+            colLatentFactor1.isDefined && colLatentFactor2.isDefined &&
+              colLatentFactor1.get.equals(colLatentFactor2.get)
+          })
+        ).filter(!_).count() == 0
+        sameMetaData && sameRowLatentFactors && sameColLatentFactors
+      case _ => false
+    }
+  }
+}
+
+object MatrixFactorizationModel {
+  protected def score(
+    dataPoints: RDD[(Long, GameDatum)],
+    rowEffectType: String,
+    colEffectType: String,
+    rowLatentFactors: RDD[(String, Vector[Double])],
+    colLatentFactors: RDD[(String, Vector[Double])]): KeyValueScore = {
+
+    val scores = dataPoints
+      //For each datum, collect a (rowEffectId, (colEffectId, uniqueId)) tuple.
+      .map { case (uniqueId, gameData) =>
+      val rowEffectId = gameData.randomEffectIdToIndividualIdMap(rowEffectType)
+      val colEffectId = gameData.randomEffectIdToIndividualIdMap(colEffectType)
+      (rowEffectId, (colEffectId, uniqueId))
+    }
+      .cogroup(rowLatentFactors)
+      // Decorate rowEffectId with row latent factors
+      .flatMap { case (rowEffectId, (colEffectIdAndUniqueIdsIterable, rowLatentFactorIterable)) =>
+      assert(rowLatentFactorIterable.size <= 1, s"More than one row latent factor (${rowLatentFactorIterable.size}) " +
+        s"found for random effect Id $rowEffectId of random effect type $rowEffectType")
+      colEffectIdAndUniqueIdsIterable.flatMap { case (colEffectId, uniqueId) =>
+        rowLatentFactorIterable.map(rowLatentFactor => (colEffectId, (rowLatentFactor, uniqueId)))
+      }
+    }
+      // Decorate colEffectId with column latent factors
+      .cogroup(colLatentFactors)
+      .flatMap { case (colEffectId, (rowLatentFactorAndUniqueIdsIterable, colLatentFactorIterable)) =>
+      assert(colLatentFactorIterable.size <= 1, s"More than one column latent factor (${colLatentFactorIterable.size}) " +
+        s"found for random effect Id $colEffectId of random effect type $colEffectType")
+      rowLatentFactorAndUniqueIdsIterable.flatMap { case (rowLatentFactor, uniqueId) =>
+        colLatentFactorIterable.map(colLatentFactor => (uniqueId, (rowLatentFactor, colLatentFactor)))
+      }
+    }
+      // Compute dot product for (row latent factors, column latent factors) tuple
+      .mapValues { case (rowLatentFactor, colLatentFactor) => rowLatentFactor.dot(colLatentFactor) }
+
+    new KeyValueScore(scores)
+  }
+}

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/sampler/DownSampler.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/sampler/DownSampler.scala
@@ -39,8 +39,8 @@ protected[ml] trait DownSampler {
   def downSample(labeledPoints: RDD[(Long, LabeledPoint)], seed: Long = DownSampler.getSeed): RDD[(Long, LabeledPoint)]
 }
 
-protected object DownSampler {
-  val random = new Random(MathConst.RANDOM_SEED)
+object DownSampler {
+  private val random = new Random(MathConst.RANDOM_SEED)
 
-  def getSeed: Long = random.nextLong()
+  protected[sampler] def getSeed: Long = random.nextLong()
 }


### PR DESCRIPTION
The motivation of this PR is to address #59 by adding MatrixFactorizationModel to GAME's model package.

In order to write integration tests for matrix factorization model, a few other tweaks are made in this PR with each corresponds to a commit:
1. Making GameDatum serializable
2. Change the scope of some functions in DownSampler.scala
3. Add the equals function to KeyValueScore, also added integTest for it as well as some other existing functions in KeyValueScore
4. Minor tweaks to the existing integTest for fixed and random effect models
5. Address #59 by adding MatrixFactorizationModel to GAME's model package, and added integTest for it.