### PR TITLE
Use sc.union to union RDDs from multiple files

### DIFF
--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/avro/AvroUtils.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/avro/AvroUtils.scala
@@ -55,10 +55,10 @@ object AvroUtils {
 
     assert(inputPaths.nonEmpty, "The number of input paths is zero.")
     val minPartitionsPerPath = math.ceil(1.0 * minPartitions / inputPaths.length).toInt
-    inputPaths.map { path =>
+    sc.union(inputPaths.map { path =>
       sc.hadoopFile[AvroWrapper[GenericRecord], NullWritable, AvroInputFormat[GenericRecord]](path,
         minPartitionsPerPath)
-    }.reduce(_ ++ _).map(_._1.datum())
+    }).map(_._1.datum())
   }
 
   /**


### PR DESCRIPTION
In cases with very many (90+) input files, we were getting a stack
overflow error here because of the long RDD lineage resulting from
unioning the RDDs one-by-one. This should address
the problem by producing a flat lineage.