### PR TITLE
Major refactoring for the diagnostics module in Photon's driver

### DIFF
--- a/photon-ml/src/integTest/scala/com/linkedin/photon/ml/DriverIntegTest.scala
+++ b/photon-ml/src/integTest/scala/com/linkedin/photon/ml/DriverIntegTest.scala
@@ -18,6 +18,7 @@ import breeze.linalg.{DenseVector, Vector, norm}
 import org.apache.hadoop.fs.Path
 import com.linkedin.photon.ml.OptionNames._
 import com.linkedin.photon.ml.constants.MathConst
+import com.linkedin.photon.ml.diagnostics.DiagnosticMode
 import com.linkedin.photon.ml.io.{FieldNamesType, GLMSuite}
 import com.linkedin.photon.ml.normalization.NormalizationType
 import com.linkedin.photon.ml.optimization.OptimizerType.OptimizerType
@@ -60,7 +61,8 @@ class DriverIntegTest extends SparkTestUtils with TestTemplateWithTmpDir {
       expectedStages = Array(DriverStage.INIT, DriverStage.PREPROCESSED, DriverStage.TRAINED),
       expectedNumFeatures = EXPECTED_NUM_FEATURES,
       expectedNumTrainingData = EXPECTED_NUM_TRAINING_DATA,
-      expectedIsSummarized = false)
+      expectedIsSummarized = false,
+      expectedDiagnosticMode = DiagnosticMode.NONE)
 
     val models = loadAllModels(new Path(outputDir, Driver.LEARNED_MODELS_TEXT).toString)
     assertEquals(models.length, defaultParams.regularizationWeights.length)
@@ -84,7 +86,8 @@ class DriverIntegTest extends SparkTestUtils with TestTemplateWithTmpDir {
       expectedStages = Array(DriverStage.INIT, DriverStage.PREPROCESSED, DriverStage.TRAINED),
       expectedNumFeatures = EXPECTED_NUM_FEATURES,
       expectedNumTrainingData = EXPECTED_NUM_TRAINING_DATA,
-      expectedIsSummarized = false)
+      expectedIsSummarized = false,
+      expectedDiagnosticMode = DiagnosticMode.NONE)
   }
 
   @Test
@@ -104,7 +107,8 @@ class DriverIntegTest extends SparkTestUtils with TestTemplateWithTmpDir {
       expectedStages = Array(DriverStage.INIT, DriverStage.PREPROCESSED, DriverStage.TRAINED),
       expectedNumFeatures = EXPECTED_NUM_FEATURES,
       expectedNumTrainingData = EXPECTED_NUM_TRAINING_DATA,
-      expectedIsSummarized = false)
+      expectedIsSummarized = false,
+      expectedDiagnosticMode = DiagnosticMode.NONE)
   }
 
   def testRunTrainingSetWithEmptyFeatures(): Unit = sparkTest("testRunTrainingSetWithEmptyFeatures") {
@@ -126,7 +130,8 @@ class DriverIntegTest extends SparkTestUtils with TestTemplateWithTmpDir {
       expectedStages = Array(DriverStage.INIT, DriverStage.PREPROCESSED, DriverStage.TRAINED),
       expectedNumFeatures = 0,
       expectedNumTrainingData = 250,
-      expectedIsSummarized = false)
+      expectedIsSummarized = false,
+      expectedDiagnosticMode = DiagnosticMode.NONE)
 
     val models = loadAllModels(new Path(outputDir, Driver.LEARNED_MODELS_TEXT).toString)
     assertEquals(models.length, defaultParams.regularizationWeights.length)
@@ -156,7 +161,8 @@ class DriverIntegTest extends SparkTestUtils with TestTemplateWithTmpDir {
       expectedStages = Array(DriverStage.INIT, DriverStage.PREPROCESSED, DriverStage.TRAINED),
       expectedNumFeatures = 13,
       expectedNumTrainingData = EXPECTED_NUM_TRAINING_DATA,
-      expectedIsSummarized = false)
+      expectedIsSummarized = false,
+      expectedDiagnosticMode = DiagnosticMode.NONE)
 
     val models = loadAllModels(new Path(outputDir, Driver.LEARNED_MODELS_TEXT).toString)
     assertEquals(models.length, defaultParams.regularizationWeights.length)
@@ -184,7 +190,8 @@ class DriverIntegTest extends SparkTestUtils with TestTemplateWithTmpDir {
       expectedStages = Array(DriverStage.INIT, DriverStage.PREPROCESSED, DriverStage.TRAINED),
       expectedNumFeatures = EXPECTED_NUM_FEATURES,
       expectedNumTrainingData = EXPECTED_NUM_TRAINING_DATA,
-      expectedIsSummarized = false)
+      expectedIsSummarized = false,
+      expectedDiagnosticMode = DiagnosticMode.NONE)
 
     val models = loadAllModels(new Path(outputDir, Driver.LEARNED_MODELS_TEXT).toString)
     assertEquals(models.length, defaultParams.regularizationWeights.length)
@@ -217,11 +224,11 @@ class DriverIntegTest extends SparkTestUtils with TestTemplateWithTmpDir {
         DriverStage.INIT,
         DriverStage.PREPROCESSED,
         DriverStage.TRAINED,
-        DriverStage.VALIDATED,
-        DriverStage.DIAGNOSED),
+        DriverStage.VALIDATED),
       expectedNumFeatures = 13,
       expectedNumTrainingData = EXPECTED_NUM_TRAINING_DATA,
-      expectedIsSummarized = false)
+      expectedIsSummarized = false,
+      expectedDiagnosticMode = DiagnosticMode.NONE)
 
     val models = loadAllModels(new Path(outputDir, Driver.LEARNED_MODELS_TEXT).toString)
     assertEquals(models.length, defaultParams.regularizationWeights.length)
@@ -256,11 +263,11 @@ class DriverIntegTest extends SparkTestUtils with TestTemplateWithTmpDir {
         DriverStage.INIT,
         DriverStage.PREPROCESSED,
         DriverStage.TRAINED,
-        DriverStage.VALIDATED,
-        DriverStage.DIAGNOSED),
+        DriverStage.VALIDATED),
       expectedNumFeatures = EXPECTED_NUM_FEATURES,
       expectedNumTrainingData = EXPECTED_NUM_TRAINING_DATA,
-      expectedIsSummarized = false)
+      expectedIsSummarized = false,
+      expectedDiagnosticMode = DiagnosticMode.NONE)
 
     val models = loadAllModels(new Path(outputDir, Driver.LEARNED_MODELS_TEXT).toString)
     assertEquals(models.length, defaultParams.regularizationWeights.length)
@@ -290,7 +297,8 @@ class DriverIntegTest extends SparkTestUtils with TestTemplateWithTmpDir {
       expectedStages = Array(DriverStage.INIT, DriverStage.PREPROCESSED, DriverStage.TRAINED),
       expectedNumFeatures = EXPECTED_NUM_FEATURES,
       expectedNumTrainingData = EXPECTED_NUM_TRAINING_DATA,
-      expectedIsSummarized = false)
+      expectedIsSummarized = false,
+      expectedDiagnosticMode = DiagnosticMode.NONE)
 
     val models = loadAllModels(new Path(outputDir, Driver.LEARNED_MODELS_TEXT).toString)
     assertEquals(models.length, defaultParams.regularizationWeights.length)
@@ -317,7 +325,8 @@ class DriverIntegTest extends SparkTestUtils with TestTemplateWithTmpDir {
       expectedStages = Array(DriverStage.INIT, DriverStage.PREPROCESSED, DriverStage.TRAINED),
       expectedNumFeatures = EXPECTED_NUM_FEATURES,
       expectedNumTrainingData = EXPECTED_NUM_TRAINING_DATA,
-      expectedIsSummarized = false)
+      expectedIsSummarized = false,
+      expectedDiagnosticMode = DiagnosticMode.NONE)
 
     val models = loadAllModels(new Path(outputDir, Driver.LEARNED_MODELS_TEXT).toString)
     assertEquals(models.length, defaultParams.regularizationWeights.length)
@@ -352,7 +361,8 @@ class DriverIntegTest extends SparkTestUtils with TestTemplateWithTmpDir {
       expectedStages = Array(DriverStage.INIT, DriverStage.PREPROCESSED, DriverStage.TRAINED),
       expectedNumFeatures = 13,
       expectedNumTrainingData = EXPECTED_NUM_TRAINING_DATA,
-      expectedIsSummarized = false)
+      expectedIsSummarized = false,
+      expectedDiagnosticMode = DiagnosticMode.NONE)
 
     val models = loadAllModels(new Path(outputDir, Driver.LEARNED_MODELS_TEXT).toString)
 
@@ -402,7 +412,8 @@ class DriverIntegTest extends SparkTestUtils with TestTemplateWithTmpDir {
       expectedStages = Array(DriverStage.INIT, DriverStage.PREPROCESSED, DriverStage.TRAINED),
       expectedNumFeatures = EXPECTED_NUM_FEATURES,
       expectedNumTrainingData = EXPECTED_NUM_TRAINING_DATA,
-      expectedIsSummarized = false)
+      expectedIsSummarized = false,
+      expectedDiagnosticMode = DiagnosticMode.NONE)
 
     val models = loadAllModels(new Path(outputDir, Driver.LEARNED_MODELS_TEXT).toString)
     assertEquals(models.length, lambdas.length)
@@ -446,7 +457,8 @@ class DriverIntegTest extends SparkTestUtils with TestTemplateWithTmpDir {
       expectedStages = Array(DriverStage.INIT, DriverStage.PREPROCESSED, DriverStage.TRAINED),
       expectedNumFeatures = EXPECTED_NUM_FEATURES,
       expectedNumTrainingData = EXPECTED_NUM_TRAINING_DATA,
-      expectedIsSummarized = true)
+      expectedIsSummarized = true,
+      expectedDiagnosticMode = DiagnosticMode.NONE)
 
     val models = loadAllModels(new Path(outputDir, Driver.LEARNED_MODELS_TEXT).toString)
     assertEquals(models.length, defaultParams.regularizationWeights.length)
@@ -473,7 +485,9 @@ class DriverIntegTest extends SparkTestUtils with TestTemplateWithTmpDir {
       expectedStages = Array(DriverStage.INIT, DriverStage.PREPROCESSED, DriverStage.TRAINED),
       expectedNumFeatures = EXPECTED_NUM_FEATURES,
       expectedNumTrainingData = EXPECTED_NUM_TRAINING_DATA,
-      expectedIsSummarized = true)
+      expectedIsSummarized = true,
+      expectedDiagnosticMode = DiagnosticMode.NONE)
+
     val models = loadAllModels(new Path(outputDir, Driver.LEARNED_MODELS_TEXT).toString)
     assertEquals(models.length, defaultParams.regularizationWeights.length)
     // Verify lambdas
@@ -500,7 +514,8 @@ class DriverIntegTest extends SparkTestUtils with TestTemplateWithTmpDir {
       expectedStages = Array(DriverStage.INIT, DriverStage.PREPROCESSED, DriverStage.TRAINED),
       expectedNumFeatures = EXPECTED_NUM_FEATURES,
       expectedNumTrainingData = EXPECTED_NUM_TRAINING_DATA,
-      expectedIsSummarized = false)
+      expectedIsSummarized = false,
+      expectedDiagnosticMode = DiagnosticMode.NONE)
 
     val models = loadAllModels(new Path(outputDir, Driver.LEARNED_MODELS_TEXT).toString)
     assertEquals(models.length, defaultParams.regularizationWeights.length)
@@ -530,7 +545,8 @@ class DriverIntegTest extends SparkTestUtils with TestTemplateWithTmpDir {
       expectedStages = Array(DriverStage.INIT, DriverStage.PREPROCESSED, DriverStage.TRAINED),
       expectedNumFeatures = EXPECTED_NUM_FEATURES,
       expectedNumTrainingData = EXPECTED_NUM_TRAINING_DATA,
-      expectedIsSummarized = true)
+      expectedIsSummarized = true,
+      expectedDiagnosticMode = DiagnosticMode.NONE)
   }
 
   @Test
@@ -550,7 +566,8 @@ class DriverIntegTest extends SparkTestUtils with TestTemplateWithTmpDir {
       expectedStages = Array(DriverStage.INIT, DriverStage.PREPROCESSED, DriverStage.TRAINED),
       expectedNumFeatures = EXPECTED_NUM_FEATURES,
       expectedNumTrainingData = EXPECTED_NUM_TRAINING_DATA,
-      expectedIsSummarized = true)
+      expectedIsSummarized = true,
+      expectedDiagnosticMode = DiagnosticMode.NONE)
 
     val models = loadAllModels(new Path(outputDir, Driver.LEARNED_MODELS_TEXT).toString)
     assertEquals(models.length, defaultParams.regularizationWeights.length)
@@ -584,11 +601,11 @@ class DriverIntegTest extends SparkTestUtils with TestTemplateWithTmpDir {
         DriverStage.INIT,
         DriverStage.PREPROCESSED,
         DriverStage.TRAINED,
-        DriverStage.VALIDATED,
-        DriverStage.DIAGNOSED),
+        DriverStage.VALIDATED),
       expectedNumFeatures = EXPECTED_NUM_FEATURES,
       expectedNumTrainingData = EXPECTED_NUM_TRAINING_DATA,
-      expectedIsSummarized = true)
+      expectedIsSummarized = true,
+      expectedDiagnosticMode = DiagnosticMode.NONE)
 
     val models = loadAllModels(new Path(outputDir, Driver.LEARNED_MODELS_TEXT).toString)
     assertEquals(models.length, defaultParams.regularizationWeights.length)
@@ -603,8 +620,7 @@ class DriverIntegTest extends SparkTestUtils with TestTemplateWithTmpDir {
   }
 
   @Test
-  def testRunWithDataValidationPerIteration(): Unit = sparkTest(
-    "testRunWithDataValidationPerIteration") {
+  def testRunWithDataValidationPerIteration(): Unit = sparkTest("testRunWithDataValidationPerIteration") {
     val outputDir = getTmpDir + "/testRunWithDataValidationPerIteration"
     val args = mutable.ArrayBuffer[String]()
     appendCommonJobArgs(args, outputDir, isValidating = true)
@@ -621,11 +637,11 @@ class DriverIntegTest extends SparkTestUtils with TestTemplateWithTmpDir {
         DriverStage.INIT,
         DriverStage.PREPROCESSED,
         DriverStage.TRAINED,
-        DriverStage.VALIDATED,
-        DriverStage.DIAGNOSED),
+        DriverStage.VALIDATED),
       expectedNumFeatures = EXPECTED_NUM_FEATURES,
       expectedNumTrainingData = EXPECTED_NUM_TRAINING_DATA,
-      expectedIsSummarized = false)
+      expectedIsSummarized = false,
+      expectedDiagnosticMode = DiagnosticMode.NONE)
 
     val models = loadAllModels(new Path(outputDir, Driver.LEARNED_MODELS_TEXT).toString)
     assertEquals(models.length, defaultParams.regularizationWeights.length)
@@ -669,11 +685,11 @@ class DriverIntegTest extends SparkTestUtils with TestTemplateWithTmpDir {
         DriverStage.INIT,
         DriverStage.PREPROCESSED,
         DriverStage.TRAINED,
-        DriverStage.VALIDATED,
-        DriverStage.DIAGNOSED),
+        DriverStage.VALIDATED),
       expectedNumFeatures = EXPECTED_NUM_FEATURES,
       expectedNumTrainingData = EXPECTED_NUM_TRAINING_DATA,
-      expectedIsSummarized = false)
+      expectedIsSummarized = false,
+      expectedDiagnosticMode = DiagnosticMode.NONE)
   }
 
   @DataProvider
@@ -699,9 +715,14 @@ class DriverIntegTest extends SparkTestUtils with TestTemplateWithTmpDir {
     (for (m <- models; r <- regularizations) yield {
       (m._1, m._2._1, m._2._2, r._1, r._2._1, r._2._2, m._2._3, m._2._4)
     }).map { case (taskType, trainData, testData, regType, optimType, lambdas, numDim, numSamp) =>
-      val trainEnabled = TaskType.SMOOTHED_HINGE_LOSS_LINEAR_SVM != taskType
+      val diagnosticMode =
+        if (TaskType.SMOOTHED_HINGE_LOSS_LINEAR_SVM != taskType) {
+          DiagnosticMode.ALL
+        } else {
+          DiagnosticMode.NONE
+        }
 
-      val outputDir = s"${taskType}_${regType}_$trainEnabled"
+      val outputDir = s"${taskType}_${regType}_$diagnosticMode"
 
       val args = mutable.ArrayBuffer[String]()
       args += CommonTestUtils.fromOptionNameToArg(TOLERANCE_OPTION)
@@ -744,8 +765,8 @@ class DriverIntegTest extends SparkTestUtils with TestTemplateWithTmpDir {
       args += outputDir + "/summary"
       args += CommonTestUtils.fromOptionNameToArg(NORMALIZATION_TYPE)
       args += NormalizationType.STANDARDIZATION.toString
-      args += CommonTestUtils.fromOptionNameToArg(TRAINING_DIAGNOSTICS)
-      args += trainEnabled.toString
+      args += CommonTestUtils.fromOptionNameToArg(DIAGNOSTIC_MODE)
+      args += diagnosticMode.toString
       Array(outputDir, args.toArray, numDim, numSamp)
     }.toArray
   }
@@ -767,7 +788,61 @@ class DriverIntegTest extends SparkTestUtils with TestTemplateWithTmpDir {
         DriverStage.DIAGNOSED),
       expectedNumFeatures = numFeatures,
       expectedNumTrainingData = numTrainingSamples,
-      expectedIsSummarized = true)
+      expectedIsSummarized = true,
+      expectedDiagnosticMode = DiagnosticMode.ALL)
+  }
+
+  @Test
+  def testTrainOnlyDiagnostic(): Unit = sparkTest("testTrainOnlyDiagnostic") {
+
+    val outputDir = getTmpDir + "/testTrainOnlyDiagnostic"
+    val args = mutable.ArrayBuffer[String]()
+    appendCommonJobArgs(args, outputDir)
+
+    args += CommonTestUtils.fromOptionNameToArg(DIAGNOSTIC_MODE)
+    args += DiagnosticMode.TRAIN.toString
+    args += CommonTestUtils.fromOptionNameToArg(MAX_NUM_ITERATIONS_OPTION)
+    args += LIGHT_MAX_NUM_ITERATIONS.toString
+
+    MockDriver.runLocally(
+      args = args.toArray,
+      sparkContext = sc,
+      expectedStages = Array(
+        DriverStage.INIT,
+        DriverStage.PREPROCESSED,
+        DriverStage.TRAINED,
+        DriverStage.DIAGNOSED),
+      expectedNumFeatures = EXPECTED_NUM_FEATURES,
+      expectedNumTrainingData = EXPECTED_NUM_TRAINING_DATA,
+      expectedIsSummarized = false,
+      expectedDiagnosticMode = DiagnosticMode.TRAIN)
+  }
+
+  @Test
+  def testValidateOnlyDiagnostic(): Unit = sparkTest("testValidateOnlyDiagnostic") {
+
+    val outputDir = getTmpDir + "/testValidateOnlyDiagnostic"
+    val args = mutable.ArrayBuffer[String]()
+    appendCommonJobArgs(args, outputDir, isValidating = true)
+
+    args += CommonTestUtils.fromOptionNameToArg(DIAGNOSTIC_MODE)
+    args += DiagnosticMode.VALIDATE.toString
+    args += CommonTestUtils.fromOptionNameToArg(MAX_NUM_ITERATIONS_OPTION)
+    args += LIGHT_MAX_NUM_ITERATIONS.toString
+
+    MockDriver.runLocally(
+      args = args.toArray,
+      sparkContext = sc,
+      expectedStages = Array(
+        DriverStage.INIT,
+        DriverStage.PREPROCESSED,
+        DriverStage.TRAINED,
+        DriverStage.VALIDATED,
+        DriverStage.DIAGNOSED),
+      expectedNumFeatures = EXPECTED_NUM_FEATURES,
+      expectedNumTrainingData = EXPECTED_NUM_TRAINING_DATA,
+      expectedIsSummarized = false,
+      expectedDiagnosticMode = DiagnosticMode.VALIDATE)
   }
 }
 

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/OptionNames.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/OptionNames.scala
@@ -44,11 +44,14 @@ object OptionNames {
   val COEFFICIENT_BOX_CONSTRAINTS = "coefficient-box-constraints"
   val DATA_VALIDATION_TYPE = "data-validation-type"
   val TREE_AGGREGATE_DEPTH = "tree-aggregate-depth"
-  val TRAINING_DIAGNOSTICS = "training-diagnostics"
+  val DIAGNOSTIC_MODE = "diagnostic-mode"
   val SELECTED_FEATURES_FILE = "selected-features-file"
 
   val OFFHEAP_INDEXMAP_DIR = "offheap-indexmap-dir"
   val OFFHEAP_INDEXMAP_NUM_PARTITIONS = "offheap-indexmap-num-partitions"
 
   val DELETE_OUTPUT_DIRS_IF_EXIST = "delete-output-dirs-if-exist"
+
+  @deprecated
+  val TRAINING_DIAGNOSTICS = "training-diagnostics"
 }

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/Params.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/Params.scala
@@ -16,6 +16,9 @@ package com.linkedin.photon.ml
 
 
 import com.linkedin.photon.ml.DataValidationType._
+import com.linkedin.photon.ml.OptionNames._
+import com.linkedin.photon.ml.diagnostics.DiagnosticMode
+import com.linkedin.photon.ml.diagnostics.DiagnosticMode.DiagnosticMode
 import com.linkedin.photon.ml.io.FieldNamesType._
 import com.linkedin.photon.ml.normalization.NormalizationType
 import com.linkedin.photon.ml.optimization.OptimizerType._
@@ -133,10 +136,10 @@ class Params {
    */
   var constraintString: Option[String] = None
   /**
-   * Control whether training diagnostics like bootstrapping, etc. should be run. Since these
-   * tend to be more computationally demanding, this should default to false.
+   * Control the running mode for diagnostics. Examples include training diagnostics like bootstrapping, and validating
+   * diagnostics like Hosmer-Lemeshow diagnostic.
    */
-  var trainingDiagnosticsEnabled: Boolean = false
+  var diagnosticMode: DiagnosticMode = DiagnosticMode.NONE
   /**
    * A file containing selected features. The file is expected to contain avro records that have
    * the "name" and "term" fields
@@ -171,6 +174,11 @@ class Params {
     if (normalizationType == NormalizationType.STANDARDIZATION && !addIntercept) {
       messages += s"Intercept must be used to enable feature standardization. Normalization type: " +
                   s"$normalizationType, add intercept: $addIntercept."
+    }
+    if (validateDirOpt.isEmpty && (diagnosticMode == DiagnosticMode.VALIDATE || diagnosticMode == DiagnosticMode.ALL)) {
+      messages += s"Diagnostic mode cannot be $diagnosticMode when the validate directory is not specified. " +
+        s"Try ${DiagnosticMode.TRAIN} or ${DiagnosticMode.NONE} or " +
+          s"please specify the validate directory through $VALIDATE_DIR_OPTION"
     }
     if (messages.nonEmpty) {
       throw new IllegalArgumentException(messages.mkString("\n"))

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/diagnostics/DiagnosticMode.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/diagnostics/DiagnosticMode.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2016 LinkedIn Corp. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linkedin.photon.ml.diagnostics
+
+/**
+ * Supported options for model diagnostic.
+ */
+object DiagnosticMode extends Enumeration {
+  type DiagnosticMode = Value
+  val ALL, TRAIN, VALIDATE, NONE = Value
+}

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/diagnostics/reporting/reports/model/ModelDiagnosticReport.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/diagnostics/reporting/reports/model/ModelDiagnosticReport.scala
@@ -59,10 +59,10 @@ case class ModelDiagnosticReport[GLM <: GeneralizedLinearModel](
     val nameIdxMap: Map[String, Int],
     val metrics: Map[String, Double],
     val summary: Option[BasicStatisticalSummary],
-    val predictionErrorIndependence: PredictionErrorIndependenceReport,
+    val predictionErrorIndependence: Option[PredictionErrorIndependenceReport],
     var hosmerLemeshow: Option[HosmerLemeshowReport],
-    val meanImpactFeatureImportance:FeatureImportanceReport,
-    val varianceImpactFeatureImportance:FeatureImportanceReport,
+    val meanImpactFeatureImportance: Option[FeatureImportanceReport],
+    val varianceImpactFeatureImportance: Option[FeatureImportanceReport],
     val fitReport:Option[FittingReport],
     val bootstrapReport:Option[BootstrapReport])
   extends LogicalReport

--- a/photon-ml/src/test/scala/com/linkedin/photon/ml/PhotonMLCmdLineParserTest.scala
+++ b/photon-ml/src/test/scala/com/linkedin/photon/ml/PhotonMLCmdLineParserTest.scala
@@ -15,6 +15,7 @@
 package com.linkedin.photon.ml
 
 import com.linkedin.photon.ml.OptionNames._
+import com.linkedin.photon.ml.diagnostics.DiagnosticMode
 import com.linkedin.photon.ml.io.FieldNamesType
 import com.linkedin.photon.ml.normalization.NormalizationType
 import com.linkedin.photon.ml.optimization.{OptimizerType, RegularizationType}
@@ -224,6 +225,35 @@ class PhotonMLCmdLineParserTest {
     )
     PhotonMLCmdLineParser.parseFromCommandLine(requiredArgs() ++ args)
   }
+
+  @Test(expectedExceptions = Array(classOf[IllegalArgumentException]))
+  def testDiagnosticModeBeingALLWhenNoValidateDirSpecified(): Unit = {
+    val args = Array(
+      CommonTestUtils.fromOptionNameToArg(DIAGNOSTIC_MODE),
+      DiagnosticMode.ALL.toString
+    )
+    PhotonMLCmdLineParser.parseFromCommandLine(requiredArgs() ++ args)
+  }
+
+  @Test(expectedExceptions = Array(classOf[IllegalArgumentException]))
+  def testDiagnosticModeBeingValidateWhenNoValidateDirSpecified(): Unit = {
+    val args = Array(
+      CommonTestUtils.fromOptionNameToArg(DIAGNOSTIC_MODE),
+      DiagnosticMode.VALIDATE.toString
+    )
+    PhotonMLCmdLineParser.parseFromCommandLine(requiredArgs() ++ args)
+  }
+
+  @Test(expectedExceptions = Array(classOf[IllegalArgumentException]))
+  def testDiagnosticModeAndTrainDiagnosticsBothSpecified(): Unit = {
+    val args = Array(
+      CommonTestUtils.fromOptionNameToArg(DIAGNOSTIC_MODE),
+      DiagnosticMode.NONE.toString,
+      CommonTestUtils.fromOptionNameToArg(TRAINING_DIAGNOSTICS),
+      "false"
+    )
+    PhotonMLCmdLineParser.parseFromCommandLine(requiredArgs() ++ args)
+  }
 }
 
 object PhotonMLCmdLineParserTest {
@@ -245,7 +275,8 @@ object PhotonMLCmdLineParserTest {
     SUMMARIZATION_OUTPUT_DIR,
     NORMALIZATION_TYPE,
     COEFFICIENT_BOX_CONSTRAINTS,
-    TREE_AGGREGATE_DEPTH
+    TREE_AGGREGATE_DEPTH,
+    DIAGNOSTIC_MODE
   )
 
   // Boolean options are unary instead of binary options
@@ -253,8 +284,7 @@ object PhotonMLCmdLineParserTest {
     INTERCEPT_OPTION,
     KRYO_OPTION,
     VALIDATE_PER_ITERATION,
-    OPTIMIZATION_STATE_TRACKER_OPTION,
-    TRAINING_DIAGNOSTICS
+    OPTIMIZATION_STATE_TRACKER_OPTION
   )
 
   val constraintString =
@@ -299,6 +329,7 @@ object PhotonMLCmdLineParserTest {
         case NORMALIZATION_TYPE => NormalizationType.NONE.toString
         case COEFFICIENT_BOX_CONSTRAINTS => constraintString
         case TREE_AGGREGATE_DEPTH => 2.toString
+        case DIAGNOSTIC_MODE => DiagnosticMode.NONE.toString
         case _ => "dummy-value"
       }
       i += 2

--- a/photon-ml/src/test/scala/com/linkedin/photon/ml/diagnostics/DiagnosticStatus.scala
+++ b/photon-ml/src/test/scala/com/linkedin/photon/ml/diagnostics/DiagnosticStatus.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2016 LinkedIn Corp. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linkedin.photon.ml.diagnostics
+
+import com.linkedin.photon.ml.diagnostics.DiagnosticMode._
+
+/**
+ * A compact representation of the model diagnostic status
+ *
+ * @param trainDiagnosed Whether model training is diagnosed
+ * @param validateDiagnosed Whether model  with validation data
+ */
+protected[ml] case class DiagnosticStatus(var trainDiagnosed: Boolean, var validateDiagnosed: Boolean) {
+
+  /**
+   * Get the diagnostic mode based on the current diagnostic status
+   *
+   * @return The diagnostic mode
+   */
+  def getDiagnosticMode: DiagnosticMode = {
+    if (trainDiagnosed && validateDiagnosed) {
+      DiagnosticMode.ALL
+    } else if (trainDiagnosed) {
+      DiagnosticMode.TRAIN
+    } else if (validateDiagnosed) {
+      DiagnosticMode.VALIDATE
+    } else {
+      DiagnosticMode.NONE
+    }
+  }
+}

--- a/photon-ml/src/test/scala/com/linkedin/photon/ml/diagnostics/DiagnosticStatusTest.scala
+++ b/photon-ml/src/test/scala/com/linkedin/photon/ml/diagnostics/DiagnosticStatusTest.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2016 LinkedIn Corp. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linkedin.photon.ml.diagnostics
+
+import org.testng.annotations.Test
+import org.testng.Assert.assertEquals
+
+/**
+ * Simple tests for [[DiagnosticStatus]]
+ */
+class DiagnosticStatusTest {
+  @Test
+  def testGetDiagnosticMode(): Unit = {
+    val diagnosticStatus = DiagnosticStatus(trainDiagnosed = false, validateDiagnosed = false)
+    assertEquals(diagnosticStatus.getDiagnosticMode, DiagnosticMode.NONE)
+    diagnosticStatus.trainDiagnosed = true
+    diagnosticStatus.validateDiagnosed = false
+    assertEquals(diagnosticStatus.getDiagnosticMode, DiagnosticMode.TRAIN)
+    diagnosticStatus.trainDiagnosed = false
+    diagnosticStatus.validateDiagnosed = true
+    assertEquals(diagnosticStatus.getDiagnosticMode, DiagnosticMode.VALIDATE)
+    diagnosticStatus.trainDiagnosed = true
+    diagnosticStatus.validateDiagnosed = true
+    assertEquals(diagnosticStatus.getDiagnosticMode, DiagnosticMode.ALL)
+  }
+}


### PR DESCRIPTION
This PR addresses issue #118 by allowing the users to specify which mode (all, none, train, validate) of diagnostic is needed in Photon's driver.

In order to achieve this goal, some refactoring is also done for the diagnostics module in Photon.

One interesting side-effect of this PR I observed is that, the integTest runtime got further reduced (issue #19) due to the more fine grained control over model diagnostic. And after this PR, it is expected that the overall runtime of Photon's GLM model training will also be reduced if the diagnostic mode is chosen to better reflect the user's need.

This PR also addresses an internal issue ML-1273.