### PR TITLE
Changing the default value for isNullOk to false.

### DIFF
--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/avro/AvroUtils.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/avro/AvroUtils.scala
@@ -104,8 +104,8 @@ object AvroUtils {
    * @return The nameAndTerm parsed from the Avro record
    */
   protected[avro] def readNameAndTermFromGenericRecord(record: GenericRecord): NameAndTerm = {
-    val name = Utils.getStringAvro(record, AvroFieldNames.NAME, isNullOK = false)
-    val term = Utils.getStringAvro(record, AvroFieldNames.TERM, isNullOK = false)
+    val name = Utils.getStringAvro(record, AvroFieldNames.NAME)
+    val term = Utils.getStringAvro(record, AvroFieldNames.TERM, isNullOK = true)
     NameAndTerm(name, term)
   }
 

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/avro/data/DataProcessingUtils.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/avro/data/DataProcessingUtils.scala
@@ -85,7 +85,7 @@ object DataProcessingUtils {
     }
 
     val ids = randomEffectIdSet.map { randomEffectId =>
-      (randomEffectId, Utils.getStringAvro(record, randomEffectId, isNullOK = false))
+      (randomEffectId, Utils.getStringAvro(record, randomEffectId))
     }.toMap
     new GameDatum(response, offset, weight, featureShardContainer, ids)
   }

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/util/Utils.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/util/Utils.scala
@@ -39,7 +39,7 @@ protected[ml] object Utils {
    * @return The feature name
    */
   def getFeatureKey(record: GenericRecord, nameKey: String, termKey: String, delimiter: String): String = {
-    val name = getStringAvro(record, nameKey, isNullOK = false)
+    val name = getStringAvro(record, nameKey)
     val term = getStringAvro(record, termKey, isNullOK = true)
     getFeatureKey(name, term, delimiter)
   }
@@ -90,9 +90,11 @@ protected[ml] object Utils {
    * Extract the String typed field with a given key from the Avro GenericRecord
    * @param record the generic record
    * @param key the key of the field
+   * @param isNullOK whether null is accepted. If set to true, then an empty string will be returned if the
+   *                 corresponding field of the key is null, otherwise, exception will be thrown.
    * @return the String typed field
    */
-  def getStringAvro(record: GenericRecord, key: String, isNullOK: Boolean = true): String = {
+  def getStringAvro(record: GenericRecord, key: String, isNullOK: Boolean = false): String = {
     record.get(key) match {
       case id@(_: Utf8 | _: JString) => id.toString
       case number: JNumber => number.toString

--- a/photon-ml/src/test/scala/com/linkedin/photon/ml/util/UtilsTest.scala
+++ b/photon-ml/src/test/scala/com/linkedin/photon/ml/util/UtilsTest.scala
@@ -146,15 +146,15 @@ class UtilsTest extends TestTemplateWithTmpDir {
       .setDoubleValue(-4.4d)
       .build()
 
-    assertEquals(Utils.getStringAvro(record, "stringField"), "foo")
-    assertEquals(Utils.getStringAvro(record, "utf8StringField", true), "bar")
-    assertEquals(Utils.getStringAvro(record, "floatField"), "1.1")
-    assertEquals(Utils.getStringAvro(record, "intField", true), "-1")
-    assertEquals(Utils.getStringAvro(record, "longField"), "3")
-    assertEquals(Utils.getStringAvro(record, "doubleField", true), "-4.4")
+    assertEquals(Utils.getStringAvro(record, "stringField", isNullOK = true), "foo")
+    assertEquals(Utils.getStringAvro(record, "utf8StringField"), "bar")
+    assertEquals(Utils.getStringAvro(record, "floatField", isNullOK = true), "1.1")
+    assertEquals(Utils.getStringAvro(record, "intField"), "-1")
+    assertEquals(Utils.getStringAvro(record, "longField", isNullOK = true), "3")
+    assertEquals(Utils.getStringAvro(record, "doubleField"), "-4.4")
 
     // Nullable okay
-    assertEquals(Utils.getStringAvro(EMPTY_RECORD, "stringField", true), "")
+    assertEquals(Utils.getStringAvro(EMPTY_RECORD, "stringField", isNullOK = true), "")
   }
 
   @Test
@@ -252,7 +252,7 @@ class UtilsTest extends TestTemplateWithTmpDir {
 
   @Test(expectedExceptions = Array(classOf[IllegalArgumentException]))
   def testGetStringAvroNullableNotOk(): Unit = {
-    Utils.getStringAvro(EMPTY_RECORD, "stringField", false)
+    Utils.getStringAvro(EMPTY_RECORD, "stringField")
   }
 
   @Test(expectedExceptions = Array(classOf[IllegalArgumentException]))
@@ -307,7 +307,7 @@ class UtilsTest extends TestTemplateWithTmpDir {
 
   @Test(expectedExceptions = Array(classOf[IllegalArgumentException]))
   def testGetStringAvroOtherType(): Unit = {
-    Utils.getStringAvro(FIXED_TYPE_RECORD, "fixedField", true)
+    Utils.getStringAvro(FIXED_TYPE_RECORD, "fixedField", isNullOK = true)
   }
 
   @Test(expectedExceptions = Array(classOf[IllegalArgumentException]))


### PR DESCRIPTION
This PR changes the default value for ```isNullOK``` to false, in order to make it consistent with other ```get*Avro``` functions.

This PR also makes sure that ```getFeatureKey``` and ```readNameAndTermFromGenericRecord``` functions are sharing the same the same logic, which is that the term is allowed to be null.

See #77 for more details.