### PR TITLE
Fix the bugs identified through Photon model training logs

### DIFF
--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/Driver.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/Driver.scala
@@ -188,8 +188,8 @@ protected[ml] class Driver(
     featureNum = trainingData.first().features.size
 
     // Print out the basic statistics of the training data
-    logger.info(s"number of training data points: $trainingDataNum, " +
-      s"number of features in each training example including intercept (if any) $featureNum.")
+    logger.info(s"Number of training data points: $trainingDataNum, " +
+      s"total number of unique features found in training data including intercept (if any): $featureNum.")
     logger.info(s"Input RDD persisted in storage level $trainDataStorageLevel")
 
     if (! DataValidators.sanityCheckData(trainingData, params.taskType, params.dataValidationType)) {

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/optimization/AbstractOptimizer.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/optimization/AbstractOptimizer.scala
@@ -98,15 +98,21 @@ abstract class AbstractOptimizer[Datum <: DataPoint, -Function <: DiffFunction[D
   def getCurrentState: Option[OptimizerState] = currentState
 
   protected def setCurrentState(state: Option[OptimizerState]): Unit = {
-    currentState = state
-    state match {
-      case Some(x) =>
-        statesTracker match {
-          case Some(y) =>
-            y.track(x)
-            y.convergenceReason = convergenceReason
-          case None =>
+    (state, statesTracker, currentState) match {
+      case (Some(s), Some(st), Some(ct)) =>
+        // Only tracks the state if it is different from the previous state (e.g., different objects)
+        if (s != ct) {
+          st.track(s)
         }
+      case _ =>
+    }
+    currentState = state
+  }
+
+  protected def setConvergenceReason(): Unit = {
+    // Set the convergenceReason when the optimization is done
+    statesTracker match {
+      case Some(y) => y.convergenceReason = convergenceReason
       case None =>
     }
   }

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/optimization/OptimizationStatesTracker.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/optimization/OptimizationStatesTracker.scala
@@ -14,7 +14,6 @@
  */
 package com.linkedin.photon.ml.optimization
 
-import java.io.{PrintWriter, StringWriter}
 
 import breeze.linalg.norm
 import breeze.optimize.FirstOrderMinimizer.{ConvergenceReason, FunctionValuesConverged, GradientConverged}
@@ -26,7 +25,6 @@ import scala.collection.mutable
  * Class to track the history of an optimizer's states and wall-clock time elapsed per iteration
  * @param maxNumStates The maximum number of states to track. This is used to prevent the OptimizationHistoryTracker
  *                     from using too much memory to track the history of the states.
- * @author xazhang
  * @note  DO NOT USE this class outside of Photon-ML. It is intended as an internal utility, and is likely to be changed
  *   or removed in future releases.
  */

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/optimization/Optimizer.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/optimization/Optimizer.scala
@@ -88,6 +88,12 @@ trait Optimizer[Datum <: DataPoint, -Function <: DiffFunction[Datum]] extends Se
    */
   def getPreviousState: Option[OptimizerState]
 
+
+  /**
+   * Set the convergence reason
+   */
+  protected def setConvergenceReason(): Unit
+
   /**
    * Set the initial state for the optimizer
    * @param state The initial state
@@ -206,6 +212,7 @@ trait Optimizer[Datum <: DataPoint, -Function <: DiffFunction[Datum]] extends Se
       setPreviousState(getCurrentState)
       setCurrentState(Some(updatedState))
     } while (!isDone)
+    setConvergenceReason()
     val currentState = getCurrentState
     (currentState.get.coefficients, currentState.get.value)
   }

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/optimization/OptimizerState.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/optimization/OptimizerState.scala
@@ -25,7 +25,6 @@ import breeze.linalg.Vector
  * @param value The current objective function's value
  * @param gradient The current objective function's gradient
  * @param iter what iteration number we are on
- * @author xazhang
  */
 protected[optimization] case class OptimizerState(
   coefficients: Vector[Double],

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/optimization/TRON.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/optimization/TRON.scala
@@ -134,7 +134,7 @@ class TRON[Datum <: DataPoint](
     var numImprovementFailure = 0
     var finalState = state
     do {
-      //retry the Tron optimization with tne shrunken trust region boundary (delta) until either
+      // retry the TRON optimization with the shrunken trust region boundary (delta) until either
       // 1. the function value is improved; or
       // 2. the maximum number of improvement failures reached.
       val (cgIter, step, residual) = TRON.truncatedConjugateGradientMethod(


### PR DESCRIPTION
When investigating some of the issues that our Photon ML customers encountered recently, I found the following logs from the model training job:

number of training data points: 25250560, number of features in **each** training example including intercept (if any) 3479.
Convergence reason: objective is not improving
      Iter   Time(s)                    Value     |Gradient|
         0     1.607        37800195.11474618       1.18e+07
         1    21.362        35780206.30930489       1.52e+07
         2    28.717        35490290.19306723       1.95e+06
         **3    50.755        35224190.91374312       1.94e+06
         3    69.871        35224190.91374312       1.94e+06**

Highlighted are two problems I found:
The first is the misleading statement on the feature size, what we really want to inform the user is that "**total** number of **unique** features found in training data including intercept", not "number of features in **each** training example including intercept".

The second is that, a duplicated optimization state is always tracked at the last iteration, if the convergence reason is "objective is not improving".

And this PR addresses the above two issues.
