### PR TITLE
Add L1 and Elastic Net regularization terms to getRegularizationTermV…

### DIFF
--- a/photon-ml/src/test/scala/com/linkedin/photon/ml/optimization/GeneralizedLinearOptimizationProblemTest.scala
+++ b/photon-ml/src/test/scala/com/linkedin/photon/ml/optimization/GeneralizedLinearOptimizationProblemTest.scala
@@ -20,9 +20,11 @@ import com.linkedin.photon.ml.model.Coefficients
 import com.linkedin.photon.ml.normalization.NormalizationContext
 import com.linkedin.photon.ml.sampler.DownSampler
 import com.linkedin.photon.ml.supervised.model.{GeneralizedLinearModel, ModelTracker}
+import com.linkedin.photon.ml.supervised.classification.LogisticRegressionModel
 import com.linkedin.photon.ml.test.CommonTestUtils
 
 import breeze.linalg.Vector
+import breeze.linalg.sum
 import org.apache.spark.rdd.RDD
 import org.mockito.Matchers
 import org.mockito.Mockito._
@@ -30,6 +32,7 @@ import org.testng.Assert._
 import org.testng.annotations.Test
 
 import scala.collection.mutable
+import scala.math.abs
 
 class GeneralizedLinearOptimizationProblemTest {
   import GeneralizedLinearOptimizationProblemTest._
@@ -37,7 +40,7 @@ class GeneralizedLinearOptimizationProblemTest {
 
   @Test
   def testRun(): Unit = {
-    val (problem, optimizer, objectiveFunction) = createProblem
+    val (problem, optimizer, objectiveFunction) = createProblem()
 
     val dim = 10
     val data = mock(classOf[RDD[LabeledPoint]])
@@ -62,15 +65,41 @@ class GeneralizedLinearOptimizationProblemTest {
     assertEquals(coefficients, model.coefficients)
     assertEquals(problem.getModelTracker.get.length, 1)
   }
+
+  @Test
+  def testGetRegularizationTermValue: Unit = {
+    val epsilon = 1E-5D
+    val dim = 10
+    val regWeight = 0.8
+    val alpha = 0.25
+    val coefficients = new Coefficients(generateDenseVector(dim))
+    val simpleModel = new LogisticRegressionModel(coefficients)
+
+    val expectedL1Term = sum(coefficients.means.map(abs)) * regWeight
+    val expectedL2Term = coefficients.means.dot(coefficients.means) * regWeight / 2.0
+    val expectedElasticNetTerm = alpha * expectedL1Term + (1 - alpha) * expectedL2Term
+
+    val (withL1, _, _) = createProblem(L1RegularizationContext, regWeight)
+    assertEquals(expectedL1Term, withL1.getRegularizationTermValue(simpleModel), epsilon)
+
+    val(withL2, _, _) = createProblem(L2RegularizationContext, regWeight)
+    assertEquals(expectedL2Term, withL2.getRegularizationTermValue(simpleModel), epsilon)
+
+    val ElasticNetRegularizationContext = new RegularizationContext(RegularizationType.ELASTIC_NET, Some(alpha))
+    val(withElasticNet, _, _) = createProblem(ElasticNetRegularizationContext, regWeight)
+    assertEquals(expectedElasticNetTerm, withElasticNet.getRegularizationTermValue(simpleModel), epsilon)
+
+    val(withNoReg, _, _) = createProblem(NoRegularizationContext, regWeight)
+    assertEquals(0.0, withNoReg.getRegularizationTermValue(simpleModel), epsilon)
+  }
 }
 
 object GeneralizedLinearOptimizationProblemTest {
-  def createProblem() = {
+  def createProblem(regularizationContext: RegularizationContext = mock(classOf[RegularizationContext]),
+      regularizationWeight: Double = 0D) = {
     val optimizer = mock(classOf[Optimizer[LabeledPoint, TwiceDiffFunction[LabeledPoint]]])
     val sampler = mock(classOf[DownSampler])
     val objectiveFunction = mock(classOf[TwiceDiffFunction[LabeledPoint]])
-    val regularizationContext = mock(classOf[RegularizationContext])
-    val regularizationWeight = 0D
     val modelTrackerBuilder = Some(new mutable.ListBuffer[ModelTracker]())
     val treeAggregateDepth = 1
     val isComputingVariances: Boolean = false


### PR DESCRIPTION
This is a potential fix for https://github.com/linkedin/photon-ml/issues/129.

Originally, the getRegularizationTermValue always returned the L2 regularization term. 

