### PR TITLE
Issue#156: allowing randomEffectId fetching in metadatMap as an option

### DIFF
--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/avro/AvroFieldNames.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/avro/AvroFieldNames.scala
@@ -25,4 +25,5 @@ object AvroFieldNames {
   protected[avro] val OFFSET: String = "offset"
   protected[avro] val WEIGHT: String = "weight"
   protected[avro] val UID: String = "uid"
+  protected[avro] val META_DATA_MAP: String = "metadataMap"
 }

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/util/Utils.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/util/Utils.scala
@@ -127,6 +127,24 @@ protected[ml] object Utils {
   }
 
   /**
+    * Fetch the java map from an Avro map field.
+    *
+    * @param record The Avro generic record
+    * @param key The field key
+    * @return A java map of String -> Object
+    */
+  def getMapAvro(
+      record: GenericRecord,
+      key: String,
+      isNullOK: Boolean = false): java.util.Map[String, JObject] = {
+    record.get(key) match {
+      case map: java.util.Map[String, JObject] => map
+      case obj: JObject => throw new IllegalArgumentException(s"$obj is not map type.")
+      case _ => if (isNullOK) null else throw new IllegalArgumentException(s"field $key is null")
+    }
+  }
+
+  /**
     * Parse String to Double
     */
   private def atod(string: String): Double = {

--- a/photon-ml/src/test/scala/com/linkedin/photon/ml/avro/data/DataProcessingUtilsTest.scala
+++ b/photon-ml/src/test/scala/com/linkedin/photon/ml/avro/data/DataProcessingUtilsTest.scala
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2016 LinkedIn Corp. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linkedin.photon.ml.avro.data
+
+import com.linkedin.photon.ml.avro.AvroFieldNames
+import org.apache.avro.SchemaBuilder
+import org.apache.avro.generic.GenericData
+import org.testng.annotations.Test
+import org.testng.Assert._
+
+/**
+  * This class tests the DataProcessingUtils.
+  *
+  * @see [[com.linkedin.photon.ml.avro.data.DataProcessingUtils]]
+  */
+class DataProcessingUtilsTest {
+
+  @Test
+  def testMakeRandomEffectIdMapWithIdField(): Unit = {
+    val record = new GenericData.Record(SchemaBuilder
+      .record("testRecordForRandomIdFetch1")
+      .namespace("com.linkedin.photon.ml.avro.data")
+      .fields()
+      .name("userId").`type`().stringType().noDefault()
+      .name("jobId").`type`().longType().noDefault()
+      .endRecord())
+
+    record.put("userId", "11A")
+    record.put("jobId", 112L)
+    val map1 = DataProcessingUtils.makeRandomEffectIdMap(record, Set[String]("userId"))
+    assertEquals(map1.size, 1)
+    assertEquals(map1("userId"), "11A")
+
+    val map2 = DataProcessingUtils.makeRandomEffectIdMap(record, Set[String]("userId", "jobId"))
+    assertEquals(map2.size, 2)
+    assertEquals(map2("userId"), "11A")
+    assertEquals(map2("jobId"), "112")
+  }
+
+  @Test
+  def testMakeRandomEffectIdMapWithMetadataMap(): Unit = {
+    val record = new GenericData.Record(SchemaBuilder
+      .record("testRecordForRandomIdFetch2")
+      .namespace("com.linkedin.photon.ml.avro.data")
+      .fields()
+      .name(AvroFieldNames.META_DATA_MAP).`type`().map().values().stringType().noDefault()
+      .endRecord())
+
+    val map = new java.util.HashMap[String, String]()
+    map.put("userId", "11A")
+    map.put("jobId", "112")
+    record.put(AvroFieldNames.META_DATA_MAP, map)
+
+    val res = DataProcessingUtils.makeRandomEffectIdMap(record, Set[String]("userId"))
+    assertEquals(res.size, 1)
+    assertEquals(res("userId"), "11A")
+
+    val res2 = DataProcessingUtils.makeRandomEffectIdMap(record, Set[String]("userId", "jobId"))
+    assertEquals(res2.size, 2)
+    assertEquals(res2("userId"), "11A")
+    assertEquals(res2("jobId"), "112")
+  }
+
+  @Test
+  def testMakeRandomEffectIdMapWithBothFields(): Unit = {
+    // Expecting 1st layer fields override the metadataMap fields
+
+    val record = new GenericData.Record(SchemaBuilder
+      .record("testRecordForRandomIdFetch3")
+      .namespace("com.linkedin.photon.ml.avro.data")
+      .fields()
+      .name(AvroFieldNames.META_DATA_MAP).`type`().map().values().stringType().noDefault()
+      .name("userId").`type`().stringType().noDefault()
+      .name("jobId").`type`().longType().noDefault()
+      .endRecord())
+
+    record.put("userId", "11B")
+    record.put("jobId", 113L)
+
+    val map = new java.util.HashMap[String, String]()
+    map.put("userId", "11A")
+    map.put("jobId", "112")
+    record.put(AvroFieldNames.META_DATA_MAP, map)
+
+    val res = DataProcessingUtils.makeRandomEffectIdMap(record, Set[String]("userId"))
+    assertEquals(res.size, 1)
+    assertEquals(res("userId"), "11B")
+
+    val res2 = DataProcessingUtils.makeRandomEffectIdMap(record, Set[String]("userId", "jobId"))
+    assertEquals(res2.size, 2)
+    assertEquals(res2("userId"), "11B")
+    assertEquals(res2("jobId"), "113")
+  }
+
+  @Test
+  def testNoRandomEffectIdAtAll(): Unit = {
+    // Excepting the method to still proceed but return an empty map
+
+    val emptyRecord = new GenericData.Record(SchemaBuilder
+      .record("testRecordForRandomIdFetch3")
+      .namespace("com.linkedin.photon.ml.avro.data")
+      .fields()
+      .name(AvroFieldNames.META_DATA_MAP).`type`().map().values().stringType().noDefault()
+      .name("foo").`type`().stringType().noDefault()
+      .endRecord())
+
+    assertTrue(DataProcessingUtils.makeRandomEffectIdMap(emptyRecord, Set[String]()).isEmpty)
+  }
+
+  @Test(expectedExceptions = Array(classOf[IllegalArgumentException]))
+  def testMakeRandomEffectIdMapWithMissingField(): Unit = {
+    // Expecting errors to be raised since nothing is present
+
+    val emptyRecord = new GenericData.Record(SchemaBuilder
+      .record("testRecordForRandomIdFetch3")
+      .namespace("com.linkedin.photon.ml.avro.data")
+      .fields()
+      .name(AvroFieldNames.META_DATA_MAP).`type`().map().values().stringType().noDefault()
+      .name("foo").`type`().stringType().noDefault()
+      .endRecord())
+
+    DataProcessingUtils.makeRandomEffectIdMap(emptyRecord, Set[String]("userId"))
+  }
+}


### PR DESCRIPTION
This change will allow randomEffectId fetching to fall back to metadataMap if
a key is not present in the Avro field directly. This will make the Avro schema
a bit more flexible in the sense that users won't necessarily to change Avro
schema definition when changing the set of ids provided for training.

Addressing #156 , I modified `Utils` and added corresponding tests for reading a map. Could anyone help point me to the doc location for explaining the Avro input format, I didn't find it's explained in param parser? ...

to: @joshvfleming @XianXing @ashelkovnykov 

**Another thing:**
I'd like to introduce @jq (Julian Qian) to everyone. He is my current colleague at Airbnb Pricing team. We are starting on some experiments using Photon GAME in our models; things are still at an early stage and we have not laid out a clear plan yet. But generally speaking, we are foreseeing some changes might be needed to carry out in:
  * data formatting/conversion;
  * parameter configuration;
  * diff function and optimizer interfacing (cz. our problem is a regression problem and most likely we need to develop customized objective function implementations) and etc.

Although the internal customized modeling details might not be a good fit for PhotonML's purpose. We'd like to contribute generally useful functions to Photon ML as much as possible. Please bare with us that we might frequently file issues, start discussions or sending out PRs. 

Ps: [here](https://github.com/airbnb/aerosolve/pull/236) is a recent data conversion job we added into aerosolve library allowing us to converting aerosolve style of inputs (with transformations) into Photon GAME format.