### PR TITLE
Bug fix: make GAME scoring backward compatible.

### DIFF
--- a/photon-ml/src/integTest/scala/com/linkedin/photon/ml/avro/ScoreProcessingUtilsTest.scala
+++ b/photon-ml/src/integTest/scala/com/linkedin/photon/ml/avro/ScoreProcessingUtilsTest.scala
@@ -29,22 +29,22 @@ class ScoreProcessingUtilsTest extends SparkTestUtils with TestTemplateWithTmpDi
       predictionScore = 1.0,
       label = Some(1.0),
       weight = Some(1.0),
-      idTypeToValueMap = Map(DefaultFieldNames.UID -> "1", "id2" -> "2")),
+      idTypeToValueMap = Map(AvroFieldNames.UID -> "1", "id2" -> "2")),
     ScoredItem(
       predictionScore = 0.0,
       label = Some(0.0),
       weight = Some(2.0),
-      idTypeToValueMap = Map(DefaultFieldNames.UID -> "3", "id2" -> "4")),
+      idTypeToValueMap = Map(AvroFieldNames.UID -> "3", "id2" -> "4")),
     ScoredItem(
       predictionScore = 0.5,
       label = Some(0.5),
       weight = Some(-1.0),
-      idTypeToValueMap = Map(DefaultFieldNames.UID -> "5", "id2" -> "6")),
+      idTypeToValueMap = Map(AvroFieldNames.UID -> "5", "id2" -> "6")),
     ScoredItem(
       predictionScore = -1.0,
       label = Some(-0.5),
       weight = Some(0.0),
-      idTypeToValueMap = Map(DefaultFieldNames.UID -> "7", "id2" -> "8"))
+      idTypeToValueMap = Map(AvroFieldNames.UID -> "7", "id2" -> "8"))
   )
 
   private val scoredItemsWithoutUid = Array(
@@ -59,22 +59,22 @@ class ScoreProcessingUtilsTest extends SparkTestUtils with TestTemplateWithTmpDi
       predictionScore = 1.0,
       label = None,
       weight = Some(1.0),
-      idTypeToValueMap = Map(DefaultFieldNames.UID -> "1", "id2" -> "2")),
+      idTypeToValueMap = Map(AvroFieldNames.UID -> "1", "id2" -> "2")),
     ScoredItem(
       predictionScore = 0.0,
       label = None,
       weight = Some(2.0),
-      idTypeToValueMap = Map(DefaultFieldNames.UID -> "3", "id2" -> "4")),
+      idTypeToValueMap = Map(AvroFieldNames.UID -> "3", "id2" -> "4")),
     ScoredItem(
       predictionScore = 0.5,
       label = None,
       weight = Some(-1.0),
-      idTypeToValueMap = Map(DefaultFieldNames.UID -> "5", "id2" -> "6")),
+      idTypeToValueMap = Map(AvroFieldNames.UID -> "5", "id2" -> "6")),
     ScoredItem(
       predictionScore = -1.0,
       label = None,
       weight = Some(0.0),
-      idTypeToValueMap = Map(DefaultFieldNames.UID -> "7", "id2" -> "8"))
+      idTypeToValueMap = Map(AvroFieldNames.UID -> "7", "id2" -> "8"))
   )
 
   private val scoredItemsWithoutWeight = Array(
@@ -82,22 +82,22 @@ class ScoreProcessingUtilsTest extends SparkTestUtils with TestTemplateWithTmpDi
       predictionScore = 1.0,
       label = Some(1.0),
       weight = None,
-      idTypeToValueMap = Map(DefaultFieldNames.UID -> "1", "id2" -> "2")),
+      idTypeToValueMap = Map(AvroFieldNames.UID -> "1", "id2" -> "2")),
     ScoredItem(
       predictionScore = 0.0,
       label = Some(0.0),
       weight = None,
-      idTypeToValueMap = Map(DefaultFieldNames.UID -> "3", "id2" -> "4")),
+      idTypeToValueMap = Map(AvroFieldNames.UID -> "3", "id2" -> "4")),
     ScoredItem(
       predictionScore = 0.5,
       label = Some(0.5),
       weight = None,
-      idTypeToValueMap = Map(DefaultFieldNames.UID -> "5", "id2" -> "6")),
+      idTypeToValueMap = Map(AvroFieldNames.UID -> "5", "id2" -> "6")),
     ScoredItem(
       predictionScore = -1.0,
       label = Some(-0.5),
       weight = None,
-      idTypeToValueMap = Map(DefaultFieldNames.UID -> "7", "id2" -> "8"))
+      idTypeToValueMap = Map(AvroFieldNames.UID -> "7", "id2" -> "8"))
   )
 
   private val scoredItemsWithoutIds = Array(
@@ -119,12 +119,12 @@ class ScoreProcessingUtilsTest extends SparkTestUtils with TestTemplateWithTmpDi
       predictionScore = 1.0,
       label = None,
       weight = Some(1.0),
-      idTypeToValueMap = Map(DefaultFieldNames.UID -> "1", "id2" -> "2")),
+      idTypeToValueMap = Map(AvroFieldNames.UID -> "1", "id2" -> "2")),
     ScoredItem(
       predictionScore = 0.0,
       label = Some(0.0),
       weight = None,
-      idTypeToValueMap = Map(DefaultFieldNames.UID -> "3", "id2" -> "4")),
+      idTypeToValueMap = Map(AvroFieldNames.UID -> "3", "id2" -> "4")),
     ScoredItem(
       predictionScore = 0.5,
       label = Some(0.5),
@@ -134,7 +134,7 @@ class ScoreProcessingUtilsTest extends SparkTestUtils with TestTemplateWithTmpDi
       predictionScore = -1.0,
       label = Some(-0.5),
       weight = Some(0.0),
-      idTypeToValueMap = Map(DefaultFieldNames.UID -> "7", "id2" -> "8"))
+      idTypeToValueMap = Map(AvroFieldNames.UID -> "7", "id2" -> "8"))
   )
 
   @DataProvider
@@ -170,8 +170,8 @@ class ScoreProcessingUtilsTest extends SparkTestUtils with TestTemplateWithTmpDi
     assertEquals(loadedScoredItem.deep, scoredItems.deep)
 
     // Same unique ids
-    val loadedUids = loadedScoredItem.map(_.idTypeToValueMap.get(DefaultFieldNames.UID))
-    val uids = scoredItems.map(_.idTypeToValueMap.get(DefaultFieldNames.UID))
+    val loadedUids = loadedScoredItem.map(_.idTypeToValueMap.get(AvroFieldNames.UID))
+    val uids = scoredItems.map(_.idTypeToValueMap.get(AvroFieldNames.UID))
     assertEquals(loadedUids.deep, uids.deep)
   }
 }

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/avro/FieldNames.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/avro/FieldNames.scala
@@ -28,7 +28,3 @@ trait FieldNames extends Serializable {
   val offset: String
   val weight: String
 }
-
-object DefaultFieldNames {
-  val UID = "uid"
-}

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/avro/data/ScoreProcessingUtils.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/avro/data/ScoreProcessingUtils.scala
@@ -21,7 +21,7 @@ import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
 
 import com.linkedin.photon.avro.generated.ScoringResultAvro
-import com.linkedin.photon.ml.avro.{AvroIOUtils, DefaultFieldNames}
+import com.linkedin.photon.ml.avro.{AvroIOUtils, AvroFieldNames}
 import com.linkedin.photon.ml.cli.game.scoring.ScoredItem
 
 
@@ -47,7 +47,7 @@ object ScoreProcessingUtils {
       val weight = Option(scoreAvro.getWeight()).map(_.toDouble)
       val ids = scoreAvro.getMetadataMap().asScala.map { case (k, v) => (k.toString, v.toString) }.toMap
       val idsWithUid = uid match {
-        case Some(id) => ids + (DefaultFieldNames.UID -> id)
+        case Some(id) => ids + (AvroFieldNames.UID -> id)
         case _ => ids
       }
       val modelId = scoreAvro.getModelId.toString
@@ -67,7 +67,7 @@ object ScoreProcessingUtils {
       val builder = ScoringResultAvro.newBuilder()
       builder.setPredictionScore(predictionScore)
       builder.setModelId(modelId)
-      ids.get(DefaultFieldNames.UID).foreach(builder.setUid(_))
+      ids.get(AvroFieldNames.UID).foreach(builder.setUid(_))
       labelOpt.foreach(builder.setLabel(_))
       weightOpt.foreach(builder.setWeight(_))
       builder.setMetadataMap(metaDataMap)

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/cli/game/scoring/Driver.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/cli/game/scoring/Driver.scala
@@ -80,7 +80,7 @@ class Driver(val params: Params, val sparkContext: SparkContext, val logger: Pho
       featureShardIdToFeatureSectionKeysMap,
       featureShardIdToFeatureMapLoader,
       idTypeSet,
-      isResponseRequired = false)
+      isForModelTraining = false)
       .partitionBy(globalDataPartitioner)
       .setName("Game data set with UIDs for scoring")
       .persist(StorageLevel.INFREQUENT_REUSE_RDD_STORAGE_LEVEL)

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/cli/game/training/Driver.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/cli/game/training/Driver.scala
@@ -113,7 +113,7 @@ final class Driver(val params: Params, val sparkContext: SparkContext, val logge
       featureShardIdToFeatureSectionKeysMap,
       featureShardIdToFeatureMapLoader,
       idTypeSet,
-      isResponseRequired = true)
+      isForModelTraining = true)
       .partitionBy(globalDataPartitioner)
       .setName("GAME training data")
       .persist(StorageLevel.INFREQUENT_REUSE_RDD_STORAGE_LEVEL)
@@ -243,7 +243,7 @@ final class Driver(val params: Params, val sparkContext: SparkContext, val logge
       featureShardIdToFeatureSectionKeysMap,
       featureShardIdToFeatureMapLoader,
       idTypeSet,
-      isResponseRequired = true)
+      isForModelTraining = true)
       .partitionBy(partitioner).setName("Validating Game data set")
       .persist(StorageLevel.INFREQUENT_REUSE_RDD_STORAGE_LEVEL)
 

--- a/photon-ml/src/test/scala/com/linkedin/photon/ml/avro/data/DataProcessingUtilsTest.scala
+++ b/photon-ml/src/test/scala/com/linkedin/photon/ml/avro/data/DataProcessingUtilsTest.scala
@@ -30,6 +30,46 @@ class DataProcessingUtilsTest {
   import DataProcessingUtilsTest._
 
   @Test
+  def testGetGameDatumFromGenericRecordWithUID(): Unit = {
+    val record = new GenericData.Record(SchemaBuilder
+        .record("testGetGameDatumFromGenericRecordWithUID")
+        .namespace("com.linkedin.photon.ml.avro.data")
+        .fields()
+        .name(AvroFieldNames.UID).`type`().stringType().noDefault()
+        .endRecord())
+    val uid = "foo"
+    record.put(AvroFieldNames.UID, uid)
+
+    val gameDatum = DataProcessingUtils.getGameDatumFromGenericRecord(
+      record = record,
+      featureShardIdToFeatureSectionKeysMap = Map(),
+      featureShardIdToIndexMap = Map(),
+      shardIdToFeatureDimensionMap = Map(),
+      idTypeSet = Set(),
+      isForModelTraining = false)
+
+    assertEquals(gameDatum.idTypeToValueMap.get(AvroFieldNames.UID), Some(uid))
+  }
+
+  @Test(expectedExceptions = Array(classOf[IllegalArgumentException]))
+  def testGetGameDatumFromGenericRecordWithNoResponse(): Unit = {
+    val record = new GenericData.Record(SchemaBuilder
+        .record("testGetGameDatumFromGenericRecordWithNoResponse")
+        .namespace("com.linkedin.photon.ml.avro.data")
+        .fields()
+        .name(AvroFieldNames.RESPONSE).`type`().stringType().noDefault()
+        .endRecord())
+
+    DataProcessingUtils.getGameDatumFromGenericRecord(
+      record = record,
+      featureShardIdToFeatureSectionKeysMap = Map(),
+      featureShardIdToIndexMap = Map(),
+      shardIdToFeatureDimensionMap = Map(),
+      idTypeSet = Set(),
+      isForModelTraining = true)
+  }
+
+  @Test
   def testMakeRandomEffectIdMapWithIdField(): Unit = {
     val record = new GenericData.Record(SchemaBuilder
       .record("testRecordForRandomIdFetch1")

--- a/photon-ml/src/test/scala/com/linkedin/photon/ml/data/GAMEDatumTest.scala
+++ b/photon-ml/src/test/scala/com/linkedin/photon/ml/data/GAMEDatumTest.scala
@@ -20,8 +20,6 @@ import breeze.linalg.Vector
 import org.testng.Assert._
 import org.testng.annotations.{DataProvider, Test}
 
-import com.linkedin.photon.ml.avro.DefaultFieldNames
-
 class GAMEDatumTest {
 
   import GAMEDatumTest._
@@ -31,7 +29,7 @@ class GAMEDatumTest {
     offsetOpt = Some(-10.0),
     weightOpt = Some(5.0),
     featureShardContainer = Map(DEFAULT_SHARD_ID -> Vector.zeros[Double](1)),
-    idTypeToValueMap = Map(DefaultFieldNames.UID -> "uid")
+    idTypeToValueMap = Map("foo" -> "bar")
   )
 
   private val gameDatumWithoutOffset = new GameDatum(
@@ -39,7 +37,7 @@ class GAMEDatumTest {
     offsetOpt = None,
     weightOpt = Some(5.0),
     featureShardContainer = Map(DEFAULT_SHARD_ID -> Vector.zeros[Double](1)),
-    idTypeToValueMap = Map(DefaultFieldNames.UID -> "uid")
+    idTypeToValueMap = Map("foo" -> "bar")
   )
 
   private val gameDatumWithoutWeight = new GameDatum(
@@ -47,7 +45,7 @@ class GAMEDatumTest {
     offsetOpt = Some(-10.0),
     weightOpt = None,
     featureShardContainer = Map(DEFAULT_SHARD_ID -> Vector.zeros[Double](1)),
-    idTypeToValueMap = Map(DefaultFieldNames.UID -> "uid")
+    idTypeToValueMap = Map("uid" -> "uid")
   )
 
   private val gameDatumWithoutIdTypeToValueMap = new GameDatum(


### PR DESCRIPTION
Sorry folks, here is another PR to address some PROD issues caused by PR #166.

The main problem is that, previously GAME's scoring module would automatically find a field call "uid" in the scoring data and populate it to the scoring results in the format of ```ScoringResultAvro```. However, with PR #166, the users are required to instruct GAME to look for the "uid" field explicitly, otherwise the "uid" field in ```ScoringResultAvro``` would be null by default, which is not backward compatible and will break things.

Now with the fix proposed in this PR, "uid" will be added automatically to ```GameDatum``` again with GAME scoring job.

I really look forward to the upcoming Photon client redesign and refactoring, which should make our life easier :)