### PR TITLE
Fix skipped test

### DIFF
--- a/build-scripts/integration-test.gradle
+++ b/build-scripts/integration-test.gradle
@@ -57,6 +57,7 @@ plugins.withType(JavaPlugin) {
     options {
       parallel = 'methods'
       threadCount = 4
+      listeners << 'com.linkedin.photon.ml.test.FailOnSkipListener'
     }
 
     afterSuite { desc, result ->

--- a/build.gradle
+++ b/build.gradle
@@ -107,6 +107,7 @@ subprojects {
       options {
         parallel = 'methods'
         threadCount = 4
+        listeners << 'com.linkedin.photon.ml.test.FailOnSkipListener'
       }
 
       afterSuite { desc, result ->

--- a/photon-ml/src/integTest/scala/com/linkedin/photon/ml/util/IOUtilsIntegTest.scala
+++ b/photon-ml/src/integTest/scala/com/linkedin/photon/ml/util/IOUtilsIntegTest.scala
@@ -48,7 +48,7 @@ class IOUtilsIntegTest extends SparkTestUtils with TestTemplateWithTmpDir {
       Array(baseDir.toString, DateRange.fromDates("20160101-20160401"), Seq(path1, path2, path3)),
       Array(baseDir.toString, DateRange.fromDates("20160101-20160301"), Seq(path1, path2, path3)),
       Array(baseDir.toString, DateRange.fromDates("20160101-20160201"), Seq(path1, path2)),
-      Array(baseDir.toString, DateRange.fromDates("20160101-20160101"), Seq(path1)),
+      Array(baseDir.toString, DateRange.fromDates("20160101-20160102"), Seq(path1)),
       Array(baseDir.toString, DateRange.fromDaysAgo(95, 1), Seq(path1, path2, path3)),
       Array(baseDir.toString, DateRange.fromDaysAgo(60, 1), Seq(path2, path3)),
       Array(baseDir.toString, DateRange.fromDaysAgo(45, 1), Seq(path3)))

--- a/photon-test/src/main/scala/com/linkedin/photon/ml/test/FailOnSkipListener.scala
+++ b/photon-test/src/main/scala/com/linkedin/photon/ml/test/FailOnSkipListener.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2016 LinkedIn Corp. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linkedin.photon.ml.test
+
+import org.testng.ITestResult
+import org.testng.TestListenerAdapter
+
+/**
+ * Implements a TestNG listener that converts "skip" status to "fail". This is a global approach to a problem where
+ * exceptions thrown in the code for a DataProvider cause dependent tests to be silently skipped. The listener surfaces
+ * any skip with an associated Throwable as a failure.
+ */
+class FailOnSkipListener extends TestListenerAdapter {
+
+  /**
+   * Invoked each time a test is skipped.
+   *
+   * @param result ITestResult containing information about the run test
+   */
+  override def onTestSkipped(tr: ITestResult) {
+    // If the skip was a result of an exception, change the skip to a failure
+    if (Option(tr.getThrowable).isDefined) {
+      tr.setStatus(ITestResult.FAILURE)
+    }
+  }
+}


### PR DESCRIPTION
TestNG was skipping this test because the DataProvider failed to create a null date range.

This PR also includes a change that would prevent this from happening in the future. The idea is to globally transform all tests that are skipped on account of a Throwable into failures.