### PR TITLE
Allow the start date and end date to be configured as the same day

### DIFF
--- a/photon-ml/src/integTest/scala/com/linkedin/photon/ml/util/IOUtilsIntegTest.scala
+++ b/photon-ml/src/integTest/scala/com/linkedin/photon/ml/util/IOUtilsIntegTest.scala
@@ -48,6 +48,7 @@ class IOUtilsIntegTest extends SparkTestUtils with TestTemplateWithTmpDir {
       Array(baseDir.toString, DateRange.fromDates("20160101-20160301"), Seq(path1, path2, path3)),
       Array(baseDir.toString, DateRange.fromDates("20160101-20160201"), Seq(path1, path2)),
       Array(baseDir.toString, DateRange.fromDates("20160101-20160102"), Seq(path1)),
+      Array(baseDir.toString, DateRange.fromDates("20160101-20160101"), Seq(path1)),
       Array(baseDir.toString, DateRange.fromDaysAgo(95, 1), Seq(path1, path2, path3)),
       Array(baseDir.toString, DateRange.fromDaysAgo(60, 1), Seq(path2, path3)),
       Array(baseDir.toString, DateRange.fromDaysAgo(45, 1), Seq(path3)))

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/util/DateRange.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/util/DateRange.scala
@@ -26,14 +26,14 @@ import org.joda.time.format.DateTimeFormat
  */
 case class DateRange(val startDate: LocalDate, val endDate: LocalDate) {
 
-  require(startDate.isBefore(endDate), s"Invalid range: start date $startDate comes after end date $endDate.")
+  require(!startDate.isAfter(endDate), s"Invalid range: start date $startDate comes after end date $endDate.")
 
   /**
    * Builds a string representation for the date range.
    *
    * @return the string representation
    */
-  override def toString(): String = {
+  override def toString: String = {
     s"$startDate-$endDate"
   }
 
@@ -87,7 +87,7 @@ object DateRange {
    * Builds a new range from the starting and ending days ago.
    *
    * @param startDaysAgo beginning of the range, in number of days from now
-   * @param endDate end of the range, in number of days from now
+   * @param endDaysAgo end of the range, in number of days from now
    * @return the new date range
    */
   def fromDaysAgo(startDaysAgo: Int, endDaysAgo: Int, now: LocalDate = new LocalDate): DateRange = {
@@ -101,7 +101,7 @@ object DateRange {
    * Builds a new range from string representations of the starting and ending days ago.
    *
    * @param startDaysAgo string representation of the beginning of the range, in number of days from now
-   * @param endDate string representation of the end of the range, in number of days from now
+   * @param endDaysAgo string representation of the end of the range, in number of days from now
    * @return the new date range
    */
   def fromDaysAgo(startDaysAgo: String, endDaysAgo: String): DateRange = {

--- a/photon-ml/src/test/scala/com/linkedin/photon/ml/util/DateRangeTest.scala
+++ b/photon-ml/src/test/scala/com/linkedin/photon/ml/util/DateRangeTest.scala
@@ -17,7 +17,6 @@ package com.linkedin.photon.ml.util
 import org.joda.time.DateTime
 import org.joda.time.DateTimeUtils
 import org.joda.time.LocalDate
-import org.joda.time.LocalDate
 import org.testng.annotations.{AfterClass, BeforeClass, DataProvider, Test}
 import org.testng.Assert._
 
@@ -30,17 +29,18 @@ class DateRangeTest {
 
   @BeforeClass
   def setup() {
-    DateTimeUtils.setCurrentMillisFixed(DateTime.parse(today).getMillis());
+    DateTimeUtils.setCurrentMillisFixed(DateTime.parse(today).getMillis)
   }
 
   @AfterClass
   def teardown() {
-    DateTimeUtils.setCurrentMillisSystem();
+    DateTimeUtils.setCurrentMillisSystem()
   }
 
   @DataProvider
   def rangeDataProvider(): Array[Array[Any]] = {
     Array(
+      Array(DateRange.fromDates("20150101-20150101"), "2015-01-01", "2015-01-01"),
       Array(DateRange.fromDates("20150101-20150201"), "2015-01-01", "2015-02-01"),
       Array(DateRange.fromDates("20140312-20150211"), "2014-03-12", "2015-02-11"),
       Array(DateRange.fromDates("19950816-20011120"), "1995-08-16", "2001-11-20"),


### PR DESCRIPTION
As discussed in issue #91, it is useful to allow the start date and end date to be configured as the same day in certain use cases.