### PR TITLE
Remove extra calculation of feature number

### DIFF
--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/Driver.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/Driver.scala
@@ -202,7 +202,7 @@ protected[ml] class Driver(
       .readLabeledPointsFromAvro(sc, params.trainDir, params.selectedFeaturesFile, params.minNumPartitions)
       .persist(trainDataStorageLevel)
       .setName("training data")
-    featureNum = trainingData.first().features.size
+
     trainingDataNum = trainingData.count().toInt
     require(trainingDataNum > 0,
       "No training data found. Ensure that training data exists and feature vectors are not empty.")


### PR DESCRIPTION
The same line appears 5 lines below here. This duplicate was causing a
bug where we call "trainingData.first()" before checking whether
"trainingData" is empty.