### PR TITLE
Fix GAME model selection logic bug

### DIFF
--- a/photon-ml/src/integTest/scala/com/linkedin/photon/ml/cli/game/training/DriverGameIntegTest.scala
+++ b/photon-ml/src/integTest/scala/com/linkedin/photon/ml/cli/game/training/DriverGameIntegTest.scala
@@ -244,7 +244,7 @@ class DriverGameIntegTest extends SparkTestUtils with TestTemplateWithTmpDir {
     val fixedEffectModelPath = bestModelPath(outputDir, "fixed-effect", "global")
 
     assertTrue(Files.exists(fixedEffectModelPath))
-    assertTrue(modelSane(fixedEffectModelPath, expectedNumCoefficients = 14982))
+    assertTrue(modelSane(fixedEffectModelPath, expectedNumCoefficients = 14983))
     assertTrue(evaluateModel(driver, fs.getPath(outputDir, "best")) < errorThreshold)
   }
 

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/evaluation/BinaryClassificationEvaluator.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/evaluation/BinaryClassificationEvaluator.scala
@@ -18,22 +18,22 @@ import org.apache.spark.mllib.evaluation.BinaryClassificationMetrics
 import org.apache.spark.rdd.RDD
 
 /**
- * Evaluator for binary classification problems
- *
- * @param labelAndOffsets a [[RDD]] of (id, (label, offset)) pairs
- * @param defaultScore the default score used to compute the metric
- * @author xazhang
- */
+  * Evaluator for binary classification problems
+  *
+  * @param labelAndOffsets a [[RDD]] of (id, (label, offset)) pairs
+  * @param defaultScore the default score used to compute the metric
+  * @author xazhang
+  */
 protected[ml] class BinaryClassificationEvaluator(
     labelAndOffsets: RDD[(Long, (Double, Double))],
     defaultScore: Double = 0.0) extends Evaluator {
 
   /**
-   * Evaluate the scores of the model
-   *
-   * @param scores the scores to evaluate
-   * @return score metric value
-   */
+    * Evaluate the scores of the model
+    *
+    * @param scores the scores to evaluate
+    * @return score metric value
+    */
   override def evaluate(scores: RDD[(Long, Double)]): Double = {
     // Create a local copy of the defaultScore, so that the underlying object won't get shipped to the executor nodes
     val defaultScore = this.defaultScore
@@ -43,4 +43,14 @@ protected[ml] class BinaryClassificationEvaluator(
 
     new BinaryClassificationMetrics(scoreAndLabels).areaUnderROC()
   }
+
+  /**
+    * Determine the best between two scores returned by the evaluator. In some cases, the better score is higher
+    * (e.g. AUC) and in others, the better score is lower (e.g. RMSE).
+    *
+    * @param score1 the first score to compare
+    * @param score2 the second score to compare
+    * @return true if the first score is better than the second
+    */
+  override def betterThan(score1: Double, score2: Double): Boolean = score1 > score2
 }

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/evaluation/Evaluator.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/evaluation/Evaluator.scala
@@ -24,10 +24,20 @@ import org.apache.spark.rdd.RDD
 protected[ml] trait Evaluator {
 
   /**
-   * Evaluate the scores of the model
-   *
-   * @param scores the scores to evaluate
-   * @return score metric value
-   */
+    * Evaluate the scores of the model
+    *
+    * @param scores the scores to evaluate
+    * @return score metric value
+    */
   def evaluate(scores: RDD[(Long, Double)]): Double
+
+  /**
+    * Determine the best between two scores returned by the evaluator. In some cases, the better score is higher
+    * (e.g. AUC) and in others, the better score is lower (e.g. RMSE).
+    *
+    * @param score1 the first score to compare
+    * @param score2 the second score to compare
+    * @return true if the first score is better than the second
+    */
+  def betterThan(score1: Double, score2: Double): Boolean
 }

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/evaluation/LogisticLossEvaluator.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/evaluation/LogisticLossEvaluator.scala
@@ -21,22 +21,22 @@ import com.linkedin.photon.ml.util.Utils
 
 
 /**
- * Evaluator for logistic loss
- *
- * @param labelAndOffsetAndWeights a [[RDD]] of (id, (labels, offsets, weights)) pairs
- * @param defaultScore the default score used to compute the metric
- * @author xazhang
- */
+  * Evaluator for logistic loss
+  *
+  * @param labelAndOffsetAndWeights a [[RDD]] of (id, (labels, offsets, weights)) pairs
+  * @param defaultScore the default score used to compute the metric
+  * @author xazhang
+  */
 protected[ml] class LogisticLossEvaluator(
     labelAndOffsetAndWeights: RDD[(Long, (Double, Double, Double))],
     defaultScore: Double = 0.0) extends Evaluator {
 
   /**
-   * Evaluate the scores of the model
-   *
-   * @param scores the scores to evaluate
-   * @return score metric value
-   */
+    * Evaluate the scores of the model
+    *
+    * @param scores the scores to evaluate
+    * @return score metric value
+    */
   def evaluate(scores: RDD[(Long, Double)]): Double = {
     val defaultScore = this.defaultScore
 
@@ -53,4 +53,14 @@ protected[ml] class LogisticLossEvaluator(
       }
     }.reduce(_ + _)
   }
+
+  /**
+    * Determine the best between two scores returned by the evaluator. In some cases, the better score is higher
+    * (e.g. AUC) and in others, the better score is lower (e.g. RMSE).
+    *
+    * @param score1 the first score to compare
+    * @param score2 the second score to compare
+    * @return true if the first score is better than the second
+    */
+  override def betterThan(score1: Double, score2: Double): Boolean = score1 < score2
 }

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/evaluation/RMSEEvaluator.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/evaluation/RMSEEvaluator.scala
@@ -18,12 +18,12 @@ import org.apache.spark.rdd.RDD
 
 
 /**
- * Evaluator for root mean squared error
- *
- * @param labelAndOffsetAndWeights a [[RDD]] of (id, (labels, offsets, weights)) pairs
- * @param defaultScore the default score used to compute the metric
- * @author xazhang
- */
+  * Evaluator for root mean squared error
+  *
+  * @param labelAndOffsetAndWeights a [[RDD]] of (id, (labels, offsets, weights)) pairs
+  * @param defaultScore the default score used to compute the metric
+  * @author xazhang
+  */
 protected[ml] class RMSEEvaluator(
     labelAndOffsetAndWeights: RDD[(Long, (Double, Double, Double))],
     defaultScore: Double = 0.0) extends Evaluator {
@@ -31,12 +31,22 @@ protected[ml] class RMSEEvaluator(
   val squaredLossEvaluator = new SquaredLossEvaluator(labelAndOffsetAndWeights, defaultScore)
 
   /**
-   * Evaluate the scores of the model
-   *
-   * @param scores the scores to evaluate
-   * @return score metric value
-   */
+    * Evaluate the scores of the model
+    *
+    * @param scores the scores to evaluate
+    * @return score metric value
+    */
   override def evaluate(scores: RDD[(Long, Double)]): Double = {
     math.sqrt(squaredLossEvaluator.evaluate(scores) / labelAndOffsetAndWeights.count())
   }
+
+  /**
+    * Determine the best between two scores returned by the evaluator. In some cases, the better score is higher
+    * (e.g. AUC) and in others, the better score is lower (e.g. RMSE).
+    *
+    * @param score1 the first score to compare
+    * @param score2 the second score to compare
+    * @return true if the first score is better than the second
+    */
+  override def betterThan(score1: Double, score2: Double): Boolean = score1 < score2
 }

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/evaluation/SquaredLossEvaluator.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/evaluation/SquaredLossEvaluator.scala
@@ -17,22 +17,22 @@ package com.linkedin.photon.ml.evaluation
 import org.apache.spark.rdd.RDD
 
 /**
- * Evaluator for squared loss
- *
- * @param labelAndOffsetAndWeights a [[RDD]] of (id, (labels, offsets, weights)) pairs
- * @param defaultScore the default score used to compute the metric
- * @author xazhang
- */
+  * Evaluator for squared loss
+  *
+  * @param labelAndOffsetAndWeights a [[RDD]] of (id, (labels, offsets, weights)) pairs
+  * @param defaultScore the default score used to compute the metric
+  * @author xazhang
+  */
 protected[ml] class SquaredLossEvaluator(
     labelAndOffsetAndWeights: RDD[(Long, (Double, Double, Double))],
     defaultScore: Double = 0.0) extends Evaluator {
 
   /**
-   * Evaluate the scores of the model
-   *
-   * @param scores the scores to evaluate
-   * @return score metric value
-   */
+    * Evaluate the scores of the model
+    *
+    * @param scores the scores to evaluate
+    * @return score metric value
+    */
   override def evaluate(scores: RDD[(Long, Double)]): Double = {
     val defaultScore = this.defaultScore
 
@@ -46,4 +46,14 @@ protected[ml] class SquaredLossEvaluator(
       weight * diff * diff
     }.reduce(_ + _)
   }
+
+  /**
+    * Determine the best between two scores returned by the evaluator. In some cases, the better score is higher
+    * (e.g. AUC) and in others, the better score is lower (e.g. RMSE).
+    *
+    * @param score1 the first score to compare
+    * @param score2 the second score to compare
+    * @return true if the first score is better than the second
+    */
+  override def betterThan(score1: Double, score2: Double): Boolean = score1 < score2
 }


### PR DESCRIPTION
This addresses issue https://github.com/linkedin/photon-ml/issues/93

Previously we selected the "best" model by largest score value. This is
wrong for some metrics, however, such as RMSE where larger values
indicated greater error.

The fix is a change to the Evaluator interface that allows evaluator
implementations to specify how scores should be compared.