### PR TITLE
Revert function argument name to make it backward compatible.

### DIFF
--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/cli/game/scoring/Driver.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/cli/game/scoring/Driver.scala
@@ -80,7 +80,7 @@ class Driver(val params: Params, val sparkContext: SparkContext, val logger: Pho
       featureShardIdToFeatureSectionKeysMap,
       featureShardIdToFeatureMapLoader,
       idTypeSet,
-      isForModelTraining = false)
+      isResponseRequired = false)
       .partitionBy(globalDataPartitioner)
       .setName("Game data set with UIDs for scoring")
       .persist(StorageLevel.INFREQUENT_REUSE_RDD_STORAGE_LEVEL)

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/cli/game/training/Driver.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/cli/game/training/Driver.scala
@@ -113,7 +113,7 @@ final class Driver(val params: Params, val sparkContext: SparkContext, val logge
       featureShardIdToFeatureSectionKeysMap,
       featureShardIdToFeatureMapLoader,
       idTypeSet,
-      isForModelTraining = true)
+      isResponseRequired = true)
       .partitionBy(globalDataPartitioner)
       .setName("GAME training data")
       .persist(StorageLevel.INFREQUENT_REUSE_RDD_STORAGE_LEVEL)
@@ -243,7 +243,7 @@ final class Driver(val params: Params, val sparkContext: SparkContext, val logge
       featureShardIdToFeatureSectionKeysMap,
       featureShardIdToFeatureMapLoader,
       idTypeSet,
-      isForModelTraining = true)
+      isResponseRequired = true)
       .partitionBy(partitioner).setName("Validating Game data set")
       .persist(StorageLevel.INFREQUENT_REUSE_RDD_STORAGE_LEVEL)
 

--- a/photon-ml/src/test/scala/com/linkedin/photon/ml/avro/data/DataProcessingUtilsTest.scala
+++ b/photon-ml/src/test/scala/com/linkedin/photon/ml/avro/data/DataProcessingUtilsTest.scala
@@ -40,15 +40,14 @@ class DataProcessingUtilsTest {
     val uid = "foo"
     record.put(AvroFieldNames.UID, uid)
 
-    val gameDatum = DataProcessingUtils.getGameDatumFromGenericRecord(
+    val gameDatumWithoutResponse = DataProcessingUtils.getGameDatumFromGenericRecord(
       record = record,
       featureShardIdToFeatureSectionKeysMap = Map(),
       featureShardIdToIndexMap = Map(),
       shardIdToFeatureDimensionMap = Map(),
       idTypeSet = Set(),
-      isForModelTraining = false)
-
-    assertEquals(gameDatum.idTypeToValueMap.get(AvroFieldNames.UID), Some(uid))
+      isResponseRequired = false)
+    assertEquals(gameDatumWithoutResponse.idTypeToValueMap.get(AvroFieldNames.UID), Some(uid))
   }
 
   @Test(expectedExceptions = Array(classOf[IllegalArgumentException]))
@@ -66,7 +65,7 @@ class DataProcessingUtilsTest {
       featureShardIdToIndexMap = Map(),
       shardIdToFeatureDimensionMap = Map(),
       idTypeSet = Set(),
-      isForModelTraining = true)
+      isResponseRequired = true)
   }
 
   @Test


### PR DESCRIPTION
Sorry folks, another PR for to make Photon-ML backward compatible.

Lesson learned: I didn't realize that the naming of parameters of Scala's functions (not the naming of the function or the signature of the function) would lead to such compatibility issues. Need to be more careful next time.