### PR TITLE
Add precision@K to GAME, and address some related issues.

### DIFF
--- a/photon-ml/src/integTest/scala/com/linkedin/photon/ml/avro/ScoreProcessingUtilsTest.scala
+++ b/photon-ml/src/integTest/scala/com/linkedin/photon/ml/avro/ScoreProcessingUtilsTest.scala
@@ -27,22 +27,22 @@ class ScoreProcessingUtilsTest extends SparkTestUtils with TestTemplateWithTmpDi
   @DataProvider
   def scoredItemsProvider():Array[Array[Any]] = {
     val completeScoreItems = Array(
-      ScoredItem(predictionScore = 1.0, label = Some(1.0), idTypeToValueMap = Map("id1" -> "1", "id2" -> "2")),
-      ScoredItem(predictionScore = 0.0, label = Some(0.0), idTypeToValueMap = Map("id1" -> "3", "id2" -> "4")),
-      ScoredItem(predictionScore = 0.5, label = Some(0.5), idTypeToValueMap = Map("id1" -> "5", "id2" -> "6")),
-      ScoredItem(predictionScore = -1.0, label = Some(-0.5), idTypeToValueMap = Map("id1" -> "7", "id2" -> "8"))
+      ScoredItem(predictionScore = 1.0, label = Some(1.0), idTypeToValueMap = Map("uid" -> "1", "id2" -> "2")),
+      ScoredItem(predictionScore = 0.0, label = Some(0.0), idTypeToValueMap = Map("uid" -> "3", "id2" -> "4")),
+      ScoredItem(predictionScore = 0.5, label = Some(0.5), idTypeToValueMap = Map("uid" -> "5", "id2" -> "6")),
+      ScoredItem(predictionScore = -1.0, label = Some(-0.5), idTypeToValueMap = Map("uid" -> "7", "id2" -> "8"))
     )
     val scoredItemsWithoutUid = Array(
-      ScoredItem(predictionScore = 1.0, label = Some(1.0), idTypeToValueMap = Map("id1" -> "1", "id2" -> "2")),
-      ScoredItem(predictionScore = 0.0, label = Some(0.0), idTypeToValueMap = Map("id1" -> "3", "id2" -> "4")),
-      ScoredItem(predictionScore = 0.5, label = Some(0.5), idTypeToValueMap = Map("id1" -> "5", "id2" -> "6")),
-      ScoredItem(predictionScore = -1.0, label = Some(-0.5), idTypeToValueMap = Map("id1" -> "7", "id2" -> "8"))
+      ScoredItem(predictionScore = 1.0, label = Some(1.0), idTypeToValueMap = Map("id2" -> "2")),
+      ScoredItem(predictionScore = 0.0, label = Some(0.0), idTypeToValueMap = Map("id2" -> "4")),
+      ScoredItem(predictionScore = 0.5, label = Some(0.5), idTypeToValueMap = Map("id2" -> "6")),
+      ScoredItem(predictionScore = -1.0, label = Some(-0.5), idTypeToValueMap = Map("id2" -> "8"))
     )
     val scoredItemsWithoutLabel = Array(
-      ScoredItem(predictionScore = 1.0, label = None, idTypeToValueMap = Map("id1" -> "1", "id2" -> "2")),
-      ScoredItem(predictionScore = 0.0, label = None, idTypeToValueMap = Map("id1" -> "3", "id2" -> "4")),
-      ScoredItem(predictionScore = 0.5, label = None, idTypeToValueMap = Map("id1" -> "5", "id2" -> "6")),
-      ScoredItem(predictionScore = -1.0, label = None, idTypeToValueMap = Map("id1" -> "7", "id2" -> "8"))
+      ScoredItem(predictionScore = 1.0, label = None, idTypeToValueMap = Map("uid" -> "1", "id2" -> "2")),
+      ScoredItem(predictionScore = 0.0, label = None, idTypeToValueMap = Map("uid" -> "3", "id2" -> "4")),
+      ScoredItem(predictionScore = 0.5, label = None, idTypeToValueMap = Map("uid" -> "5", "id2" -> "6")),
+      ScoredItem(predictionScore = -1.0, label = None, idTypeToValueMap = Map("uid" -> "7", "id2" -> "8"))
     )
     val scoredItemsWithScoreAndLabel = Array(
       ScoredItem(predictionScore = 1.0, label = Some(1.0), idTypeToValueMap = Map[String, String]()),
@@ -89,5 +89,10 @@ class ScoreProcessingUtilsTest extends SparkTestUtils with TestTemplateWithTmpDi
 
     // Same scored items
     assertEquals(loadedScoredItem.deep, scoredItems.deep)
+
+    // Same unique ids
+    val loadedUids = loadedScoredItem.map(_.idTypeToValueMap.get(DefaultFieldNames.UID))
+    val uids = scoredItems.map(_.idTypeToValueMap.get(DefaultFieldNames.UID))
+    assertEquals(loadedUids.deep, uids.deep)
   }
 }

--- a/photon-ml/src/integTest/scala/com/linkedin/photon/ml/avro/ScoreProcessingUtilsTest.scala
+++ b/photon-ml/src/integTest/scala/com/linkedin/photon/ml/avro/ScoreProcessingUtilsTest.scala
@@ -27,40 +27,40 @@ class ScoreProcessingUtilsTest extends SparkTestUtils with TestTemplateWithTmpDi
   @DataProvider
   def scoredItemsProvider():Array[Array[Any]] = {
     val completeScoreItems = Array(
-      ScoredItem(predictionScore = 1.0, uid = Some("1"), label = Some(1.0), ids = Map("id1" -> "1", "id2" -> "2")),
-      ScoredItem(predictionScore = 0.0, uid = Some("2"), label = Some(0.0), ids = Map("id1" -> "3", "id2" -> "4")),
-      ScoredItem(predictionScore = 0.5, uid = Some("3"), label = Some(0.5), ids = Map("id1" -> "5", "id2" -> "6")),
-      ScoredItem(predictionScore = -1.0, uid = Some("4"), label = Some(-0.5), ids = Map("id1" -> "7", "id2" -> "8"))
+      ScoredItem(predictionScore = 1.0, label = Some(1.0), idTypeToValueMap = Map("id1" -> "1", "id2" -> "2")),
+      ScoredItem(predictionScore = 0.0, label = Some(0.0), idTypeToValueMap = Map("id1" -> "3", "id2" -> "4")),
+      ScoredItem(predictionScore = 0.5, label = Some(0.5), idTypeToValueMap = Map("id1" -> "5", "id2" -> "6")),
+      ScoredItem(predictionScore = -1.0, label = Some(-0.5), idTypeToValueMap = Map("id1" -> "7", "id2" -> "8"))
     )
     val scoredItemsWithoutUid = Array(
-      ScoredItem(predictionScore = 1.0, uid = None, label = Some(1.0), ids = Map("id1" -> "1", "id2" -> "2")),
-      ScoredItem(predictionScore = 0.0, uid = None, label = Some(0.0), ids = Map("id1" -> "3", "id2" -> "4")),
-      ScoredItem(predictionScore = 0.5, uid = None, label = Some(0.5), ids = Map("id1" -> "5", "id2" -> "6")),
-      ScoredItem(predictionScore = -1.0, uid = None, label = Some(-0.5), ids = Map("id1" -> "7", "id2" -> "8"))
+      ScoredItem(predictionScore = 1.0, label = Some(1.0), idTypeToValueMap = Map("id1" -> "1", "id2" -> "2")),
+      ScoredItem(predictionScore = 0.0, label = Some(0.0), idTypeToValueMap = Map("id1" -> "3", "id2" -> "4")),
+      ScoredItem(predictionScore = 0.5, label = Some(0.5), idTypeToValueMap = Map("id1" -> "5", "id2" -> "6")),
+      ScoredItem(predictionScore = -1.0, label = Some(-0.5), idTypeToValueMap = Map("id1" -> "7", "id2" -> "8"))
     )
     val scoredItemsWithoutLabel = Array(
-      ScoredItem(predictionScore = 1.0, uid = Some("1"), label = None, ids = Map("id1" -> "1", "id2" -> "2")),
-      ScoredItem(predictionScore = 0.0, uid = Some("2"), label = None, ids = Map("id1" -> "3", "id2" -> "4")),
-      ScoredItem(predictionScore = 0.5, uid = Some("3"), label = None, ids = Map("id1" -> "5", "id2" -> "6")),
-      ScoredItem(predictionScore = -1.0, uid = Some("4"), label = None, ids = Map("id1" -> "7", "id2" -> "8"))
+      ScoredItem(predictionScore = 1.0, label = None, idTypeToValueMap = Map("id1" -> "1", "id2" -> "2")),
+      ScoredItem(predictionScore = 0.0, label = None, idTypeToValueMap = Map("id1" -> "3", "id2" -> "4")),
+      ScoredItem(predictionScore = 0.5, label = None, idTypeToValueMap = Map("id1" -> "5", "id2" -> "6")),
+      ScoredItem(predictionScore = -1.0, label = None, idTypeToValueMap = Map("id1" -> "7", "id2" -> "8"))
     )
     val scoredItemsWithScoreAndLabel = Array(
-      ScoredItem(predictionScore = 1.0, uid = None, label = Some(1.0), ids = Map[String, String]()),
-      ScoredItem(predictionScore = 0.0, uid = None, label = Some(0.0), ids = Map[String, String]()),
-      ScoredItem(predictionScore = 0.5, uid = None, label = Some(0.5), ids = Map[String, String]()),
-      ScoredItem(predictionScore = -1.0, uid = None, label = Some(-0.5), ids = Map[String, String]())
+      ScoredItem(predictionScore = 1.0, label = Some(1.0), idTypeToValueMap = Map[String, String]()),
+      ScoredItem(predictionScore = 0.0, label = Some(0.0), idTypeToValueMap = Map[String, String]()),
+      ScoredItem(predictionScore = 0.5, label = Some(0.5), idTypeToValueMap = Map[String, String]()),
+      ScoredItem(predictionScore = -1.0, label = Some(-0.5), idTypeToValueMap = Map[String, String]())
     )
     val scoredItemsWithoutIds = Array(
-      ScoredItem(predictionScore = 1.0, uid = Some("1"), label = Some(1.0), ids = Map[String, String]()),
-      ScoredItem(predictionScore = 0.0, uid = Some("2"), label = Some(0.0), ids = Map[String, String]()),
-      ScoredItem(predictionScore = 0.5, uid = Some("3"), label = Some(0.5), ids = Map[String, String]()),
-      ScoredItem(predictionScore = -1.0, uid = Some("4"), label = Some(-0.5), ids = Map[String, String]())
+      ScoredItem(predictionScore = 1.0, label = Some(1.0), idTypeToValueMap = Map[String, String]()),
+      ScoredItem(predictionScore = 0.0, label = Some(0.0), idTypeToValueMap = Map[String, String]()),
+      ScoredItem(predictionScore = 0.5, label = Some(0.5), idTypeToValueMap = Map[String, String]()),
+      ScoredItem(predictionScore = -1.0, label = Some(-0.5), idTypeToValueMap = Map[String, String]())
     )
     val scoredItemsWithOnlyScores = Array(
-      ScoredItem(predictionScore = 1.0, uid = None, label = None, ids = Map[String, String]()),
-      ScoredItem(predictionScore = 0.0, uid = None, label = None, ids = Map[String, String]()),
-      ScoredItem(predictionScore = 0.5, uid = None, label = None, ids = Map[String, String]()),
-      ScoredItem(predictionScore = -1.0, uid = None, label = None, ids = Map[String, String]())
+      ScoredItem(predictionScore = 1.0, label = None, idTypeToValueMap = Map[String, String]()),
+      ScoredItem(predictionScore = 0.0, label = None, idTypeToValueMap = Map[String, String]()),
+      ScoredItem(predictionScore = 0.5, label = None, idTypeToValueMap = Map[String, String]()),
+      ScoredItem(predictionScore = -1.0, label = None, idTypeToValueMap = Map[String, String]())
     )
     Array(
       Array("completeScoreItems", completeScoreItems),

--- a/photon-ml/src/integTest/scala/com/linkedin/photon/ml/evaluation/EvaluatorTest.scala
+++ b/photon-ml/src/integTest/scala/com/linkedin/photon/ml/evaluation/EvaluatorTest.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2016 LinkedIn Corp. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linkedin.photon.ml.evaluation
+
+import org.testng.Assert.assertEquals
+import org.testng.annotations.{DataProvider, Test}
+
+import com.linkedin.photon.ml.data.GameDatum
+import com.linkedin.photon.ml.test.SparkTestUtils
+
+class EvaluatorTest extends SparkTestUtils {
+
+  @DataProvider
+  def evaluatorTypeProvider(): Array[Array[Any]] = {
+    Array(
+      Array(AUC),
+      Array(RMSE),
+      Array(PoissonLoss),
+      Array(LogisticLoss),
+      Array(SmoothedHingeLoss),
+      Array(SquaredLoss),
+      Array(PrecisionAtK(1, EvaluatorTest.documentIdName)),
+      Array(PrecisionAtK(5, EvaluatorTest.documentIdName))
+    )
+  }
+
+  @Test(dataProvider = "evaluatorTypeProvider")
+  def testBuildEvaluator(evaluatorType: EvaluatorType): Unit = sparkTest("testBuildEvaluator") {
+    val gameDatum = new GameDatum(
+      response = 1.0,
+      offset = 0.0,
+      weight = 1.0,
+      featureShardContainer = Map(),
+      idTypeToValueMap = Map(EvaluatorTest.documentIdName -> "id"))
+    val gameDataSet = sc.parallelize(Seq((1L, gameDatum)))
+    val evaluator = Evaluator.buildEvaluator(evaluatorType, gameDataSet)
+    assertEquals(evaluator.getEvaluatorName, evaluatorType.name)
+  }
+}
+
+object EvaluatorTest {
+  val documentIdName = "documentIdName"
+}

--- a/photon-ml/src/integTest/scala/com/linkedin/photon/ml/evaluation/PrecisionAtKEvaluatorTest.scala
+++ b/photon-ml/src/integTest/scala/com/linkedin/photon/ml/evaluation/PrecisionAtKEvaluatorTest.scala
@@ -75,7 +75,7 @@ class PrecisionAtKEvaluatorTest extends SparkTestUtils {
     expectedResult: Double): Unit = sparkTest("testEvaluate") {
 
     val labelAndOffsetAndWeights = sc.parallelize(labels).mapValues((_, 0.0, 1.0))
-    val evaluator = new PrecisionAtKEvaluator(k, labelAndOffsetAndWeights, sc.parallelize(documentIds))
+    val evaluator = new PrecisionAtKEvaluator(k, labelAndOffsetAndWeights, sc.parallelize(documentIds), "")
     val actualResult = evaluator.evaluate(sc.parallelize(scores))
     assertEquals(actualResult, expectedResult, MathConst.MEDIUM_PRECISION_TOLERANCE_THRESHOLD)
   }

--- a/photon-ml/src/integTest/scala/com/linkedin/photon/ml/model/MatrixFactorizationModelTest.scala
+++ b/photon-ml/src/integTest/scala/com/linkedin/photon/ml/model/MatrixFactorizationModelTest.scala
@@ -67,7 +67,7 @@ class MatrixFactorizationModelTest extends SparkTestUtils {
       val colId = col.toString
       val randomEffectIdToIndividualIdMap = Map(rowEffectType -> rowId, colEffectType -> colId)
       val gameDatum = new GameDatum(response = 1.0, offset = 0.0, weight = 0.0, featureShardContainer = Map(),
-        randomEffectIdToIndividualIdMap = randomEffectIdToIndividualIdMap)
+        idTypeToValueMap = randomEffectIdToIndividualIdMap)
       val score = rowLatentFactors(row)._2.dot(colLatentFactors(col)._2)
       (gameDatum, score)
     }

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/algorithm/Coordinate.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/algorithm/Coordinate.scala
@@ -40,8 +40,9 @@ protected[ml] abstract class Coordinate[D <: DataSet[D], C <: Coordinate[D, C]](
     */
   protected[algorithm] def initializeModel(seed: Long): DatumScoringModel
 
-  protected[algorithm] def updateModel(model: DatumScoringModel, score: KeyValueScore)
-  : (DatumScoringModel, OptimizationTracker) = {
+  protected[algorithm] def updateModel(
+    model: DatumScoringModel,
+    score: KeyValueScore): (DatumScoringModel, OptimizationTracker) = {
 
     val dataSetWithUpdatedOffsets = dataSet.addScoresToOffsets(score)
     updateCoordinateWithDataSet(dataSetWithUpdatedOffsets).updateModel(model)

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/algorithm/Coordinate.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/algorithm/Coordinate.scala
@@ -40,7 +40,9 @@ protected[ml] abstract class Coordinate[D <: DataSet[D], C <: Coordinate[D, C]](
     */
   protected[algorithm] def initializeModel(seed: Long): DatumScoringModel
 
-  protected[algorithm] def updateModel(model: DatumScoringModel, score: KeyValueScore): (DatumScoringModel, OptimizationTracker) = {
+  protected[algorithm] def updateModel(model: DatumScoringModel, score: KeyValueScore)
+  : (DatumScoringModel, OptimizationTracker) = {
+
     val dataSetWithUpdatedOffsets = dataSet.addScoresToOffsets(score)
     updateCoordinateWithDataSet(dataSetWithUpdatedOffsets).updateModel(model)
   }

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/algorithm/CoordinateDescent.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/algorithm/CoordinateDescent.scala
@@ -25,13 +25,13 @@ import org.apache.spark.rdd.RDD
 /**
  * Coordinate descent implementation
  *
- * @param coordinates The individual optimization problem coordinates. The coordinates is a [[Seq]] consists of
+ * @param coordinates The individual optimization problem coordinates. The coordinates are a [[Seq]] of
  *                    (coordinateName, [[Coordinate]] object) pairs.
  * @param trainingLossFunctionEvaluator Training loss function evaluator
- * @param validatingDataAndEvaluatorsOption Optional validation data evaluator. The validating data is a [[RDD]]
- *                                         consists of (global Id, [[GameDatum]] object pairs), there the global Id
- *                                         is a unique identifier for each [[GameDatum]] object. The evaluators are
- *                                         a [[Seq]] of evaluators
+ * @param validatingDataAndEvaluatorsOption Optional validation data and evaluator. The validating data are a [[RDD]]
+ *                                          of (globalId, [[GameDatum]] object pairs), where globalId is a unique
+ *                                          identifier for each [[GameDatum]] object. The evaluators are
+ *                                          a [[Seq]] of evaluators
  * @param logger A logger instance
  */
 class CoordinateDescent(
@@ -41,12 +41,12 @@ class CoordinateDescent(
     logger: PhotonLogger) {
 
   /**
-    * Run coordinate descent
-    *
-    * @param numIterations Number of iterations
-    * @param seed Random seed (default: MathConst.RANDOM_SEED)
-    * @return A trained GAME model
-    */
+   * Run coordinate descent
+   *
+   * @param numIterations Number of iterations
+   * @param seed Random seed (default: MathConst.RANDOM_SEED)
+   * @return A trained GAME model
+   */
   def run(numIterations: Int, seed: Long = MathConst.RANDOM_SEED): GAMEModel = {
     val initializedModelContainer = coordinates.map { case (coordinateId, coordinate) =>
       val initializedModel = coordinate.initializeModel(seed)
@@ -67,12 +67,12 @@ class CoordinateDescent(
   }
 
   /**
-    * Run coordinate descent
-    *
-    * @param numIterations Number of iterations
-    * @param gameModel The initial GAME model
-    * @return Trained GAME model
-    */
+   * Run coordinate descent
+   *
+   * @param numIterations Number of iterations
+   * @param gameModel The initial GAME model
+   * @return Trained GAME model
+   */
   def run(numIterations: Int, gameModel: GAMEModel): GAMEModel = {
 
     coordinates.foreach { case (coordinateId, _) =>

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/avro/FieldNames.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/avro/FieldNames.scala
@@ -18,7 +18,6 @@ import com.linkedin.photon.ml.supervised.model.GeneralizedLinearModel
 
 /**
  * Field names of the Avro formatted file used as input of [[GeneralizedLinearModel]]
- * @author xazhang
  */
 trait FieldNames extends Serializable {
   val features: String
@@ -28,4 +27,8 @@ trait FieldNames extends Serializable {
   val response: String
   val offset: String
   val weight: String
+}
+
+object DefaultFieldNames {
+  val UID = "uid"
 }

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/avro/data/ScoreProcessingUtils.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/avro/data/ScoreProcessingUtils.scala
@@ -45,15 +45,12 @@ object ScoreProcessingUtils {
       val uid = Option(scoreAvro.getUid).map(_.toString)
       val label = Option(scoreAvro.getLabel()).map(_.toDouble)
       val ids = scoreAvro.getMetadataMap().asScala.map { case (k, v) => (k.toString, v.toString) }.toMap
-      val idsWithUid =
-        if (uid.isDefined) {
-          ids + (DefaultFieldNames.UID -> uid.get)
-        } else {
-          ids
-        }
-      uid.foreach{ id => }
+      val idsWithUid = uid match {
+        case Some(id) => ids + (DefaultFieldNames.UID -> id)
+        case _ => ids
+      }
       val modelId = scoreAvro.getModelId.toString
-      (modelId, ScoredItem(score, label, ids))
+      (modelId, ScoredItem(score, label, idsWithUid))
     }
   }
 

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/avro/model/ModelProcessingUtils.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/avro/model/ModelProcessingUtils.scala
@@ -86,7 +86,7 @@ object ModelProcessingUtils {
   }
 
   protected[ml] def loadGameModelFromHDFS(
-      featureShardIdToFeatureMapLoader: Map[String, IndexMapLoader],
+      featureShardIdToIndexMapLoader: Map[String, IndexMapLoader],
       inputDir: String,
       sparkContext: SparkContext): GAMEModel = {
 
@@ -106,7 +106,7 @@ object ModelProcessingUtils {
         val Array(featureShardId) = IOUtils.readStringsFromHDFS(idInfoPath, configuration).toArray
 
         // Load the coefficients
-        val featureNameAndTermToIndexMap = featureShardIdToFeatureMapLoader(featureShardId).indexMapForDriver()
+        val featureNameAndTermToIndexMap = featureShardIdToIndexMapLoader(featureShardId).indexMapForDriver()
         val modelPath = new Path(innerPath, COEFFICIENTS)
         val glm = loadGLMFromHDFS(modelPath.toString, featureNameAndTermToIndexMap, sparkContext)
 
@@ -128,7 +128,7 @@ object ModelProcessingUtils {
         val Array(randomEffectId, featureShardId) = IOUtils.readStringsFromHDFS(idInfoPath, configuration).toArray
 
         // Load the models
-        val featureMapLoader = featureShardIdToFeatureMapLoader(featureShardId)
+        val featureMapLoader = featureShardIdToIndexMapLoader(featureShardId)
         val modelsRDDInputPath = new Path(innerPath, COEFFICIENTS)
         val modelsRDD = loadModelsRDDFromHDFS(modelsRDDInputPath.toString, featureMapLoader, sparkContext)
 

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/cli/game/EvaluatorParams.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/cli/game/EvaluatorParams.scala
@@ -14,8 +14,14 @@
  */
 package com.linkedin.photon.ml.cli.game
 
+import com.linkedin.photon.ml.evaluation.EvaluatorType
+
 /**
  * Evaluator params common to GAME training and scoring.
  */
-class EvaluatorParams {
+trait EvaluatorParams {
+  /**
+   * A list of evaluators separated by comma. E.g, AUC,Precision@1:documentId,Precision@3:documentId,Logistic_Loss
+   */
+  var evaluatorTypes: Seq[EvaluatorType] = Seq()
 }

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/cli/game/EvaluatorParams.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/cli/game/EvaluatorParams.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2016 LinkedIn Corp. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linkedin.photon.ml.cli.game
+
+/**
+ * Evaluator params common to GAME training and scoring.
+ */
+class EvaluatorParams {
+}

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/cli/game/scoring/Driver.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/cli/game/scoring/Driver.scala
@@ -111,20 +111,21 @@ class Driver(val params: Params, val sparkContext: SparkContext, val logger: Pho
   }
 
   /**
-   * Score the game data set with the game model
-   * @param featureShardIdToFeatureMapLoader A map of feature shard id to feature map loader
+   * Load the GAME model and score the GAME data set.
+   *
+   * @param featureShardIdToIndexMapLoader A map of feature shard id to feature map loader
    * @param gameDataSet The game data set
    * @return The scores
    */
   protected def scoreGameDataSet(
-      featureShardIdToFeatureMapLoader: Map[String, IndexMapLoader],
+      featureShardIdToIndexMapLoader: Map[String, IndexMapLoader],
       gameDataSet: RDD[(Long, GameDatum)]): KeyValueScore = {
 
     // TODO: make the number of files written to HDFS to be configurable
 
     // Load the model from HDFS
     val gameModel = ModelProcessingUtils.loadGameModelFromHDFS(
-      featureShardIdToFeatureMapLoader, gameModelInputDir, sparkContext)
+      featureShardIdToIndexMapLoader, gameModelInputDir, sparkContext)
 
     logger.debug(s"Loaded game model summary:\n${gameModel.toSummaryString}")
 

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/cli/game/scoring/Driver.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/cli/game/scoring/Driver.scala
@@ -41,13 +41,13 @@ class Driver(val params: Params, val sparkContext: SparkContext, val logger: Pho
     s"${sparkContext.getExecutorStorageStatus.length * 3}").toInt
 
   /**
-    * Builds a GAME data set according to input data configuration
-    *
-    * @param featureShardIdToFeatureMapMap A map of shard id to feature map
-    * @return The prepared GAME data set
-    */
+   * Builds a GAME data set according to input data configuration
+   *
+   * @param featureShardIdToFeatureMapLoader A map of shard id to feature map loader
+   * @return The prepared GAME data set
+   */
   protected def prepareGameDataSet(featureShardIdToFeatureMapLoader: Map[String, IndexMapLoader])
-  : (RDD[(Long, Option[String])], RDD[(Long, GameDatum)]) = {
+  : RDD[(Long, GameDatum)] = {
 
     val recordsPath = (dateRangeOpt, dateRangeDaysAgoOpt) match {
       // Specified as date range
@@ -74,43 +74,48 @@ class Driver(val params: Params, val sparkContext: SparkContext, val logger: Pho
     val recordsWithUniqueId = records.zipWithUniqueId().map(_.swap)
     val globalDataPartitioner = new LongHashPartitioner(records.partitions.length)
 
-    val gameDataSetWithUIDs = DataProcessingUtils.getGameDataSetWithUIDFromGenericRecords(
+    val gameDataSet = DataProcessingUtils.getGameDataSetFromGenericRecords(
       recordsWithUniqueId,
       featureShardIdToFeatureSectionKeysMap,
       featureShardIdToFeatureMapLoader,
-      randomEffectIdSet,
+      randomEffectIdTypeSet,
       isResponseRequired = false)
       .partitionBy(globalDataPartitioner)
       .setName("Game data set with UIDs for scoring")
       .persist(StorageLevel.INFREQUENT_REUSE_RDD_STORAGE_LEVEL)
 
-    val gameDataSet = gameDataSetWithUIDs.mapValues(_._1)
-    val uids = gameDataSetWithUIDs.mapValues(_._2)
+    logGameDataSet(gameDataSet)
+    gameDataSet
+  }
 
+  /**
+   * Log some statistics of the GAME data set for debugging purpose
+   *
+   * @param gameDataSet The GAME data set
+   */
+  private def logGameDataSet(gameDataSet: RDD[(Long, GameDatum)]): Unit = {
     // Log some simple summary info on the Game data set
     logger.debug(s"Summary for the GAME data set")
-    val numSamples = gameDataSetWithUIDs.count()
+    val numSamples = gameDataSet.count()
     logger.debug(s"numSamples: $numSamples")
-    randomEffectIdSet.foreach { randomEffectId =>
+    randomEffectIdTypeSet.foreach { idType =>
       val numSamplesStats = gameDataSet.map { case (_, gameData) =>
-        val individualId = gameData.randomEffectIdToIndividualIdMap(randomEffectId)
-        (individualId, 1)
+        val idValue = gameData.idTypeToValueMap(idType)
+        (idValue, 1)
       }
         .reduceByKey(_ + _)
         .values
         .stats()
-      logger.debug(s"numSamples for $randomEffectId: $numSamplesStats")
+      logger.debug(s"numSamples for $idType: $numSamplesStats")
     }
-    (uids, gameDataSet)
   }
 
   /**
-    * Score the game data set with the game model
-    *
-    * @param featureShardIdToFeatureMapMap A map of shard id to feature map
-    * @param gameDataSet The game data set
-    * @return The scores
-    */
+   * Score the game data set with the game model
+   * @param featureShardIdToFeatureMapLoader A map of feature shard id to feature map loader
+   * @param gameDataSet The game data set
+   * @return The scores
+   */
   protected def scoreGameDataSet(
       featureShardIdToFeatureMapLoader: Map[String, IndexMapLoader],
       gameDataSet: RDD[(Long, GameDatum)]): KeyValueScore = {
@@ -123,25 +128,22 @@ class Driver(val params: Params, val sparkContext: SparkContext, val logger: Pho
 
     logger.debug(s"Loaded game model summary:\n${gameModel.toSummaryString}")
 
-    val scores = gameModel.score(gameDataSet)
-    val offsets = new KeyValueScore(gameDataSet.mapValues(_.offset))
-    scores + offsets
+    gameModel.score(gameDataSet)
   }
 
   /**
    * Save the computed scores to HDFS with auxiliary info
    *
-   * @param uids The unique ids
    * @param gameDataSet The GAME data set
    * @param scores The computed scores
    */
   protected def saveScoresToHDFS(
-      uids: RDD[(Long, Option[String])],
       gameDataSet: RDD[(Long, GameDatum)],
       scores: KeyValueScore): Unit = {
 
-    val scoredItems = uids.join(gameDataSet).join(scores.scores).map { case (_, ((uid, gameDatum), score)) =>
-      ScoredItem(score, uid, Some(gameDatum.response), gameDatum.randomEffectIdToIndividualIdMap)
+    // Take the offset information into account when writing the scores to HDFS
+    val scoredItems = gameDataSet.join(scores.scores).map { case (_, (gameDatum, score)) =>
+      ScoredItem(score + gameDatum.offset, Some(gameDatum.response), gameDatum.idTypeToValueMap)
     }
     scoredItems.setName("Scored items").persist(StorageLevel.INFREQUENT_REUSE_RDD_STORAGE_LEVEL)
     val numScoredItems = scoredItems.count()
@@ -158,8 +160,8 @@ class Driver(val params: Params, val sparkContext: SparkContext, val logger: Pho
   }
 
   /**
-    * Run the driver
-    */
+   * Run the driver
+   */
   def run(): Unit = {
     val timer = new Timer
 
@@ -172,7 +174,7 @@ class Driver(val params: Params, val sparkContext: SparkContext, val logger: Pho
     logger.info(s"Time elapsed after preparing feature maps: ${timer.durationSeconds} (s)\n")
 
     timer.start()
-    val (uids, gameDataSet) = prepareGameDataSet(featureShardIdToFeatureMapMap)
+    val gameDataSet = prepareGameDataSet(featureShardIdToFeatureMapMap)
     timer.stop()
     logger.info(s"Time elapsed after game data set preparation: ${timer.durationSeconds} (s)\n")
 
@@ -183,17 +185,17 @@ class Driver(val params: Params, val sparkContext: SparkContext, val logger: Pho
     logger.info(s"Time elapsed after computing scores: ${timer.durationSeconds} (s)\n")
 
     timer.start()
-    saveScoresToHDFS(uids, gameDataSet, scores)
+    saveScoresToHDFS(gameDataSet, scores)
     timer.stop()
     logger.info(s"Time elapsed saving scores to HDFS: ${timer.durationSeconds} (s)\n")
 
-    evaluatorType.foreach { evaluatorType =>
-      timer.start()
+    timer.start()
+    evaluatorTypes.foreach { evaluatorType =>
       val evaluationMetricValue = Driver.evaluateScores(evaluatorType, scores, gameDataSet)
       logger.info(s"Evaluation metric value on scores with $evaluatorType: $evaluationMetricValue")
-      timer.stop()
-      logger.info(s"Time elapsed after evaluating scores: ${timer.durationSeconds} (s)\n")
     }
+    timer.stop()
+    logger.info(s"Time elapsed after evaluating scores: ${timer.durationSeconds} (s)\n")
   }
 }
 
@@ -222,25 +224,18 @@ object Driver {
 
     // Make sure the GAME data set makes sense
     val numSamplesWithNaNResponse = gameDataSet.filter(_._2.response.isNaN).count()
-    require(numSamplesWithNaNResponse == 0, s"numSamplesWithNaNResponse: $numSamplesWithNaNResponse")
+    require(numSamplesWithNaNResponse == 0,
+      s"Number of data points with NaN found as response: $numSamplesWithNaNResponse. Make sure the responses are " +
+        s"well defined in your data point in order to evaluate the computed scores with the specified " +
+        s"evaluator $evaluatorType!")
 
-    // The computed scores already take the offset into account
-    val labelAndOffsetAndWeights = gameDataSet.mapValues(gameDatum => (gameDatum.response, 0.0, gameDatum.weight))
-    val evaluator = evaluatorType match {
-      case AUC => new AreaUnderROCCurveEvaluator(labelAndOffsetAndWeights)
-      case RMSE => new RMSEEvaluator(labelAndOffsetAndWeights)
-      case PoissonLoss => new PoissonLossEvaluator(labelAndOffsetAndWeights)
-      case LogisticLoss => new LogisticLossEvaluator(labelAndOffsetAndWeights)
-      case SmoothedHingeLoss => new SmoothedHingeLossEvaluator(labelAndOffsetAndWeights)
-      case SquaredLoss => new SquaredLossEvaluator(labelAndOffsetAndWeights)
-      case _ => throw new UnsupportedOperationException(s"Unsupported evaluator type: $evaluatorType")
-    }
+    val evaluator = Evaluator.buildEvaluator(evaluatorType, gameDataSet)
     evaluator.evaluate(scores.scores)
   }
 
   /**
-    * Main entry point
-    */
+   * Main entry point
+   */
   def main(args: Array[String]): Unit = {
 
     val timer = Timer.start()

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/cli/game/scoring/Driver.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/cli/game/scoring/Driver.scala
@@ -21,9 +21,7 @@ import com.linkedin.photon.ml.avro.data.{DataProcessingUtils, ScoreProcessingUti
 import com.linkedin.photon.ml.avro.model.ModelProcessingUtils
 import com.linkedin.photon.ml.constants.StorageLevel
 import com.linkedin.photon.ml.data.{GameDatum, KeyValueScore}
-import com.linkedin.photon.ml.evaluation.EvaluatorType.EvaluatorType
 import com.linkedin.photon.ml.evaluation._
-import com.linkedin.photon.ml.evaluation.EvaluatorType._
 import com.linkedin.photon.ml.util._
 import org.apache.hadoop.fs.Path
 import org.apache.spark.SparkContext
@@ -231,10 +229,10 @@ object Driver {
     val evaluator = evaluatorType match {
       case AUC => new AreaUnderROCCurveEvaluator(labelAndOffsetAndWeights)
       case RMSE => new RMSEEvaluator(labelAndOffsetAndWeights)
-      case POISSON_LOSS => new PoissonLossEvaluator(labelAndOffsetAndWeights)
-      case LOGISTIC_LOSS => new LogisticLossEvaluator(labelAndOffsetAndWeights)
-      case SMOOTHED_HINGE_LOSS => new SmoothedHingeLossEvaluator(labelAndOffsetAndWeights)
-      case SQUARED_LOSS => new SquaredLossEvaluator(labelAndOffsetAndWeights)
+      case PoissonLoss => new PoissonLossEvaluator(labelAndOffsetAndWeights)
+      case LogisticLoss => new LogisticLossEvaluator(labelAndOffsetAndWeights)
+      case SmoothedHingeLoss => new SmoothedHingeLossEvaluator(labelAndOffsetAndWeights)
+      case SquaredLoss => new SquaredLossEvaluator(labelAndOffsetAndWeights)
       case _ => throw new UnsupportedOperationException(s"Unsupported evaluator type: $evaluatorType")
     }
     evaluator.evaluate(scores.scores)

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/cli/game/scoring/ScoredItem.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/cli/game/scoring/ScoredItem.scala
@@ -19,13 +19,12 @@ import scala.collection.Map
 /**
  * A compact representation of the scored item
  * @param predictionScore The prediction score
- * @param uid An optional unique Id of the score
  * @param label An optional label of the score
- * @param ids An map of random effect keys to random effect ids (e.g., item -> itemId or member -> memberId)
+ * @param idTypeToValueMap The id type to value map that holds different types of ids associated with this data
+ *                         point, e.g. Map("userId" -> "1234", "itemId" -> "abcd").
  */
 case class ScoredItem(
     predictionScore: Double,
-    uid: Option[String],
     label: Option[Double],
-    ids: Map[String, String]
+    idTypeToValueMap: Map[String, String]
 )

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/cli/game/training/Params.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/cli/game/training/Params.scala
@@ -15,7 +15,8 @@
 package com.linkedin.photon.ml.cli.game.training
 
 import com.linkedin.photon.ml.OptionNames._
-import com.linkedin.photon.ml.cli.game.FeatureParams
+import com.linkedin.photon.ml.cli.game.{EvaluatorParams, FeatureParams}
+import com.linkedin.photon.ml.evaluation.EvaluatorType
 import com.linkedin.photon.ml.optimization.game.{MFOptimizationConfiguration, GLMOptimizationConfiguration}
 import com.linkedin.photon.ml.data.{FixedEffectDataConfiguration, RandomEffectDataConfiguration}
 import com.linkedin.photon.ml.io.ModelOutputMode
@@ -27,11 +28,12 @@ import scopt.OptionParser
 
 /**
  * A bean class for GAME training parameters to replace the original case class for input parameters.
+ *
  * @note Note that examples of how to configure GAME parameters can be found in the integration tests for the GAME
  *       driver.
  * @todo Making the way GAME being configured more user friendly
  */
-class Params extends FeatureParams with PalDBIndexMapParams {
+class Params extends FeatureParams with PalDBIndexMapParams with EvaluatorParams {
 
   /**
    * Input directories of training data. Multiple input directories are also accepted if they are
@@ -377,6 +379,9 @@ object Params {
             "feature index building and has zero performance impact on training other than maintaining a " +
             "convention.")
         .foreach(x => params.offHeapIndexMapNumPartitions = x)
+      opt[String](EvaluatorType.cmdArgument)
+        .text("Type of the evaluator used to evaluate the computed scores.")
+        .foreach(x => params.evaluatorTypes = x.split(",").map(EvaluatorType.withName))
 
       help("help").text("prints usage text.")
       override def showUsageOnError = true

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/data/GameDatum.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/data/GameDatum.scala
@@ -19,28 +19,30 @@ import breeze.linalg.Vector
 import scala.collection.Map
 
 /**
-  * Representation of a single GAME data point
-  *
-  * @param response The response or label
-  * @param offset The offset
-  * @param weight The importance weight
-  * @param featureShardContainer The sharded feature vectors
-  * @param randomEffectIdToIndividualIdMap A map from random effect type id to actual individual id
-  *   (e.g. "memberId" -> "1234" or "itemId" -> "abcd")
-  */
+ * Representation of a single GAME data point
+ *
+ * @param response The response or label
+ * @param offset The offset
+ * @param weight The importance weight
+ * @param featureShardContainer The sharded feature vectors
+ * @param idTypeToValueMap The id type to value map that holds different types of ids associated with this data
+ *                         point. A few examples of the ids types are: (i) ids used to build the random effect model
+ *                         such as userId and itemId; (ii) ids used to compute certain metrics like precision@k such
+ *                         as documentId or queryId; (iii) ids that are used to uniquely identify each training record.
+ */
 protected[ml] class GameDatum(
     val response: Double,
     val offset: Double,
     val weight: Double,
     val featureShardContainer: Map[String, Vector[Double]],
-    val randomEffectIdToIndividualIdMap: Map[String, String]) extends Serializable {
+    val idTypeToValueMap: Map[String, String]) extends Serializable {
 
   /**
-    * Build a labeled point with sharded feature container
-    *
-    * @param featureShardId The feature shard id
-    * @return The new labeled point
-    */
+   * Build a labeled point with sharded feature container
+   *
+   * @param featureShardId The feature shard id
+   * @return The new labeled point
+   */
   def generateLabeledPointWithFeatureShardId(featureShardId: String): LabeledPoint = {
     LabeledPoint(response, featureShardContainer(featureShardId), offset, weight)
   }

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/data/RandomEffectDataSet.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/data/RandomEffectDataSet.scala
@@ -36,7 +36,7 @@ import com.linkedin.photon.ml.constants.StorageLevel
  * @param featureShardId the feature shard id
  * @author xazhang
  */
-protected[ml] class   RandomEffectDataSet(
+protected[ml] class RandomEffectDataSet(
     val activeData: RDD[(String, LocalDataSet)],
     protected[data] val globalIdToIndividualIds: RDD[(Long, String)],
     val passiveDataOption: Option[RDD[(Long, (String, LabeledPoint))]],

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/data/RandomEffectDataSet.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/data/RandomEffectDataSet.scala
@@ -36,7 +36,7 @@ import com.linkedin.photon.ml.constants.StorageLevel
  * @param featureShardId the feature shard id
  * @author xazhang
  */
-protected[ml] class RandomEffectDataSet(
+protected[ml] class   RandomEffectDataSet(
     val activeData: RDD[(String, LocalDataSet)],
     protected[data] val globalIdToIndividualIds: RDD[(Long, String)],
     val passiveDataOption: Option[RDD[(Long, (String, LabeledPoint))]],
@@ -218,7 +218,7 @@ object RandomEffectDataSet {
     val numActiveDataPointsToKeepUpperBound = randomEffectDataConfiguration.numActiveDataPointsToKeepUpperBound
 
     val keyedRandomEffectDataSet = gameDataSet.map { case (globalId, gameData) =>
-      val individualId = gameData.randomEffectIdToIndividualIdMap(randomEffectId)
+      val individualId = gameData.idTypeToValueMap(randomEffectId)
       val labeledPoint = gameData.generateLabeledPointWithFeatureShardId(featureShardId)
       (individualId, (globalId, labeledPoint))
     }
@@ -330,7 +330,7 @@ object RandomEffectDataSet {
     // The remaining data not included in the active data will be kept as passive data
     val activeDataGlobalIds = activeData.flatMapValues(_.dataPoints.map(_._1)).map(_.swap)
     val keyedRandomEffectDataSet = gameDataSet.mapValues { gameData =>
-      val individualId = gameData.randomEffectIdToIndividualIdMap(randomEffectId)
+      val individualId = gameData.idTypeToValueMap(randomEffectId)
       val labeledPoint = gameData.generateLabeledPointWithFeatureShardId(featureShardId)
       (individualId, labeledPoint)
     }

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/data/RandomEffectIdPartitioner.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/data/RandomEffectIdPartitioner.scala
@@ -72,8 +72,8 @@ object RandomEffectIdPartitioner {
     val sortedRandomEffectIds =
       gameDataSet
           .values
-          .filter(_.randomEffectIdToIndividualIdMap.contains(randomEffectId))
-          .map(gameData => (gameData.randomEffectIdToIndividualIdMap(randomEffectId), 1))
+          .filter(_.idTypeToValueMap.contains(randomEffectId))
+          .map(gameData => (gameData.idTypeToValueMap(randomEffectId), 1))
           .reduceByKey(_ + _)
           .collect()
           .sortBy(_._2 * -1)

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/evaluation/AreaUnderROCCurveEvaluator.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/evaluation/AreaUnderROCCurveEvaluator.scala
@@ -27,6 +27,8 @@ protected[ml] class AreaUnderROCCurveEvaluator(
     labelAndOffsetAndWeights: RDD[(Long, (Double, Double, Double))],
     defaultScore: Double = 0.0) extends Evaluator {
 
+  protected val evaluatorType = AUC
+
   /**
     * Evaluate the scores of the model
     *

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/evaluation/EvaluatorType.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/evaluation/EvaluatorType.scala
@@ -75,6 +75,6 @@ object EvaluatorType {
     case PrecisionAtK.precisionAtKPattern(k, _) =>
       val PrecisionAtK.precisionAtKPattern(_, documentId) = name.trim
       PrecisionAtK(k.toInt, documentId)
-    case _ => throw new UnsupportedOperationException(s"Unsupported evaluator $name!")
+    case _ => throw new IllegalArgumentException(s"Unsupported evaluator $name!")
   }
 }

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/evaluation/EvaluatorType.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/evaluation/EvaluatorType.scala
@@ -14,7 +14,67 @@
  */
 package com.linkedin.photon.ml.evaluation
 
-object EvaluatorType extends Enumeration {
-  type EvaluatorType = Value
-  val AUC, RMSE, LOGISTIC_LOSS, POISSON_LOSS, SMOOTHED_HINGE_LOSS, SQUARED_LOSS, PRECISION_AT_K = Value
+/**
+ * Evaluator type
+ */
+trait EvaluatorType {
+  // name of the evaluator
+  val name: String
+}
+
+object AUC extends EvaluatorType {
+  val name = "AUC"
+}
+
+object RMSE extends EvaluatorType {
+  val name = "RMSE"
+}
+
+object LogisticLoss extends EvaluatorType {
+  val name = "LOGISTIC_LOSS"
+}
+
+object PoissonLoss extends EvaluatorType {
+  val name = "POISSON_LOSS"
+}
+
+object SmoothedHingeLoss extends EvaluatorType {
+  val name = "SMOOTHED_HINGE_LOSS"
+}
+
+object SquaredLoss extends EvaluatorType {
+  val name = "SQUARED_LOSS"
+}
+
+case class PrecisionAtK(k: Int, documentIdName: String) extends EvaluatorType {
+  val name = s"PRECISION@$k${PrecisionAtK.precisionAtKSplitter}$documentIdName"
+}
+
+object PrecisionAtK {
+  val precisionAtKSplitter = ":"
+  val precisionAtKPattern = s"(?i:PRECISION)@(\\d+)$precisionAtKSplitter(.*)".r
+}
+
+object EvaluatorType {
+
+  // Command line argument for evaluator type
+  val cmdArgument = "evaluator-type"
+
+  /**
+   * Parse the evaluator type with name
+   * @param name name of the evaluator type
+   * @return the parsed evaluator type
+   */
+  def withName(name: String): EvaluatorType = name.trim.toUpperCase match {
+    case AUC.name => AUC
+    case RMSE.name => RMSE
+    case LogisticLoss.name | "LOGISTICLOSS" => LogisticLoss
+    case PoissonLoss.name | "POISSONLOSS" => PoissonLoss
+    case SmoothedHingeLoss.name | "SMOOTHEDHINGELOSS" => SmoothedHingeLoss
+    case SquaredLoss.name | "SQUAREDLOSS" => SquaredLoss
+    case PrecisionAtK.precisionAtKPattern(k, _) =>
+      val PrecisionAtK.precisionAtKPattern(_, documentId) = name.trim
+      PrecisionAtK(k.toInt, documentId)
+    case _ => throw new UnsupportedOperationException(s"Unsupported evaluator $name!")
+  }
 }

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/evaluation/LogisticLossEvaluator.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/evaluation/LogisticLossEvaluator.scala
@@ -28,6 +28,8 @@ protected[ml] class LogisticLossEvaluator(
     labelAndOffsetAndWeights: RDD[(Long, (Double, Double, Double))],
     defaultScore: Double = 0.0) extends Evaluator {
 
+  protected val evaluatorType = LogisticLoss
+
   /**
    * Evaluate the scores of the model
    *

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/evaluation/PoissonLossEvaluator.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/evaluation/PoissonLossEvaluator.scala
@@ -28,6 +28,8 @@ protected[ml] class PoissonLossEvaluator(
     labelAndOffsetAndWeights: RDD[(Long, (Double, Double, Double))],
     defaultScore: Double = 0.0) extends Evaluator {
 
+  protected val evaluatorType = LogisticLoss
+
   /**
    * Evaluate the scores of the model
    *

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/evaluation/PoissonLossEvaluator.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/evaluation/PoissonLossEvaluator.scala
@@ -28,7 +28,7 @@ protected[ml] class PoissonLossEvaluator(
     labelAndOffsetAndWeights: RDD[(Long, (Double, Double, Double))],
     defaultScore: Double = 0.0) extends Evaluator {
 
-  protected val evaluatorType = LogisticLoss
+  protected val evaluatorType = PoissonLoss
 
   /**
    * Evaluate the scores of the model

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/evaluation/PrecisionAtKEvaluator.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/evaluation/PrecisionAtKEvaluator.scala
@@ -28,13 +28,17 @@ import com.linkedin.photon.ml.constants.MathConst
  *                    compute precision @ K. Such document ids can be thought as a recommendation context, e.g. in
  *                    evaluating the relevance of search results of given a query - one would use the query id as a
  *                    documentId.
+ * @param documentIdName Name of the document Id, e.g., documentId or queryId.
  * @param defaultScore The default score used to compute the metric
  */
 class PrecisionAtKEvaluator(
     k: Int,
     labelAndOffsetAndWeights: RDD[(Long, (Double, Double, Double))],
     documentIds: RDD[(Long, String)],
+    documentIdName: String,
     defaultScore: Double = 0.0) extends Evaluator {
+
+  protected val evaluatorType = PrecisionAtK(k, documentIdName)
 
   override def evaluate(scores: RDD[(Long, Double)]): Double = {
     // Create a local copy of the defaultScore, so that the underlying object won't get shipped to the executor nodes

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/evaluation/RMSEEvaluator.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/evaluation/RMSEEvaluator.scala
@@ -26,9 +26,11 @@ import org.apache.spark.rdd.RDD
   */
 protected[ml] class RMSEEvaluator(
     labelAndOffsetAndWeights: RDD[(Long, (Double, Double, Double))],
-    defaultScore: Double = 0.0) extends Evaluator(RMSE) {
+    defaultScore: Double = 0.0) extends Evaluator {
 
-  val squaredLossEvaluator = new SquaredLossEvaluator(labelAndOffsetAndWeights, defaultScore)
+  protected val evaluatorType = RMSE
+
+  private val squaredLossEvaluator = new SquaredLossEvaluator(labelAndOffsetAndWeights, defaultScore)
 
   /**
     * Evaluate the scores of the model

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/evaluation/RMSEEvaluator.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/evaluation/RMSEEvaluator.scala
@@ -26,7 +26,7 @@ import org.apache.spark.rdd.RDD
   */
 protected[ml] class RMSEEvaluator(
     labelAndOffsetAndWeights: RDD[(Long, (Double, Double, Double))],
-    defaultScore: Double = 0.0) extends Evaluator {
+    defaultScore: Double = 0.0) extends Evaluator(RMSE) {
 
   val squaredLossEvaluator = new SquaredLossEvaluator(labelAndOffsetAndWeights, defaultScore)
 

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/evaluation/SmoothedHingeLossEvaluator.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/evaluation/SmoothedHingeLossEvaluator.scala
@@ -26,7 +26,9 @@ import com.linkedin.photon.ml.function.SmoothedHingeLossFunction
  */
 protected[ml] class SmoothedHingeLossEvaluator(
   labelAndOffsetAndWeights: RDD[(Long, (Double, Double, Double))],
-  defaultScore: Double = 0.0) extends Evaluator {
+  defaultScore: Double = 0.0) extends Evaluator{
+
+  protected val evaluatorType = SmoothedHingeLoss
 
   /**
    * Evaluate the scores of the model

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/evaluation/SmoothedHingeLossEvaluator.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/evaluation/SmoothedHingeLossEvaluator.scala
@@ -26,7 +26,7 @@ import com.linkedin.photon.ml.function.SmoothedHingeLossFunction
  */
 protected[ml] class SmoothedHingeLossEvaluator(
   labelAndOffsetAndWeights: RDD[(Long, (Double, Double, Double))],
-  defaultScore: Double = 0.0) extends Evaluator{
+  defaultScore: Double = 0.0) extends Evaluator {
 
   protected val evaluatorType = SmoothedHingeLoss
 

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/evaluation/SquaredLossEvaluator.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/evaluation/SquaredLossEvaluator.scala
@@ -28,6 +28,8 @@ protected[ml] class SquaredLossEvaluator(
     labelAndOffsetAndWeights: RDD[(Long, (Double, Double, Double))],
     defaultScore: Double = 0.0) extends Evaluator {
 
+  protected val evaluatorType = SquaredLoss
+
   /**
    * Evaluate the scores of the model
    *

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/model/MatrixFactorizationModel.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/model/MatrixFactorizationModel.scala
@@ -148,8 +148,8 @@ object MatrixFactorizationModel {
     val scores = dataPoints
       //For each datum, collect a (rowEffectId, (colEffectId, uniqueId)) tuple.
       .map { case (uniqueId, gameData) =>
-      val rowEffectId = gameData.randomEffectIdToIndividualIdMap(rowEffectType)
-      val colEffectId = gameData.randomEffectIdToIndividualIdMap(colEffectType)
+      val rowEffectId = gameData.idTypeToValueMap(rowEffectType)
+      val colEffectId = gameData.idTypeToValueMap(colEffectType)
       (rowEffectId, (colEffectId, uniqueId))
     }
       .cogroup(rowLatentFactors)

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/model/RandomEffectModel.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/model/RandomEffectModel.scala
@@ -121,7 +121,7 @@ object RandomEffectModel {
     * Compute the score for the dataset
     *
     * @param dataPoints The dataset to score
-    * @param coefficientsRDD The models to use for scoring
+    * @param modelsRDD The models to use for scoring
     * @param randomEffectId The random effect type id
     * @param featureShardId The feature shard id
     * @return The scores
@@ -134,7 +134,7 @@ object RandomEffectModel {
 
     val scores = dataPoints
       .map { case (globalId, gameData) =>
-        val individualId = gameData.randomEffectIdToIndividualIdMap(randomEffectId)
+        val individualId = gameData.idTypeToValueMap(randomEffectId)
         val features = gameData.featureShardContainer(featureShardId)
         (individualId, (globalId, features))
       }

--- a/photon-ml/src/test/scala/com/linkedin/photon/ml/avro/data/DataProcessingUtilsTest.scala
+++ b/photon-ml/src/test/scala/com/linkedin/photon/ml/avro/data/DataProcessingUtilsTest.scala
@@ -45,11 +45,11 @@ class DataProcessingUtilsTest {
 
     record.put(USER_ID_NAME, userIdStr)
     record.put(JOB_ID_NAME, jobIdVal)
-    val map1 = DataProcessingUtils.makeRandomEffectIdMap(record, Set[String](USER_ID_NAME))
+    val map1 = DataProcessingUtils.getIdTypeToValueMapFromGenericRecord(record, Set[String](USER_ID_NAME))
     assertEquals(map1.size, 1)
     assertEquals(map1(USER_ID_NAME), userIdStr)
 
-    val map2 = DataProcessingUtils.makeRandomEffectIdMap(record, Set[String](USER_ID_NAME, JOB_ID_NAME))
+    val map2 = DataProcessingUtils.getIdTypeToValueMapFromGenericRecord(record, Set[String](USER_ID_NAME, JOB_ID_NAME))
     assertEquals(map2.size, 2)
     assertEquals(map2(USER_ID_NAME), userIdStr)
     assertEquals(map2(JOB_ID_NAME), jobIdValStr)
@@ -72,11 +72,11 @@ class DataProcessingUtilsTest {
     map.put(JOB_ID_NAME, jobIdValStr)
     record.put(AvroFieldNames.META_DATA_MAP, map)
 
-    val res = DataProcessingUtils.makeRandomEffectIdMap(record, Set[String](USER_ID_NAME))
+    val res = DataProcessingUtils.getIdTypeToValueMapFromGenericRecord(record, Set[String](USER_ID_NAME))
     assertEquals(res.size, 1)
     assertEquals(res(USER_ID_NAME), userIdStr)
 
-    val res2 = DataProcessingUtils.makeRandomEffectIdMap(record, Set[String](USER_ID_NAME, JOB_ID_NAME))
+    val res2 = DataProcessingUtils.getIdTypeToValueMapFromGenericRecord(record, Set[String](USER_ID_NAME, JOB_ID_NAME))
     assertEquals(res2.size, 2)
     assertEquals(res2(USER_ID_NAME), userIdStr)
     assertEquals(res2(JOB_ID_NAME), jobIdValStr)
@@ -110,11 +110,11 @@ class DataProcessingUtilsTest {
     record.put(AvroFieldNames.META_DATA_MAP, map)
 
     // Ids in metaDataMap will be ignored in this case
-    val res = DataProcessingUtils.makeRandomEffectIdMap(record, Set[String](USER_ID_NAME))
+    val res = DataProcessingUtils.getIdTypeToValueMapFromGenericRecord(record, Set[String](USER_ID_NAME))
     assertEquals(res.size, 1)
     assertEquals(res(USER_ID_NAME), userId1Str)
 
-    val res2 = DataProcessingUtils.makeRandomEffectIdMap(record, Set[String](USER_ID_NAME, JOB_ID_NAME))
+    val res2 = DataProcessingUtils.getIdTypeToValueMapFromGenericRecord(record, Set[String](USER_ID_NAME, JOB_ID_NAME))
     assertEquals(res2.size, 2)
     assertEquals(res2(USER_ID_NAME), userId1Str)
     assertEquals(res2(JOB_ID_NAME), jobId1Str)
@@ -132,7 +132,7 @@ class DataProcessingUtilsTest {
       .name("foo").`type`().stringType().noDefault()
       .endRecord())
 
-    assertTrue(DataProcessingUtils.makeRandomEffectIdMap(emptyRecord, Set[String]()).isEmpty)
+    assertTrue(DataProcessingUtils.getIdTypeToValueMapFromGenericRecord(emptyRecord, Set[String]()).isEmpty)
   }
 
   @Test(expectedExceptions = Array(classOf[IllegalArgumentException]))
@@ -147,7 +147,7 @@ class DataProcessingUtilsTest {
       .name("foo").`type`().stringType().noDefault()
       .endRecord())
 
-    DataProcessingUtils.makeRandomEffectIdMap(emptyRecord, Set[String](USER_ID_NAME))
+    DataProcessingUtils.getIdTypeToValueMapFromGenericRecord(emptyRecord, Set[String](USER_ID_NAME))
   }
 }
 

--- a/photon-ml/src/test/scala/com/linkedin/photon/ml/evaluation/EvaluatorTypeTest.scala
+++ b/photon-ml/src/test/scala/com/linkedin/photon/ml/evaluation/EvaluatorTypeTest.scala
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2016 LinkedIn Corp. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linkedin.photon.ml.evaluation
+
+import org.testng.Assert._
+import org.testng.annotations.{DataProvider, Test}
+
+class EvaluatorTypeTest {
+
+  @Test
+  def testWithName(): Unit = {
+
+    val auc = "aUc"
+    assertEquals(AUC, EvaluatorType.withName(auc))
+
+    val rmse = "RMsE"
+    assertEquals(RMSE, EvaluatorType.withName(rmse))
+
+    val logisticLoss1 = "lOGIstiClosS"
+    assertEquals(LogisticLoss, EvaluatorType.withName(logisticLoss1))
+    val logisticLoss2 = "logiSTIC_LoSS"
+    assertEquals(LogisticLoss, EvaluatorType.withName(logisticLoss2))
+
+    val poissonLoss1 = "PoISSonLoSs"
+    assertEquals(PoissonLoss, EvaluatorType.withName(poissonLoss1))
+    val poissonLoss2 = "pOISson_lOSS"
+    assertEquals(PoissonLoss, EvaluatorType.withName(poissonLoss2))
+
+    val smoothedHingeLoss1 = "  sMooThEDHingELoss"
+    assertEquals(SmoothedHingeLoss, EvaluatorType.withName(smoothedHingeLoss1))
+    val smoothedHingeLoss2 = "SmOOTheD_Hinge_LOSS"
+    assertEquals(SmoothedHingeLoss, EvaluatorType.withName(smoothedHingeLoss2))
+
+    val squareLoss1 = "sQUAREDlosS "
+    assertEquals(SquaredLoss, EvaluatorType.withName(squareLoss1))
+    val squareLoss2 = "SquAREd_LOss"
+    assertEquals(SquaredLoss, EvaluatorType.withName(squareLoss2))
+
+    val precisionAt10 = " prEcIsiON@10:queryId   "
+    assertEquals(PrecisionAtK(10, "queryId"), EvaluatorType.withName(precisionAt10))
+  }
+
+  @DataProvider
+  def generateUnrecognizedEvaluators(): Array[Array[Object]] = {
+    Array(
+      Array("AreaUnderROCCurve"),
+      Array("ROC"),
+      Array("MSE"),
+      Array("RRMSE"),
+      Array("logistic"),
+      Array("poisson"),
+      Array("SVM"),
+      Array("squared"),
+      Array("121"),
+      Array("null"),
+      Array("precision"),
+      Array("precision@"),
+      Array("precision@k"),
+      Array("precision@1k"),
+      Array("precision@10"),
+      Array("precision@queryId"),
+      Array("precision@10queryId"),
+      Array("precision@10|queryId"),
+      Array("precision@10-queryId")
+    )
+  }
+
+  @Test(dataProvider = "generateUnrecognizedEvaluators",
+    expectedExceptions = Array(classOf[UnsupportedOperationException]))
+  def testUnrecognizedEvaluatorsWithName(name: String): Unit = {
+    EvaluatorType.withName(name)
+  }
+}

--- a/photon-ml/src/test/scala/com/linkedin/photon/ml/evaluation/EvaluatorTypeTest.scala
+++ b/photon-ml/src/test/scala/com/linkedin/photon/ml/evaluation/EvaluatorTypeTest.scala
@@ -78,7 +78,7 @@ class EvaluatorTypeTest {
   }
 
   @Test(dataProvider = "generateUnrecognizedEvaluators",
-    expectedExceptions = Array(classOf[UnsupportedOperationException]))
+    expectedExceptions = Array(classOf[IllegalArgumentException]))
   def testUnrecognizedEvaluatorsWithName(name: String): Unit = {
     EvaluatorType.withName(name)
   }


### PR DESCRIPTION
A few things to watch out for in this PR:

0. Precision@K is now ready to be used as an evaluator in GAME, similar to other metrics such as AUC and RMSE.

1. ```GameDatum``` now hold all types of Ids other than just random effect ids. For example, ```uid``` used for some scoring downstream applications and ```documentId``` or ```queryId``` used to compute precision@K metric (or replay metric in the future). This change simplifies the data processing logic for GAME's scoring and evaluation modules.

2. GAME now supports running multiple evaluators at the same time, for example, the users can specify precision@1 + precision@3 + precision@10 + AUC as evaluators at the same time, and GAME will spit out four evaluation metrics per iteration - given the validation data is specified by the user. Motivation for this feature is stated in #164.

3. Minor issues like #165 is addressed, along with some minor Scala code style fixes - sorry, I just can't help fixing them when seeing those warning in my Intellij.