### PR TITLE
Bug fix: ids used to compute precision@k should be considered explici…

### DIFF
--- a/photon-ml/src/integTest/scala/com/linkedin/photon/ml/model/GAMEModelTest.scala
+++ b/photon-ml/src/integTest/scala/com/linkedin/photon/ml/model/GAMEModelTest.scala
@@ -15,7 +15,6 @@
 package com.linkedin.photon.ml.model
 
 import org.apache.spark.SparkContext
-import org.mockito.Mockito._
 import org.testng.annotations.Test
 import org.testng.Assert._
 

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/cli/game/GAMEDriver.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/cli/game/GAMEDriver.scala
@@ -22,7 +22,7 @@ import org.apache.spark.SparkContext
 /**
   * Contains common functions for GAME training and scoring drivers.
   */
-class GAMEDriver(
+abstract class GAMEDriver(
     params: FeatureParams with PalDBIndexMapParams,
     sparkContext: SparkContext,
     logger: PhotonLogger) {
@@ -30,6 +30,15 @@ class GAMEDriver(
   import params._
 
   protected val hadoopConfiguration = sparkContext.hadoopConfiguration
+
+  protected val parallelism: Int = sparkContext.getConf.get("spark.default.parallelism",
+    s"${sparkContext.getExecutorStorageStatus.length * 3}").toInt
+
+  /**
+   * All id types that are necessary for GAME driver. E.g., random effect id types for model training and scoring, or
+   * ids for model evaluation with precision@K, for example, documentId or queryId
+   */
+  protected[game] val idTypeSet: Set[String]
 
   /**
     * Builds feature key to index map loaders according to configuration

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/cli/game/scoring/Driver.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/cli/game/scoring/Driver.scala
@@ -37,8 +37,9 @@ class Driver(val params: Params, val sparkContext: SparkContext, val logger: Pho
 
   import params._
 
-  protected val parallelism: Int = sparkContext.getConf.get("spark.default.parallelism",
-    s"${sparkContext.getExecutorStorageStatus.length * 3}").toInt
+  protected[game] val idTypeSet: Set[String] = {
+    randomEffectIdTypeSet ++ getPrecisionAtKIdTypeSet
+  }
 
   /**
    * Builds a GAME data set according to input data configuration
@@ -78,7 +79,7 @@ class Driver(val params: Params, val sparkContext: SparkContext, val logger: Pho
       recordsWithUniqueId,
       featureShardIdToFeatureSectionKeysMap,
       featureShardIdToFeatureMapLoader,
-      randomEffectIdTypeSet,
+      idTypeSet,
       isResponseRequired = false)
       .partitionBy(globalDataPartitioner)
       .setName("Game data set with UIDs for scoring")

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/cli/game/scoring/Params.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/cli/game/scoring/Params.scala
@@ -104,7 +104,7 @@ class Params extends FeatureParams with PalDBIndexMapParams with EvaluatorParams
       s"outputDir: $outputDir\n" +
       s"numOutputFilesForScores: $numOutputFilesForScores\n" +
       s"deleteOutputDirIfExists: $deleteOutputDirIfExists\n" +
-      s"evaluatorTypes: ${evaluatorTypes.mkString("\t")}\n " +
+      s"evaluatorTypes: ${evaluatorTypes.map(_.name).mkString("\t")}\n" +
       s"applicationName: $applicationName\n" +
       s"offHeapIndexMapDir: $offHeapIndexMapDir\n" +
       s"offHeapIndexMapNumPartitions: $offHeapIndexMapNumPartitions"

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/evaluation/PrecisionAtKEvaluator.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/evaluation/PrecisionAtKEvaluator.scala
@@ -19,9 +19,10 @@ import org.apache.spark.rdd.RDD
 import com.linkedin.photon.ml.constants.MathConst
 
 /**
- * Evaluator for Precision@k. Definition of this evaluator along with terminologies used here (documentId) can be
+ * Evaluator for Precision@k. Definition of this evaluator along with terminologies used here (e.g., documentId) can be
  * found at [[https://en.wikipedia.org/wiki/Information_retrieval#Precision_at_K]]. No special tiebreaker is used if
  * there are ties in scores, and one of them will be picked randomly.
+ *
  * @param k The cut-off rank based on which the precision is computed (precision @ k)
  * @param labelAndOffsetAndWeights A [[RDD]] of (id, (label, offset, weight)) tuples
  * @param documentIds Document ids based on which the labels and scores are grouped to form documents in order to

--- a/photon-ml/src/test/scala/com/linkedin/photon/ml/algorithm/CoordinateDescentTest.scala
+++ b/photon-ml/src/test/scala/com/linkedin/photon/ml/algorithm/CoordinateDescentTest.scala
@@ -14,8 +14,7 @@
  */
 package com.linkedin.photon.ml.algorithm
 
-import com.linkedin.photon.ml.constants.StorageLevel
-import com.linkedin.photon.ml.data.{DataSet, GameDatum, KeyValueScore, LabeledPoint}
+import com.linkedin.photon.ml.data.{KeyValueScore, LabeledPoint}
 import com.linkedin.photon.ml.evaluation.Evaluator
 import com.linkedin.photon.ml.function.DiffFunction
 import com.linkedin.photon.ml.optimization.game.OptimizationTracker
@@ -23,11 +22,8 @@ import com.linkedin.photon.ml.model.{GAMEModel, DatumScoringModel}
 import com.linkedin.photon.ml.supervised.model.GeneralizedLinearModel
 import com.linkedin.photon.ml.util.PhotonLogger
 
-import breeze.linalg.Vector
-import org.apache.spark.rdd.RDD
 import org.mockito.Matchers
 import org.mockito.Mockito._
-import org.testng.Assert._
 import org.testng.annotations.{DataProvider, Test}
 
 /**
@@ -47,7 +43,7 @@ class CoordinateDescentTest {
     // Create Coordinate mocks
     val coordinateIds = (0 until coordinateCount).map("coordinate" + _)
     val coordinates: Seq[(String,
-        FixedEffectCoordinate[_ <: GeneralizedLinearModel, _ <: DiffFunction[LabeledPoint]])] =
+      FixedEffectCoordinate[_ <: GeneralizedLinearModel, _ <: DiffFunction[LabeledPoint]])] =
       coordinateIds.map { coordinateId =>
         val coordinate = mock(
           classOf[FixedEffectCoordinate[_ <: GeneralizedLinearModel, _ <: DiffFunction[LabeledPoint]]])
@@ -88,7 +84,7 @@ class CoordinateDescentTest {
 
     // Verify the calls to updateModel
     if (coordinates.length == 1) {
-      verify(coordinates(0)._2, times(numIterations)).updateModel(models(0))
+      verify(coordinates.head._2, times(numIterations)).updateModel(models.head)
 
     } else {
       (coordinates zip models).map { case ((coordinateId, coordinate), model) =>

--- a/photon-ml/src/test/scala/com/linkedin/photon/ml/cli/game/EvaluatorParamsTest.scala
+++ b/photon-ml/src/test/scala/com/linkedin/photon/ml/cli/game/EvaluatorParamsTest.scala
@@ -14,24 +14,21 @@
  */
 package com.linkedin.photon.ml.cli.game
 
-import com.linkedin.photon.ml.evaluation.{EvaluatorType, PrecisionAtK}
+import org.testng.Assert._
+import org.testng.annotations.Test
 
-/**
- * Evaluator params common to GAME training and scoring.
- */
-trait EvaluatorParams {
-  /**
-   * A list of evaluators separated by comma. E.g, AUC,Precision@1:documentId,Precision@3:documentId,Logistic_Loss
-   */
-  var evaluatorTypes: Seq[EvaluatorType] = Seq()
+import com.linkedin.photon.ml.evaluation._
 
-  /**
-   * Get all id types used to compute precision@K
-   */
-  def getPrecisionAtKIdTypeSet: Set[String] = {
-    evaluatorTypes
-      .filter(_.isInstanceOf[PrecisionAtK])
-      .map { case PrecisionAtK(_, documentIdName) => documentIdName }
-      .toSet
+class EvaluatorParamsTest {
+
+  @Test
+  def precisionAtKIdTypeSetTest(): Unit = {
+    val expectedIdTypeSet = Set("documentId", "queryId", "foo", "bar")
+    val precisionAtKEvaluators = expectedIdTypeSet.toSeq.flatMap(t => Seq(1, 3, 5, 10).map(PrecisionAtK(_, t)))
+    val allEvaluators = Seq(AUC, RMSE, LogisticLoss) ++ precisionAtKEvaluators
+
+    val evaluatorParamsMocker = new EvaluatorParams {}
+    evaluatorParamsMocker.evaluatorTypes = allEvaluators
+    assertEquals(evaluatorParamsMocker.getPrecisionAtKIdTypeSet, expectedIdTypeSet)
   }
 }

--- a/photon-ml/src/test/scala/com/linkedin/photon/ml/util/TimerTest.scala
+++ b/photon-ml/src/test/scala/com/linkedin/photon/ml/util/TimerTest.scala
@@ -15,7 +15,7 @@
 package com.linkedin.photon.ml.util
 
 import org.mockito.Mockito._
-import org.testng.annotations.{AfterClass, BeforeClass, DataProvider, Test}
+import org.testng.annotations.Test
 import org.testng.Assert._
 
 /**


### PR DESCRIPTION
…tly when generating GAMEDatum from Avro generic records.

Otherwise, fixed effect model will not be able to use precision@k, even full GLMix model cannot use precision@k if the id used to compute the metric is not random effect id.

But unit test and integTest are updated to catch such a bug.