### PR TITLE
Throw exception if output directory already exists.

### DIFF
--- a/photon-ml/src/integTest/scala/com/linkedin/photon/ml/util/IOUtilsIntegTest.scala
+++ b/photon-ml/src/integTest/scala/com/linkedin/photon/ml/util/IOUtilsIntegTest.scala
@@ -14,10 +14,9 @@
  */
 package com.linkedin.photon.ml.util
 
-import com.linkedin.photon.ml.test.{CommonTestUtils, SparkTestUtils, TestTemplateWithTmpDir}
+import com.linkedin.photon.ml.test.{SparkTestUtils, TestTemplateWithTmpDir}
 import org.joda.time.DateTime
 import org.joda.time.DateTimeUtils
-import org.joda.time.LocalDate
 import org.testng.Assert._
 import org.testng.annotations.{AfterClass, BeforeClass, DataProvider, Test}
 
@@ -27,19 +26,19 @@ import org.testng.annotations.{AfterClass, BeforeClass, DataProvider, Test}
 class IOUtilsIntegTest extends SparkTestUtils with TestTemplateWithTmpDir {
 
   val baseDir = getClass.getClassLoader.getResource("IOUtilsTest/input").getPath
-  val path1 = s"${baseDir}/daily/2016/01/01"
-  val path2 = s"${baseDir}/daily/2016/02/01"
-  val path3 = s"${baseDir}/daily/2016/03/01"
+  val path1 = s"$baseDir/daily/2016/01/01"
+  val path2 = s"$baseDir/daily/2016/02/01"
+  val path3 = s"$baseDir/daily/2016/03/01"
   val today = "2016-04-01"
 
   @BeforeClass
   def setup() {
-    DateTimeUtils.setCurrentMillisFixed(DateTime.parse(today).getMillis());
+    DateTimeUtils.setCurrentMillisFixed(DateTime.parse(today).getMillis)
   }
 
   @AfterClass
   def teardown() {
-    DateTimeUtils.setCurrentMillisSystem();
+    DateTimeUtils.setCurrentMillisSystem()
   }
 
   @DataProvider
@@ -71,4 +70,14 @@ class IOUtilsIntegTest extends SparkTestUtils with TestTemplateWithTmpDir {
       Seq(baseDir), DateRange.fromDates("19551105-19551106"), sc.hadoopConfiguration, errorOnMissing = true)
   }
 
+  @Test
+  def testIsDirExisting(): Unit = sparkTest("testIsDirExisting") {
+    val dir = getTmpDir
+    val configuration = sc.hadoopConfiguration
+
+    Utils.deleteHDFSDir(dir, configuration)
+    assertFalse(IOUtils.isDirExisting(dir, configuration))
+    Utils.createHDFSDir(dir, configuration)
+    assertTrue(IOUtils.isDirExisting(dir, configuration))
+  }
 }

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/avro/data/NameAndTermFeatureSetContainer.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/avro/data/NameAndTermFeatureSetContainer.scala
@@ -32,7 +32,6 @@ import com.linkedin.photon.ml.util._
 /**
  * A class contain [[NameAndTerm]] features sets for each feature section keys
  * @param nameAndTermFeatureSets A [[Map]] of feature section key to [[NameAndTerm]] feature sets
- * @author xazhang
  */
 //TODO: Change the scope to [[com.linkedin.photon.ml.avro]] after Avro related classes/functons are decoupled from the
 //rest of code
@@ -168,6 +167,9 @@ object NameAndTermFeatureSetContainer {
 
     println(params + "\n")
     val sparkContext = SparkContextConfiguration.asYarnClient(applicationName, useKryo = true)
+    val configuration = sparkContext.hadoopConfiguration
+    require(!IOUtils.isDirExisting(params.featureNameAndTermSetOutputPath, configuration),
+      s"Output path ${params.featureNameAndTermSetOutputPath} already exists!" )
 
     println(s"Application applicationName: $applicationName")
 
@@ -223,7 +225,6 @@ object NameAndTermFeatureSetContainer {
     val records = AvroUtils.readAvroFiles(sparkContext, inputRecordsPath, minPartitions)
     val nameAndTermFeatureSetContainer =
       AvroUtils.readNameAndTermFeatureSetContainerFromGenericRecords(records, featureSectionKeys)
-    Utils.deleteHDFSDir(featureNameAndTermSetOutputPath, sparkContext.hadoopConfiguration)
     nameAndTermFeatureSetContainer.saveAsTextFiles(featureNameAndTermSetOutputPath, sparkContext)
 
     sparkContext.stop()

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/cli/game/scoring/Driver.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/cli/game/scoring/Driver.scala
@@ -150,7 +150,6 @@ class Driver(val params: Params, val sparkContext: SparkContext, val logger: Pho
 
     val numScoredItems = scoredItems.count()
     val scoresDir = new Path(outputDir, Driver.SCORES).toString
-    Utils.deleteHDFSDir(scoresDir, hadoopConfiguration)
     // Should always materialize the scoredItems first (e.g., count()) before the coalesce happens
     scoredItems.coalesce(numFiles).saveAsTextFile(scoresDir)
     logger.debug(s"Number of scored items: $numScoredItems")
@@ -224,6 +223,8 @@ object Driver {
     import params._
 
     val sc = SparkContextConfiguration.asYarnClient(applicationName, useKryo = true)
+    val configuration = sc.hadoopConfiguration
+    require(!IOUtils.isDirExisting(outputDir, configuration), s"Output directory $outputDir already exists!" )
 
     val logsDir = new Path(outputDir, LOGS).toString
     Utils.createHDFSDir(logsDir, sc.hadoopConfiguration)

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/util/IOUtils.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/util/IOUtils.scala
@@ -21,16 +21,34 @@ import scala.collection.mutable
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 import org.joda.time.Days
-import org.joda.time.LocalDate
-import org.joda.time.format.DateTimeFormat
 
 /**
  * Some basic IO util functions to be merged with the other util functions
- * @todo merge this class with the IOUtil function in Photon
- * @author xazhang
  */
 protected[ml] object IOUtils {
 
+  /**
+    * Check if the given directory already exists or not
+    * @param dir the directory path
+    * @param hadoopConf the Hadoop Configuration object
+    * @return whether the given directory already exists
+    */
+  def isDirExisting(dir: String, hadoopConf: Configuration): Boolean = {
+    val path = new Path(dir)
+    val fs = path.getFileSystem(hadoopConf)
+    fs.exists(path)
+  }
+
+  /**
+    * Returns file paths matching the given date range. This method filters out invalid paths by default, but this
+    * behavior can be changed with the "errorOnMissing" parameter.
+    *
+    * @param inputDirs the base paths for input files
+    * @param dateRange date range for finding input files
+    * @param configuration Hadoop configuration
+    * @param errorOnMissing if true, the method will throw when a date has no corresponding input file
+    * @return a sequence of matching file paths
+    */
   def getInputPathsWithinDateRange(
       inputDirs: Seq[String],
       dateRange: DateRange,
@@ -74,10 +92,22 @@ protected[ml] object IOUtils {
     existingPaths.map(_.toString)
   }
 
+  /**
+    * Read a [[mutable.ArrayBuffer]] of strings from the input path on HDFS
+    * @param inputPath the input path
+    * @param configuration the Hadoop configuration
+    * @return a [[mutable.ArrayBuffer]] of strings read from the input path on HDFS
+    */
   def readStringsFromHDFS(inputPath: String, configuration: Configuration): mutable.ArrayBuffer[String] = {
     readStringsFromHDFS(new Path(inputPath), configuration)
   }
 
+  /**
+    * Read a [[mutable.ArrayBuffer]] of strings from the input path on HDFS
+    * @param inputPath the input path
+    * @param configuration the Hadoop configuration
+    * @return a [[mutable.ArrayBuffer]] of strings read from the input path on HDFS
+    */
   def readStringsFromHDFS(inputPath: Path, configuration: Configuration): mutable.ArrayBuffer[String] = {
     val fs = inputPath.getFileSystem(configuration)
     val bufferedReader = new BufferedReader(new InputStreamReader(fs.open(inputPath)))
@@ -91,6 +121,13 @@ protected[ml] object IOUtils {
     arrayBuffer
   }
 
+  /**
+    * Write an iterator of strings to HDFS
+    * @param stringMsgs the strings to be written to HDFS
+    * @param outputPath the HDFS path to write the strings
+    * @param configuration hadoop configuration
+    * @param forceOverwrite whether to force overwrite the output path if already exists
+    */
   def writeStringsToHDFS(
       stringMsgs: Iterator[String],
       outputPath: String,
@@ -100,6 +137,13 @@ protected[ml] object IOUtils {
     writeStringsToHDFS(stringMsgs, new Path(outputPath), configuration, forceOverwrite)
   }
 
+  /**
+    * Write an iterator of strings to HDFS
+    * @param stringMsgs the strings to be written to HDFS
+    * @param outputPath the HDFS path to write the strings
+    * @param configuration hadoop configuration
+    * @param forceOverwrite whether to force overwrite the output path if already exists
+    */
   def writeStringsToHDFS(
       stringMsgs: Iterator[String],
       outputPath: Path,

--- a/photon-ml/src/test/scala/com/linkedin/photon/ml/util/UtilsTest.scala
+++ b/photon-ml/src/test/scala/com/linkedin/photon/ml/util/UtilsTest.scala
@@ -60,12 +60,12 @@ class UtilsTest extends TestTemplateWithTmpDir {
     val createdDir = new Path(getTmpDir + "/testDeleteHDFSDir")
 
     // Directory not existing, nothing should happen
-    Utils.deleteHDFSDir(createdDir.toString(), conf)
+    Utils.deleteHDFSDir(createdDir.toString, conf)
     assertFalse(fs.exists(createdDir))
 
     fs.mkdirs(createdDir)
     assertTrue(fs.exists(createdDir))
-    Utils.deleteHDFSDir(createdDir.toString(), conf)
+    Utils.deleteHDFSDir(createdDir.toString, conf)
     assertFalse(fs.exists(createdDir))
   }
 


### PR DESCRIPTION
Currently Photon/GAME will silently delete the user specified output directory if it exists. However, such behavior is inconsistent with Pig and Spark, where an exception will be thrown if the output directory exists.

More details on this PR are discussed in #87.