### PR TITLE
Deprecate 'save-models-to-hdfs'. Add new parameter to control model output.

### DIFF
--- a/photon-ml/src/integTest/scala/com/linkedin/photon/ml/cli/game/training/DriverGameIntegTest.scala
+++ b/photon-ml/src/integTest/scala/com/linkedin/photon/ml/cli/game/training/DriverGameIntegTest.scala
@@ -15,19 +15,20 @@
 package com.linkedin.photon.ml.cli.game.training
 
 import collection.JavaConversions._
-import java.nio.file.{Files, FileSystems, Path}
-import org.apache.spark.SparkConf
-import org.testng.annotations.Test
-import org.testng.Assert._
-
+import com.linkedin.photon.ml.SparkContextConfiguration
 import com.linkedin.photon.ml.avro.AvroIOUtils
 import com.linkedin.photon.ml.avro.generated.BayesianLinearModelAvro
 import com.linkedin.photon.ml.avro.model.ModelProcessingUtils
 import com.linkedin.photon.ml.data.{FixedEffectDataSet, RandomEffectDataSet}
-import com.linkedin.photon.ml.SparkContextConfiguration
+import com.linkedin.photon.ml.io.ModelOutputMode
 import com.linkedin.photon.ml.supervised.TaskType
 import com.linkedin.photon.ml.test.{CommonTestUtils, SparkTestUtils, TestTemplateWithTmpDir}
 import com.linkedin.photon.ml.util.PhotonLogger
+import org.apache.spark.SparkConf
+import org.testng.annotations.Test
+import org.testng.Assert._
+
+import java.nio.file.{Files, FileSystems, Path}
 
 class DriverGameIntegTest extends SparkTestUtils with TestTemplateWithTmpDir {
   import DriverGameIntegTest._
@@ -36,33 +37,57 @@ class DriverGameIntegTest extends SparkTestUtils with TestTemplateWithTmpDir {
   @Test
   def testFixedEffects() = sparkTest("fixedEffects", useKryo = true) {
     val outputDir = s"$getTmpDir/fixedEffects"
-
     // This is a baseline RMSE capture from an assumed-correct implementation on 4/14/2016
     val errorThreshold = 1.7
+    val driver = runDriver(argArray(fixedEffectArgs ++ Map("output-dir" -> outputDir)))
+    val allFixedEffectModelPath = allModelPath(outputDir, "fixed-effect", "shard1")
+    val bestFixedEffectModelPath = bestModelPath(outputDir, "fixed-effect", "shard1")
 
-    val driver = runDriver(argArray(fixedEffectArgs ++ Map(
-      "output-dir" -> outputDir)))
-
-    val fixedEffectModelPath = modelPath(outputDir, "fixed-effect", "shard1")
-
-    assertTrue(Files.exists(fixedEffectModelPath))
-    assertTrue(modelSane(fixedEffectModelPath, expectedNumCoefficients = 14983))
+    println("HERE")
+    println(allFixedEffectModelPath)
+    assertTrue(Files.exists(allFixedEffectModelPath))
+    assertTrue(Files.exists(bestFixedEffectModelPath))
+    assertTrue(modelSane(allFixedEffectModelPath, expectedNumCoefficients = 14983))
+    assertTrue(modelSane(bestFixedEffectModelPath, expectedNumCoefficients = 14983))
+    assertTrue(evaluateModel(driver, fs.getPath(outputDir, "all/0")) < errorThreshold)
     assertTrue(evaluateModel(driver, fs.getPath(outputDir, "best")) < errorThreshold)
+  }
+
+  @Test
+  def testSaveBestOnly() = sparkTest("saveBestOnly", useKryo = true) {
+    val outputDir = s"$getTmpDir/fixedEffects"
+    val driver = runDriver(argArray(fixedEffectArgs ++ Map(
+      "output-dir" -> outputDir,
+      "model-output-mode" -> ModelOutputMode.BEST.toString)))
+    val allFixedEffectModelPath = allModelPath(outputDir, "fixed-effect", "shard1")
+    val bestFixedEffectModelPath = bestModelPath(outputDir, "fixed-effect", "shard1")
+
+    assertFalse(Files.exists(allFixedEffectModelPath))
+    assertTrue(Files.exists(bestFixedEffectModelPath))
+  }
+
+  @Test
+  def testSaveNone() = sparkTest("saveNone", useKryo = true) {
+    val outputDir = s"$getTmpDir/fixedEffects"
+    val driver = runDriver(argArray(fixedEffectArgs ++ Map(
+      "output-dir" -> outputDir,
+      "model-output-mode" -> ModelOutputMode.NONE.toString)))
+    val allFixedEffectModelPath = allModelPath(outputDir, "fixed-effect", "shard1")
+    val bestFixedEffectModelPath = bestModelPath(outputDir, "fixed-effect", "shard1")
+
+    assertFalse(Files.exists(allFixedEffectModelPath))
+    assertFalse(Files.exists(bestFixedEffectModelPath))
   }
 
   @Test
   def testRandomEffects() = sparkTest("randomEffects", useKryo = true) {
     val outputDir = s"$getTmpDir/randomEffects"
-
     // This is a baseline RMSE capture from an assumed-correct implementation on 4/14/2016
     val errorThreshold = 2.2
-
-    val driver = runDriver(argArray(randomEffectArgs ++ Map(
-      "output-dir" -> outputDir)))
-
-    val userModelPath = modelPath(outputDir, "random-effect", "userId-shard2")
-    val songModelPath = modelPath(outputDir, "random-effect", "songId-shard3")
-    val artistModelPath = modelPath(outputDir, "random-effect", "artistId-shard3")
+    val driver = runDriver(argArray(randomEffectArgs ++ Map("output-dir" -> outputDir)))
+    val userModelPath = bestModelPath(outputDir, "random-effect", "userId-shard2")
+    val songModelPath = bestModelPath(outputDir, "random-effect", "songId-shard3")
+    val artistModelPath = bestModelPath(outputDir, "random-effect", "artistId-shard3")
 
     assertTrue(Files.exists(userModelPath))
     assertTrue(modelSane(userModelPath, expectedNumCoefficients = 21))
@@ -86,10 +111,10 @@ class DriverGameIntegTest extends SparkTestUtils with TestTemplateWithTmpDir {
     val driver = runDriver(argArray(fixedAndRandomEffectArgs ++ Map(
       "output-dir" -> outputDir)))
 
-    val fixedEffectModelPath = modelPath(outputDir, "fixed-effect", "shard1")
-    val userModelPath = modelPath(outputDir, "random-effect", "userId-shard2")
-    val songModelPath = modelPath(outputDir, "random-effect", "songId-shard3")
-    val artistModelPath = modelPath(outputDir, "random-effect", "artistId-shard3")
+    val fixedEffectModelPath = bestModelPath(outputDir, "fixed-effect", "shard1")
+    val userModelPath = bestModelPath(outputDir, "random-effect", "userId-shard2")
+    val songModelPath = bestModelPath(outputDir, "random-effect", "songId-shard3")
+    val artistModelPath = bestModelPath(outputDir, "random-effect", "artistId-shard3")
 
     assertTrue(Files.exists(fixedEffectModelPath))
     assertTrue(modelSane(fixedEffectModelPath, expectedNumCoefficients = 15017))
@@ -133,75 +158,75 @@ class DriverGameIntegTest extends SparkTestUtils with TestTemplateWithTmpDir {
 
   @Test
   def testPrepareFixedAndRandomEffectTrainingDataSet() =
-      sparkTest("prepareFixedAndRandomEffectTrainingDataSet", useKryo = true) {
-    val outputDir = s"$getTmpDir/prepareFixedEffectTrainingDataSet"
+    sparkTest("prepareFixedAndRandomEffectTrainingDataSet", useKryo = true) {
+      val outputDir = s"$getTmpDir/prepareFixedEffectTrainingDataSet"
 
-    val args = argArray(fixedAndRandomEffectArgs ++ Map(
-      "output-dir" -> outputDir))
+      val args = argArray(fixedAndRandomEffectArgs ++ Map(
+        "output-dir" -> outputDir))
 
-    val driver = new Driver(
-      Params.parseFromCommandLine(args), sc, new PhotonLogger(s"$outputDir/log", sc))
+      val driver = new Driver(
+        Params.parseFromCommandLine(args), sc, new PhotonLogger(s"$outputDir/log", sc))
 
-    val featureShardIdToFeatureMapMap = driver.prepareFeatureMaps()
-    val gameDataSet = driver.prepareGameDataSet(featureShardIdToFeatureMapMap)
-    val trainingDataSet = driver.prepareTrainingDataSet(gameDataSet)
+      val featureShardIdToFeatureMapMap = driver.prepareFeatureMaps()
+      val gameDataSet = driver.prepareGameDataSet(featureShardIdToFeatureMapMap)
+      val trainingDataSet = driver.prepareTrainingDataSet(gameDataSet)
 
-    assertEquals(trainingDataSet.size, 4)
+      assertEquals(trainingDataSet.size, 4)
 
-    // fixed effect data
-    trainingDataSet("global") match {
-      case ds: FixedEffectDataSet =>
-        assertEquals(ds.labeledPoints.count(), 34810)
-        assertEquals(ds.numFeatures, 30085)
+      // fixed effect data
+      trainingDataSet("global") match {
+        case ds: FixedEffectDataSet =>
+          assertEquals(ds.labeledPoints.count(), 34810)
+          assertEquals(ds.numFeatures, 30085)
 
-      case _ => fail("Wrong dataset type.")
+        case _ => fail("Wrong dataset type.")
+      }
+
+      // per-user data
+      trainingDataSet("per-user") match {
+        case ds: RandomEffectDataSet =>
+          assertEquals(ds.activeData.count(), 33110)
+
+          val featureStats = ds.activeData.values.map(_.numActiveFeatures).stats()
+          assertEquals(featureStats.count, 33110)
+          assertEquals(featureStats.mean, 24.12999, tol)
+          assertEquals(featureStats.stdev, 0.611194, tol)
+          assertEquals(featureStats.max, 40.0, tol)
+          assertEquals(featureStats.min, 24.0, tol)
+
+        case _ => fail("Wrong dataset type.")
+      }
+
+      // per-song data
+      trainingDataSet("per-song") match {
+        case ds: RandomEffectDataSet =>
+          assertEquals(ds.activeData.count(), 23167)
+
+          val featureStats = ds.activeData.values.map(_.numActiveFeatures).stats()
+          assertEquals(featureStats.count, 23167)
+          assertEquals(featureStats.mean, 21.0, tol)
+          assertEquals(featureStats.stdev, 0.0, tol)
+          assertEquals(featureStats.max, 21.0, tol)
+          assertEquals(featureStats.min, 21.0, tol)
+
+        case _ => fail("Wrong dataset type.")
+      }
+
+      // per-artist data
+      trainingDataSet("per-artist") match {
+        case ds: RandomEffectDataSet =>
+          assertEquals(ds.activeData.count(), 4471)
+
+          val featureStats = ds.activeData.values.map(_.numActiveFeatures).stats()
+          assertEquals(featureStats.count, 4471)
+          assertEquals(featureStats.mean, 3.0, tol)
+          assertEquals(featureStats.stdev, 0.0, tol)
+          assertEquals(featureStats.max, 3.0, tol)
+          assertEquals(featureStats.min, 3.0, tol)
+
+        case _ => fail("Wrong dataset type.")
+      }
     }
-
-    // per-user data
-    trainingDataSet("per-user") match {
-      case ds: RandomEffectDataSet =>
-        assertEquals(ds.activeData.count(), 33110)
-
-        val featureStats = ds.activeData.values.map(_.numActiveFeatures).stats()
-        assertEquals(featureStats.count, 33110)
-        assertEquals(featureStats.mean, 24.12999, tol)
-        assertEquals(featureStats.stdev, 0.611194, tol)
-        assertEquals(featureStats.max, 40.0, tol)
-        assertEquals(featureStats.min, 24.0, tol)
-
-      case _ => fail("Wrong dataset type.")
-    }
-
-    // per-song data
-    trainingDataSet("per-song") match {
-      case ds: RandomEffectDataSet =>
-        assertEquals(ds.activeData.count(), 23167)
-
-        val featureStats = ds.activeData.values.map(_.numActiveFeatures).stats()
-        assertEquals(featureStats.count, 23167)
-        assertEquals(featureStats.mean, 21.0, tol)
-        assertEquals(featureStats.stdev, 0.0, tol)
-        assertEquals(featureStats.max, 21.0, tol)
-        assertEquals(featureStats.min, 21.0, tol)
-
-      case _ => fail("Wrong dataset type.")
-    }
-
-    // per-artist data
-    trainingDataSet("per-artist") match {
-      case ds: RandomEffectDataSet =>
-        assertEquals(ds.activeData.count(), 4471)
-
-        val featureStats = ds.activeData.values.map(_.numActiveFeatures).stats()
-        assertEquals(featureStats.count, 4471)
-        assertEquals(featureStats.mean, 3.0, tol)
-        assertEquals(featureStats.stdev, 0.0, tol)
-        assertEquals(featureStats.max, 3.0, tol)
-        assertEquals(featureStats.min, 3.0, tol)
-
-      case _ => fail("Wrong dataset type.")
-    }
-  }
 
   @Test
   def testMultipleOptimizerConfigs() = sparkTest("multipleOptimizerConfigs", useKryo = true) {
@@ -214,9 +239,9 @@ class DriverGameIntegTest extends SparkTestUtils with TestTemplateWithTmpDir {
       "output-dir" -> outputDir,
       "fixed-effect-optimization-configurations" ->
         ("global:10,1e-5,10,1,tron,l2;" +
-         "global:10,1e-5,10,1,lbfgs,l2"))))
+          "global:10,1e-5,10,1,lbfgs,l2"))))
 
-    val fixedEffectModelPath = modelPath(outputDir, "fixed-effect", "shard1")
+    val fixedEffectModelPath = bestModelPath(outputDir, "fixed-effect", "shard1")
 
     assertTrue(Files.exists(fixedEffectModelPath))
     assertTrue(modelSane(fixedEffectModelPath, expectedNumCoefficients = 14982))
@@ -224,11 +249,11 @@ class DriverGameIntegTest extends SparkTestUtils with TestTemplateWithTmpDir {
   }
 
   /**
-   * Overridden spark test provider that allows for specifying whether to use kryo serialization
-   *
-   * @param name the test job name
-   * @param body the execution closure
-   */
+    * Overridden spark test provider that allows for specifying whether to use kryo serialization
+    *
+    * @param name the test job name
+    * @param body the execution closure
+    */
   def sparkTest(name: String, useKryo: Boolean)(body: => Unit) {
     SparkTestUtils.SPARK_LOCAL_CONFIG.synchronized {
       sc = SparkContextConfiguration.asYarnClient(
@@ -245,26 +270,27 @@ class DriverGameIntegTest extends SparkTestUtils with TestTemplateWithTmpDir {
   }
 
   /**
-   * Perform a very basic sanity check on the model
-   *
-   * @param path path to the model coefficients file
-   * @return true if the model is sane
-   */
+    * Perform a very basic sanity check on the model
+    *
+    * @param path path to the model coefficients file
+    * @param expectedNumCoefficients expected number of non-zero coefficients
+    * @return true if the model is sane
+    */
   def modelSane(path: Path, expectedNumCoefficients: Int): Boolean = {
     val modelAvro = AvroIOUtils.readFromSingleAvro[BayesianLinearModelAvro](
       sc, path.toString, BayesianLinearModelAvro.getClassSchema.toString)
 
-    val means = modelAvro(0).getMeans()
+    val means = modelAvro.head.getMeans()
     means.filter(x => x.getValue != 0).size == expectedNumCoefficients
   }
 
   /**
-   * Evaluate the model by calculating RMSE between its scores and the validation set
-   *
-   * @param driver the driver instance used for training
-   * @param modelPath base path to the GAME model files
-   * @return validation error for the model
-   */
+    * Evaluate the model by calculating RMSE between its scores and the validation set
+    *
+    * @param driver the driver instance used for training
+    * @param modelPath base path to the GAME model files
+    * @return validation error for the model
+    */
   def evaluateModel(driver: Driver, modelPath: Path): Double = {
     val featureShardIdToFeatureMapMap = driver.prepareFeatureMaps()
     val gameDataSet = driver.prepareGameDataSet(featureShardIdToFeatureMapMap)
@@ -284,10 +310,10 @@ class DriverGameIntegTest extends SparkTestUtils with TestTemplateWithTmpDir {
   }
 
   /**
-   * Run the Game driver with the specified arguments
-   *
-   * @param args the command-line arguments
-   */
+    * Run the Game driver with the specified arguments
+    *
+    * @param args the command-line arguments
+    */
   def runDriver(args: Array[String]) = {
     val params = Params.parseFromCommandLine(args)
     val logger = new PhotonLogger(s"${params.outputDir}/log", sc)
@@ -312,20 +338,19 @@ object DriverGameIntegTest {
   val tol = 1e-5
 
   /**
-   * Default arguments to the Game driver
-   */
+    * Default arguments to the Game driver
+    */
   def defaultArgs = Map(
     "task-type" -> TaskType.LINEAR_REGRESSION.toString,
     "train-input-dirs" -> trainPath,
     "validate-input-dirs" -> testPath,
     "feature-name-and-term-set-path" -> featurePath,
     "num-iterations" -> numIterations.toString,
-    "num-output-files-for-random-effect-model" -> "-1",
-    "save-models-to-hdfs" -> true.toString)
+    "num-output-files-for-random-effect-model" -> "-1")
 
   /**
-   * Default fixed effect arguments
-   */
+    * Default fixed effect arguments
+    */
   def fixedEffectArgs = defaultArgs ++ Map(
     "feature-shard-id-to-feature-section-keys-map" -> "shard1:features",
     "updating-sequence" -> "global",
@@ -339,8 +364,8 @@ object DriverGameIntegTest {
       s"global:shard1,$numPartitionsForFixedEffectDataSet")
 
   /**
-   * Default random effect arguments
-   */
+    * Default random effect arguments
+    */
   def randomEffectArgs = {
     val userRandomEffectRegularizationWeight = 1
     val songRandomEffectRegularizationWeight = 1
@@ -353,19 +378,19 @@ object DriverGameIntegTest {
       // random-effect optimization config
       "random-effect-optimization-configurations" ->
         (s"per-user:10,1e-5,$userRandomEffectRegularizationWeight,1,tron,l2|" +
-         s"per-song:10,1e-5,$songRandomEffectRegularizationWeight,1,tron,l2|" +
-         s"per-artist:10,1e-5,$userRandomEffectRegularizationWeight,1,tron,l2"),
+          s"per-song:10,1e-5,$songRandomEffectRegularizationWeight,1,tron,l2|" +
+          s"per-artist:10,1e-5,$userRandomEffectRegularizationWeight,1,tron,l2"),
 
       // random-effect data config
       "random-effect-data-configurations" ->
         (s"per-user:userId,shard2,$numPartitionsForRandomEffectDataSet,-1,0,-1,index_map|" +
-         s"per-song:songId,shard3,$numPartitionsForRandomEffectDataSet,-1,0,-1,index_map|" +
-         s"per-artist:artistId,shard3,$numPartitionsForRandomEffectDataSet,-1,0,-1,RANDOM=2"))
+          s"per-song:songId,shard3,$numPartitionsForRandomEffectDataSet,-1,0,-1,index_map|" +
+          s"per-artist:artistId,shard3,$numPartitionsForRandomEffectDataSet,-1,0,-1,RANDOM=2"))
   }
 
   /**
-   * Default fixed and random effect arguments
-   */
+    * Default fixed and random effect arguments
+    */
   def fixedAndRandomEffectArgs = {
     fixedEffectArgs ++ randomEffectArgs ++ Map(
       "feature-shard-id-to-feature-section-keys-map" ->
@@ -375,13 +400,36 @@ object DriverGameIntegTest {
   }
 
   /**
-   * Build the path to the model coefficients file, given some model properties
-   *
-   * @param outputDir output base directory
-   * @param modelType model type (e.g. "fixed-effect", "random-effect")
-   * @param shardId the shard id designator
-   * @return full path to model coefficients file
-   */
-  def modelPath(outputDir: String, modelType: String, shardId: String): Path = fs.getPath(
-      outputDir, "best", modelType, shardId, "coefficients", "part-00000.avro")
+    * Build the path to the model coefficients file, given some model properties
+    *
+    * @param outputDir output base directory
+    * @param outputMode output mode (best or all)
+    * @param modelType model type (e.g. "fixed-effect", "random-effect")
+    * @param shardId the shard id designator
+    * @return full path to model coefficients file
+    */
+  private def modelPath(outputDir: String, outputMode: String, modelType: String, shardId: String): Path =
+    fs.getPath(outputDir, outputMode, modelType, shardId, "coefficients", "part-00000.avro")
+
+  /**
+    * Build the path to the model coefficients file
+    *
+    * @param outputDir output base directory
+    * @param modelType model type (e.g. "fixed-effect", "random-effect")
+    * @param shardId the shard id designator
+    * @return full path to model coefficients file
+    */
+  def allModelPath(outputDir: String, modelType: String, shardId: String): Path =
+    modelPath(outputDir, "all/0", modelType, shardId)
+
+  /**
+    * Build the path to the best model coefficients file
+    *
+    * @param outputDir output base directory
+    * @param modelType model type (e.g. "fixed-effect", "random-effect")
+    * @param shardId the shard id designator
+    * @return full path to model coefficients file
+    */
+  def bestModelPath(outputDir: String, modelType: String, shardId: String): Path =
+    modelPath(outputDir, "best", modelType, shardId)
 }

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/cli/game/training/Params.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/cli/game/training/Params.scala
@@ -14,18 +14,19 @@
  */
 package com.linkedin.photon.ml.cli.game.training
 
-import scala.collection.{Map, Set}
-
-import scopt.OptionParser
-
 import com.linkedin.photon.ml.optimization.game.{MFOptimizationConfiguration, GLMOptimizationConfiguration}
 import com.linkedin.photon.ml.data.{FixedEffectDataConfiguration, RandomEffectDataConfiguration}
+import com.linkedin.photon.ml.io.ModelOutputMode
+import com.linkedin.photon.ml.io.ModelOutputMode._
 import com.linkedin.photon.ml.supervised.TaskType
 import com.linkedin.photon.ml.supervised.TaskType._
+import scopt.OptionParser
 
+import scala.collection.{Map, Set}
 
 /**
  * Command line arguments for GAME
+ *
  * @param trainDirs Input directories of training data. Multiple input directories are also accepted if they are
  *                  separated by commas, e.g., inputDir1,inputDir2,inputDir3.
  * @param trainDateRangeOpt Date range for the training data represented in the form start.date-end.date,
@@ -70,14 +71,12 @@ import com.linkedin.photon.ml.supervised.TaskType._
  *                                                       separated by semi-colon.
  * @param randomEffectDataConfigurations Configurations for all the random effect data sets.
  * @param taskType GAME task type. Examples include logistic_regression and linear_regression.
- * @param isSavingModelsToHDFS Whether to save the models (best model and all models) to HDFS.
+ * @param modelOutputMode Model output mode (output all models, best model, or no models)
  * @param numberOfOutputFilesForRandomEffectModel Number of output files to write for each random effect model.
  * @param applicationName Name of this Spark application.
- *
  * @note Note that examples of how to configure GAME parameters can be found in the integration tests for the GAME
  *       driver.
  * @todo Making the way GAME being configured more user friendly
- * @author xazhang
  */
 case class Params(
     trainDirs: Array[String] = Array(),
@@ -99,36 +98,36 @@ case class Params(
         (GLMOptimizationConfiguration, GLMOptimizationConfiguration, MFOptimizationConfiguration)]] = Array(Map()),
     randomEffectDataConfigurations: Map[String, RandomEffectDataConfiguration] = Map(),
     taskType: TaskType = LOGISTIC_REGRESSION,
-    isSavingModelsToHDFS: Boolean = true,
+    modelOutputMode: ModelOutputMode = ALL,
     numberOfOutputFilesForRandomEffectModel: Int = -1,
     applicationName: String = "Game-Full-Model-Training") {
 
   override def toString: String = {
     s"trainDirs: ${trainDirs.mkString(", ")}\n" +
-        s"trainDateRangeOpt: $trainDateRangeOpt\n" +
-        s"trainDateRangeDaysAgoOpt: $trainDateRangeDaysAgoOpt\n" +
-        s"validateDirsOpt: ${validateDirsOpt.map(_.mkString(", "))}\n" +
-        s"validateDateRangeOpt: $validateDateRangeOpt\n" +
-        s"validateDateRangeDaysAgoOpt: $validateDateRangeDaysAgoOpt\n" +
-        s"minNumPartitionsForValidation: $minPartitionsForValidation\n" +
-        s"featureNameAndTermSetInputPath: $featureNameAndTermSetInputPath\n" +
-        s"featureShardIdToFeatureSectionKeysMap:\n${featureShardIdToFeatureSectionKeysMap.mapValues(_.mkString(", "))
-          .mkString("\n")}\n" +
-        s"outputDir: $outputDir\n" +
-        s"numIterations: $numIterations\n" +
-        s"updatingSequence: $updatingSequence\n" +
-        s"fixedEffectOptimizationConfigurations:\n${fixedEffectOptimizationConfigurations.map(_.mkString("\n"))
-          .mkString("\n")}\n" +
-        s"fixedEffectDataConfigurations: \n${fixedEffectDataConfigurations.mkString("\n")}\n" +
-        s"randomEffectOptimizationConfigurations:\n${randomEffectOptimizationConfigurations.map(_.mkString("\n"))
-          .mkString("\n")}\n" +
-        s"factorRandomEffectOptimizationConfigurations:\n${factoredRandomEffectOptimizationConfigurations
-          .map(_.mkString("\n")).mkString("\n")}\n" +
-        s"randomEffectDataConfigurations:\n${randomEffectDataConfigurations.mkString("\n")}\n" +
-        s"taskType: $taskType\n" +
-        s"saveModelsToHDFS: $isSavingModelsToHDFS\n" +
-        s"numberOfOutputFilesForRandomEffectModel: $numberOfOutputFilesForRandomEffectModel\n" +
-        s"applicationName: $applicationName"
+      s"trainDateRangeOpt: $trainDateRangeOpt\n" +
+      s"trainDateRangeDaysAgoOpt: $trainDateRangeDaysAgoOpt\n" +
+      s"validateDirsOpt: ${validateDirsOpt.map(_.mkString(", "))}\n" +
+      s"validateDateRangeOpt: $validateDateRangeOpt\n" +
+      s"validateDateRangeDaysAgoOpt: $validateDateRangeDaysAgoOpt\n" +
+      s"minNumPartitionsForValidation: $minPartitionsForValidation\n" +
+      s"featureNameAndTermSetInputPath: $featureNameAndTermSetInputPath\n" +
+      s"featureShardIdToFeatureSectionKeysMap:\n${featureShardIdToFeatureSectionKeysMap.mapValues(_.mkString(", "))
+        .mkString("\n")}\n" +
+      s"outputDir: $outputDir\n" +
+      s"numIterations: $numIterations\n" +
+      s"updatingSequence: $updatingSequence\n" +
+      s"fixedEffectOptimizationConfigurations:\n${fixedEffectOptimizationConfigurations.map(_.mkString("\n"))
+        .mkString("\n")}\n" +
+      s"fixedEffectDataConfigurations: \n${fixedEffectDataConfigurations.mkString("\n")}\n" +
+      s"randomEffectOptimizationConfigurations:\n${randomEffectOptimizationConfigurations.map(_.mkString("\n"))
+        .mkString("\n")}\n" +
+      s"factorRandomEffectOptimizationConfigurations:\n${factoredRandomEffectOptimizationConfigurations
+        .map(_.mkString("\n")).mkString("\n")}\n" +
+      s"randomEffectDataConfigurations:\n${randomEffectDataConfigurations.mkString("\n")}\n" +
+      s"taskType: $taskType\n" +
+      s"modelOutputOption: $modelOutputMode\n" +
+      s"numberOfOutputFilesForRandomEffectModel: $numberOfOutputFilesForRandomEffectModel\n" +
+      s"applicationName: $applicationName"
   }
 }
 
@@ -137,128 +136,153 @@ object Params {
     val defaultParams = Params()
     val parser = new OptionParser[Params]("Photon-Game") {
       opt[String]("train-input-dirs")
-          .required()
-          .text("Input directories of training data. Multiple input directories are also accepted if they are " +
+        .required()
+        .text("Input directories of training data. Multiple input directories are also accepted if they are " +
           "separated by commas, e.g., inputDir1,inputDir2,inputDir3.")
-          .action((x, c) => c.copy(trainDirs = x.split(",")))
+        .action((x, c) => c.copy(trainDirs = x.split(",")))
       opt[String]("task-type")
-          .required()
-          .text("Task type. Examples include logistic_regression and linear_regression.")
-          .action((x, c) => c.copy(taskType = TaskType.withName(x.toUpperCase)))
+        .required()
+        .text("Task type. Examples include logistic_regression and linear_regression.")
+        .action((x, c) => c.copy(taskType = TaskType.withName(x.toUpperCase)))
       opt[String]("train-date-range")
-          .text(s"Date range for the training data represented in the form start.date-end.date, " +
+        .text(s"Date range for the training data represented in the form start.date-end.date, " +
           s"e.g. 20150501-20150631. If this parameter is specified, the input directory is expected to be in the " +
           s"daily format structure (e.g., trainDir/daily/2015/05/20/input-data-files). Otherwise, the input paths " +
           s"are assumed to be flat directories of input files (e.g., trainDir/input-data-files). " +
           s"Default: ${defaultParams.trainDateRangeOpt}.")
-          .action((x, c) => c.copy(trainDateRangeOpt = Some(x)))
+        .action((x, c) => c.copy(trainDateRangeOpt = Some(x)))
       opt[String]("train-date-range-days-ago")
-          .text(s"Date range for the training data represented in the form start.daysAgo-end.daysAgo, " +
+        .text(s"Date range for the training data represented in the form start.daysAgo-end.daysAgo, " +
           s"e.g. 90-1. If this parameter is specified, the input directory is expected to be in the " +
           s"daily format structure (e.g., trainDir/daily/2015/05/20/input-data-files). Otherwise, the input paths " +
           s"are assumed to be flat directories of input files (e.g., trainDir/input-data-files). " +
           s"Default: ${defaultParams.trainDateRangeDaysAgoOpt}.")
-          .action((x, c) => c.copy(trainDateRangeDaysAgoOpt = Some(x)))
+        .action((x, c) => c.copy(trainDateRangeDaysAgoOpt = Some(x)))
       opt[String]("validate-input-dirs")
-          .text("Input directories of validating data. Multiple input directories are also accepted if they are " +
+        .text("Input directories of validating data. Multiple input directories are also accepted if they are " +
           "separated by commas, e.g., inputDir1,inputDir2,inputDir3.")
-          .action((x, c) => c.copy(validateDirsOpt = Some(x.split(","))))
+        .action((x, c) => c.copy(validateDirsOpt = Some(x.split(","))))
       opt[String]("validate-date-range")
-          .text(s"Date range for the validating data represented in the form start.date-end.date, " +
+        .text(s"Date range for the validating data represented in the form start.date-end.date, " +
           s"e.g. 20150501-20150631. If this parameter is specified, the input directory is expected to be in the " +
-          s"daily format structure (e.g., validateDir/daily/2015/05/20/input-data-files). Otherwise, the input paths " +
-          s"are assumed to be flat directories of input files (e.g., validateDir/input-data-files). " +
+          s"daily format structure (e.g., validateDir/daily/2015/05/20/input-data-files). Otherwise, the input " +
+          s"paths are assumed to be flat directories of input files (e.g., validateDir/input-data-files). " +
           s"Default: ${defaultParams.validateDateRangeOpt}.")
-          .action((x, c) => c.copy(validateDateRangeOpt = Some(x)))
+        .action((x, c) => c.copy(validateDateRangeOpt = Some(x)))
       opt[String]("validate-date-range-days-ago")
-          .text(s"Date range for the validating data represented in the form start.daysAgo-end.daysAgo, " +
+        .text(s"Date range for the validating data represented in the form start.daysAgo-end.daysAgo, " +
           s"e.g. 90-1. If this parameter is specified, the input directory is expected to be in the " +
-          s"daily format structure (e.g., validateDir/daily/2015/05/20/input-data-files). Otherwise, the input paths " +
-          s"are assumed to be flat directories of input files (e.g., validateDir/input-data-files). " +
+          s"daily format structure (e.g., validateDir/daily/2015/05/20/input-data-files). Otherwise, the input " +
+          s"paths are assumed to be flat directories of input files (e.g., validateDir/input-data-files). " +
           s"Default: ${defaultParams.validateDateRangeDaysAgoOpt}.")
-          .action((x, c) => c.copy(validateDateRangeDaysAgoOpt = Some(x)))
+        .action((x, c) => c.copy(validateDateRangeDaysAgoOpt = Some(x)))
       opt[Int]("min-partitions-for-validation")
-          .text(s"Minimum number of partitions for validating data (if provided). " +
+        .text(s"Minimum number of partitions for validating data (if provided). " +
           s"Default: ${defaultParams.minPartitionsForValidation}")
-          .action((x, c) => c.copy(minPartitionsForValidation = x))
+        .action((x, c) => c.copy(minPartitionsForValidation = x))
       opt[String]("output-dir")
-          .required()
-          .text(s"Output directory for logs and learned models.")
-          .action((x, c) => c.copy(outputDir = x.replace(',', '_').replace(':', '_')))
+        .required()
+        .text(s"Output directory for logs and learned models.")
+        .action((x, c) => c.copy(outputDir = x.replace(',', '_').replace(':', '_')))
       opt[String]("feature-name-and-term-set-path")
-          .required()
-          .text(s"Input path to the features name-and-term lists.")
-          .action((x, c) => c.copy(featureNameAndTermSetInputPath = x))
+        .required()
+        .text(s"Input path to the features name-and-term lists.")
+        .action((x, c) => c.copy(featureNameAndTermSetInputPath = x))
       opt[String]("feature-shard-id-to-feature-section-keys-map")
-          .text(s"A map between the feature shard id and it's corresponding feature section keys, in the following " +
+        .text(s"A map between the feature shard id and it's corresponding feature section keys, in the following " +
           s"format: shardId1:sectionKey1,sectionKey2|shardId2:sectionKey2,sectionKey3.")
-          .action((x, c) => c.copy(featureShardIdToFeatureSectionKeysMap =
-          x.split("\\|").map { line => line.split(":") match {
-            case Array(key, names) => (key, names.split(",").map(_.trim).toSet)
-            case Array(key) => (key, Set[String]())
-          }}.toMap
-      ))
+        .action((x, c) => c.copy(featureShardIdToFeatureSectionKeysMap =
+          x.split("\\|")
+            .map { line => line.split(":") match {
+              case Array(key, names) => (key, names.split(",").map(_.trim).toSet)
+              case Array(key) => (key, Set[String]())
+            }}
+            .toMap
+        ))
       opt[Int]("num-iterations")
-          .text(s"Number of coordinate descent iterations, default: ${defaultParams.numIterations}")
-          .action((x, c) => c.copy(numIterations = x))
+        .text(s"Number of coordinate descent iterations, default: ${defaultParams.numIterations}")
+        .action((x, c) => c.copy(numIterations = x))
       opt[String]("updating-sequence")
-          .text(s"Updating order of the ordinates (separated by commas) in the coordinate descent algorithm.")
-          .action((x, c) => c.copy(updatingSequence = x.split(",")))
+        .text(s"Updating order of the ordinates (separated by commas) in the coordinate descent algorithm.")
+        .action((x, c) => c.copy(updatingSequence = x.split(",")))
       opt[String]("fixed-effect-optimization-configurations")
-          .text("Optimization configurations for the fixed effect optimization problem, multiple configurations are " +
+        .text("Optimization configurations for the fixed effect optimization problem, multiple configurations are " +
           "accepted and separated by semi-colon \";\".")
-          .action((x, c) => c.copy(fixedEffectOptimizationConfigurations =
-          x.split(";").map(_.split("\\|").map { line => val Array(key, value) = line.split(":").map(_.trim)
-            (key, GLMOptimizationConfiguration.parseAndBuildFromString(value))
-          }.toMap)
-      ))
+        .action((x, c) => c.copy(fixedEffectOptimizationConfigurations =
+          x.split(";")
+            .map(
+              _.split("\\|")
+                .map { line =>
+                  val Array(key, value) = line.split(":").map(_.trim)
+                  (key, GLMOptimizationConfiguration.parseAndBuildFromString(value))
+                }
+                .toMap)
+        ))
       opt[String]("fixed-effect-data-configurations")
-          .text("Configurations for each fixed effect data set.")
-          .action((x, c) => c.copy(fixedEffectDataConfigurations =
-          x.split("\\|").map { line => val Array(key, value) = line.split(":").map(_.trim)
-            (key, FixedEffectDataConfiguration.parseAndBuildFromString(value))
-          }.toMap
-      ))
+        .text("Configurations for each fixed effect data set.")
+        .action((x, c) => c.copy(fixedEffectDataConfigurations =
+          x.split("\\|")
+            .map { line =>
+                val Array(key, value) = line.split(":").map(_.trim)
+                (key, FixedEffectDataConfiguration.parseAndBuildFromString(value))
+              }.toMap
+        ))
       opt[String]("random-effect-optimization-configurations")
-          .text("Optimization configurations for each random effect optimization problem, multiple parameters are " +
+        .text("Optimization configurations for each random effect optimization problem, multiple parameters are " +
           "accepted and separated by semi-colon \";\".")
-          .action((x, c) => c.copy(randomEffectOptimizationConfigurations =
-          x.split(";").map(_.split("\\|").map { line => val Array(key, value) = line.split(":").map(_.trim)
-            (key, GLMOptimizationConfiguration.parseAndBuildFromString(value))
-          }.toMap)
-      ))
+        .action((x, c) => c.copy(randomEffectOptimizationConfigurations =
+          x.split(";")
+            .map(
+              _.split("\\|")
+                .map { line =>
+                  val Array(key, value) = line.split(":").map(_.trim)
+                  (key, GLMOptimizationConfiguration.parseAndBuildFromString(value))
+                }
+                .toMap)
+        ))
       opt[String]("factored-random-effect-optimization-configurations")
-          .text("Optimization configurations for each factored random effect optimization problem, multiple parameters " +
+        .text("Optimization configurations for each factored random effect optimization problem, multiple parameters " +
           "are accepted and separated by semi-colon \";\".")
-          .action((x, c) => c.copy(factoredRandomEffectOptimizationConfigurations =
-          x.split(";").map(_.split("\\|").map { line => val Array(key, s1, s2, s3) = line.split(":").map(_.trim)
-            val randomEffectOptConfig = GLMOptimizationConfiguration.parseAndBuildFromString(s1)
-            val latentFactorOptConfig = GLMOptimizationConfiguration.parseAndBuildFromString(s2)
-            val mfOptimizationOptConfig = MFOptimizationConfiguration.parseAndBuildFromString(s3)
-            (key, (randomEffectOptConfig, latentFactorOptConfig, mfOptimizationOptConfig))
-          }.toMap)
-      ))
+        .action((x, c) => c.copy(factoredRandomEffectOptimizationConfigurations =
+          x.split(";")
+            .map(
+              _.split("\\|")
+                .map { line =>
+                  val Array(key, s1, s2, s3) = line.split(":").map(_.trim)
+                  val randomEffectOptConfig = GLMOptimizationConfiguration.parseAndBuildFromString(s1)
+                  val latentFactorOptConfig = GLMOptimizationConfiguration.parseAndBuildFromString(s2)
+                  val mfOptimizationOptConfig = MFOptimizationConfiguration.parseAndBuildFromString(s3)
+                  (key, (randomEffectOptConfig, latentFactorOptConfig, mfOptimizationOptConfig))
+                }
+                .toMap)
+        ))
       opt[String]("random-effect-data-configurations")
-          .text("Configurations for all the random effect data sets.")
-          .action((x, c) => c.copy(randomEffectDataConfigurations =
-          x.split("\\|").map { line => val Array(key, value) = line.split(":").map(_.trim)
-            (key, RandomEffectDataConfiguration.parseAndBuildFromString(value))
-          }.toMap
-      ))
+        .text("Configurations for all the random effect data sets.")
+        .action((x, c) => c.copy(randomEffectDataConfigurations =
+          x.split("\\|")
+            .map { line =>
+              val Array(key, value) = line.split(":").map(_.trim)
+              (key, RandomEffectDataConfiguration.parseAndBuildFromString(value))
+            }
+            .toMap
+        ))
       opt[Boolean]("save-models-to-hdfs")
-          .text(s"Whether to save the models (best model and all models) to HDFS." +
-          s"Default: ${defaultParams.isSavingModelsToHDFS}")
-          .action((x, c) => c.copy(isSavingModelsToHDFS = x))
+        .text(s"DEPRECATED -- USE model-output-mode")
+        .action((x, c) => c.copy(modelOutputMode = if (x) ALL else NONE))
+      opt[String]("model-output-mode")
+        .text(s"Output mode of trained models to HDFS (ALL, BEST, or NONE)." +
+          s"Default: ${defaultParams.modelOutputMode}")
+        .action((x, c) => c.copy(modelOutputMode = ModelOutputMode.withName(x.toUpperCase)))
       opt[Int]("num-output-files-for-random-effect-model")
-          .text(s"Number of output files to write for each random effect model. Not setting this parameter or " +
+        .text(s"Number of output files to write for each random effect model. Not setting this parameter or " +
           s"setting it to -1 means to use the default number of output files." +
           s"Default: ${defaultParams.numberOfOutputFilesForRandomEffectModel}")
-          .action((x, c) => c.copy(numberOfOutputFilesForRandomEffectModel = x))
+        .action((x, c) => c.copy(numberOfOutputFilesForRandomEffectModel = x))
       opt[String]("application-name")
-          .text(s"Name of this Spark application. Default: ${defaultParams.applicationName}.")
-          .action((x, c) => c.copy(applicationName = x))
+        .text(s"Name of this Spark application. Default: ${defaultParams.applicationName}.")
+        .action((x, c) => c.copy(applicationName = x))
       help("help")
-          .text("prints usage text.")
+        .text("prints usage text.")
     }
     parser.parse(args, Params()) match {
       case Some(parsedParams) => parsedParams

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/io/FieldNamesType.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/io/FieldNamesType.scala
@@ -16,7 +16,6 @@ package com.linkedin.photon.ml.io
 
 /**
  * Supported types of field names
- * @author xazhang
  */
 object FieldNamesType extends Enumeration {
   type FieldNamesType = Value

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/io/ModelOutputMode.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/io/ModelOutputMode.scala
@@ -15,11 +15,9 @@
 package com.linkedin.photon.ml.io
 
 /**
- * Enum of the keys that are expected to be present in the maps in the user-specified constraint string
- * The "name" and "term" keys are mandatory while one of "lowerBound" and "upperBound" is allowed to be skipped in
- * which case it is assumed to be -Inf / +Inf appropriately
- */
-object ConstraintMapKeys extends Enumeration {
-  type ConstraintMapKeys = Value
-  val name, term, lowerBound, upperBound = Value
+  * Supported options for model output.
+  */
+object ModelOutputMode extends Enumeration {
+  type ModelOutputMode = Value
+  val ALL, BEST, NONE = Value
 }


### PR DESCRIPTION
Addresses issue #84.

Tested on the LinkedIn internal grid. With 'save-models-to-hdfs' set to false, only the best model was output.