### PR TITLE
Remove unnecessary logging in optimizer

### DIFF
--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/optimization/Optimizer.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/optimization/Optimizer.scala
@@ -207,7 +207,6 @@ trait Optimizer[Datum <: DataPoint, -Function <: DiffFunction[Datum]] extends Se
       setCurrentState(Some(updatedState))
     } while (!isDone)
     val currentState = getCurrentState
-    logInfo(s"After optimizing, current state: $currentState")
     (currentState.get.coefficients, currentState.get.value)
   }
 

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/optimization/TRON.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/optimization/TRON.scala
@@ -187,7 +187,7 @@ class TRON[Datum <: DataPoint](
       }
       val gradientNorm = norm(updatedFunctionGradient, 2)
       val residualNorm = norm(residual, 2)
-      logInfo(f"iter ${state.iter}%3d act $actualReduction%5.3e pre $predictedReduction%5.3e delta $delta%5.3e " +
+      logDebug(f"iter ${state.iter}%3d act $actualReduction%5.3e pre $predictedReduction%5.3e delta $delta%5.3e " +
         f"f $updatedFunctionValue%5.3e |residual| $residualNorm%5.3e |g| $gradientNorm%5.3e CG $cgIter%3d")
 
       if (actualReduction > eta0 * predictedReduction) {
@@ -286,7 +286,7 @@ object TRON extends Logging {
         var alpha = rTr / direction.dot(Hd)
         step += direction * alpha
         if (norm(step, 2) > truncationBoundary) {
-          logInfo(s"cg reaches truncation boundary after $iteration iterations")
+          logDebug(s"cg reaches truncation boundary after $iteration iterations")
           /* Solve equation (13) of Algorithm 2 */
           alpha = -alpha
           step += direction * alpha


### PR DESCRIPTION
As discussed in #98, this PR removes the unnecessary logging in ```optimizer```, and also changes the log level in ```Tron``` from info to debug.