### PR TITLE
Change differentiation function names to follow Euler's notation

### DIFF
--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/evaluation/LogisticLossEvaluator.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/evaluation/LogisticLossEvaluator.scala
@@ -32,7 +32,7 @@ protected[ml] class LogisticLossEvaluator(
     scoresAndLabelsAndWeights: RDD[(Long, (Double, Double, Double))]): Double = {
 
     scoresAndLabelsAndWeights
-      .map { case (_, (score, label, weight)) => weight * LogisticLossFunction.loss(score, label)._1 }
+      .map { case (_, (score, label, weight)) => weight * LogisticLossFunction.lossAndDzLoss(score, label)._1 }
       .reduce(_ + _)
   }
 

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/evaluation/PoissonLossEvaluator.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/evaluation/PoissonLossEvaluator.scala
@@ -32,7 +32,7 @@ protected[ml] class PoissonLossEvaluator(
     scoresAndLabelsAndWeights: RDD[(Long, (Double, Double, Double))]): Double = {
 
     scoresAndLabelsAndWeights.map { case (_, (score, label, weight)) =>
-        weight * PoissonLossFunction.loss(score, label)._1
+        weight * PoissonLossFunction.lossAndDzLoss(score, label)._1
       }
       .reduce(_ + _)
   }

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/evaluation/SmoothedHingeLossEvaluator.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/evaluation/SmoothedHingeLossEvaluator.scala
@@ -32,7 +32,7 @@ protected[ml] class SmoothedHingeLossEvaluator(
     scoresAndLabelsAndWeights: RDD[(Long, (Double, Double, Double))]): Double = {
 
     scoresAndLabelsAndWeights.map { case (_, (score, label, weight)) =>
-        weight * SmoothedHingeLossFunction.lossAndDerivative(score, label)._1
+        weight * SmoothedHingeLossFunction.lossAndDzLoss(score, label)._1
       }
       .reduce(_ + _)
   }

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/evaluation/SquaredLossEvaluator.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/evaluation/SquaredLossEvaluator.scala
@@ -32,7 +32,7 @@ protected[ml] class SquaredLossEvaluator(
     scoresAndLabelsAndWeights: RDD[(Long, (Double, Double, Double))]): Double = {
 
     scoresAndLabelsAndWeights.map { case (_, (score, label, weight)) =>
-        weight * SquaredLossFunction.loss(score, label)._1
+        weight * SquaredLossFunction.lossAndDzLoss(score, label)._1
       }
       .reduce(_ + _)
   }

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/function/HessianDiagonalAggregator.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/function/HessianDiagonalAggregator.scala
@@ -55,9 +55,9 @@ protected[ml] class HessianDiagonalAggregator(func: PointwiseLossFunction, val d
     require(features.size == dim, s"Size mismatch. Coefficient size: $dim, features size: ${features.size}")
 
     val margin = datum.computeMargin(coefficients)
-    val d2ldz2 = func.d2lossdz2(margin, label)
+    val dzzLoss = func.DzzLoss(margin, label)
 
-    axpy(weight * d2ldz2, features :* features, vectorSum)
+    axpy(weight * dzzLoss, features :* features, vectorSum)
     this
   }
 

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/function/HessianVectorAggregator.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/function/HessianVectorAggregator.scala
@@ -110,9 +110,9 @@ protected[ml] class HessianVectorAggregator(func: PointwiseLossFunction, dim: In
     val LabeledPoint(label, features, _, weight) = datum
     require(features.size == dim, s"Size mismatch. Coefficient size: $dim, features size: ${features.size}")
     val margin = datum.computeMargin(effectiveCoefficients) + marginShift
-    val d2ldz2 = func.d2lossdz2(margin, label)
+    val dzzLoss = func.DzzLoss(margin, label)
     // l'' * (\sum_k x_{ki} * effectiveMultiplyVector_k - featureVectorProductShift)
-    val effectiveWeight = weight * d2ldz2 * (features.dot(effectiveMultiplyVector) - featureVectorProductShift)
+    val effectiveWeight = weight * dzzLoss * (features.dot(effectiveMultiplyVector) - featureVectorProductShift)
 
     totalCnt += 1
     vectorShiftPrefactorSum += effectiveWeight

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/function/ValueAndGradientAggregator.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/function/ValueAndGradientAggregator.scala
@@ -143,12 +143,12 @@ protected[ml] class ValueAndGradientAggregator(func: PointwiseLossFunction, val 
       features.size == effectiveCoefficients.size,
       s"Size mismatch. Coefficient size: ${effectiveCoefficients.size}, features size: ${features.size}")
     val margin = datum.computeMargin(effectiveCoefficients) + marginShift
-    val (l, dldz) = func.loss(margin, label)
+    val (loss, dzLoss) = func.lossAndDzLoss(margin, label)
 
     totalCnt += 1
-    valueSum += weight * l
-    vectorShiftPrefactorSum += weight * dldz
-    axpy(weight * dldz, features, vectorSum)
+    valueSum += weight * loss
+    vectorShiftPrefactorSum += weight * dzLoss
+    axpy(weight * dzLoss, features, vectorSum)
 
     this
   }

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/function/glm/LogisticLossFunction.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/function/glm/LogisticLossFunction.scala
@@ -65,7 +65,7 @@ object LogisticLossFunction extends PointwiseLossFunction {
    * @param label The label, i.e. y in l(z, y)
    * @return The value and the 1st derivative
    */
-  override def loss(margin: Double, label: Double): (Double, Double) = {
+  override def lossAndDzLoss(margin: Double, label: Double): (Double, Double) = {
     if (label > MathConst.POSITIVE_RESPONSE_THRESHOLD) {
       // The following is equivalent to log(1 + exp(-margin)) but more numerically stable.
       (Utils.log1pExp(-margin), -sigmoid(-margin))
@@ -81,7 +81,7 @@ object LogisticLossFunction extends PointwiseLossFunction {
    * @param label The label, i.e. y in l(z, y)
    * @return The value and the 2st derivative with respect to z
    */
-  override def d2lossdz2(margin: Double, label: Double): Double = {
+  override def DzzLoss(margin: Double, label: Double): Double = {
     val s = sigmoid(margin)
     s * (1 - s)
   }

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/function/glm/PointwiseLossFunction.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/function/glm/PointwiseLossFunction.scala
@@ -29,6 +29,9 @@ package com.linkedin.photon.ml.function.glm
  * It is the negative of the log-likelihood for one data point, except for an irrelevant constant term.
  *
  * For example, for linear regression, l(z, y) = 1/2 (z - y)^2^.
+ *
+ * @note Function names follow the differentiation notation found here:
+ *       [[http://www.wikiwand.com/en/Notation_for_differentiation#/Euler.27s_notation]]
  */
 trait PointwiseLossFunction extends Serializable {
   /**
@@ -38,7 +41,7 @@ trait PointwiseLossFunction extends Serializable {
    * @param label The label, i.e. y in l(z, y)
    * @return The value and the 1st derivative
    */
-  def loss(margin: Double, label: Double): (Double, Double)
+  def lossAndDzLoss(margin: Double, label: Double): (Double, Double)
 
   /**
    * Calculate the 2nd derivative with respect to z.
@@ -47,5 +50,5 @@ trait PointwiseLossFunction extends Serializable {
    * @param label The label, i.e. y in l(z, y)
    * @return The value and the 2st derivative with respect to z
    */
-  def d2lossdz2(margin: Double, label: Double): Double
+  def DzzLoss(margin: Double, label: Double): Double
 }

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/function/glm/PoissonLossFunction.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/function/glm/PoissonLossFunction.scala
@@ -37,7 +37,7 @@ object PoissonLossFunction extends PointwiseLossFunction {
    * @param label The label, i.e. y in l(z, y)
    * @return The value and the 1st derivative
    */
-  override def loss(margin: Double, label: Double): (Double, Double) = {
+  override def lossAndDzLoss(margin: Double, label: Double): (Double, Double) = {
     val prediction = math.exp(margin)
     (prediction - margin * label, prediction - label)
   }
@@ -49,5 +49,5 @@ object PoissonLossFunction extends PointwiseLossFunction {
    * @param label The label, i.e. y in l(z, y)
    * @return The value and the 2st derivative with respect to z
    */
-  override def d2lossdz2(margin: Double, label: Double): Double = math.exp(margin)
+  override def DzzLoss(margin: Double, label: Double): Double = math.exp(margin)
 }

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/function/glm/SquaredLossFunction.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/function/glm/SquaredLossFunction.scala
@@ -39,7 +39,7 @@ object SquaredLossFunction extends PointwiseLossFunction {
    * @param label The label, i.e. y in l(z, y)
    * @return The value and the 1st derivative
    */
-  override def loss(margin: Double, label: Double): (Double, Double) = {
+  override def lossAndDzLoss(margin: Double, label: Double): (Double, Double) = {
     val delta = margin - label
     (delta * delta / 2.0, delta)
   }
@@ -51,5 +51,5 @@ object SquaredLossFunction extends PointwiseLossFunction {
    * @param label The label, i.e. y in l(z, y)
    * @return The value and the 2st derivative with respect to z
    */
-  override def d2lossdz2(margin: Double, label: Double): Double = 1d
+  override def DzzLoss(margin: Double, label: Double): Double = 1d
 }

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/function/svm/SmoothedHingeLossFunction.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/function/svm/SmoothedHingeLossFunction.scala
@@ -23,6 +23,9 @@ import com.linkedin.photon.ml.data.LabeledPoint
  * Implement Rennie's smoothed hinge loss function (http://qwone.com/~jason/writing/smoothHinge.pdf) as an
  * optimizer-friendly approximation for linear SVMs. This Object is to the individual/distributed smoothed hinge loss
  * functions is as the PointwiseLossFunction is to the individual/distributed GLM loss functions.
+ *
+ * @note Function names follow the differentiation notation found here:
+ *       [[http://www.wikiwand.com/en/Notation_for_differentiation#/Euler.27s_notation]]
  */
 object SmoothedHingeLossFunction {
   /**
@@ -34,7 +37,7 @@ object SmoothedHingeLossFunction {
    * @param label The label, i.e. y in l(z, y)
    * @return The value and the 1st derivative
    */
-  def lossAndDerivative(margin: Double, label: Double): (Double, Double) = {
+  def lossAndDzLoss(margin: Double, label: Double): (Double, Double) = {
     val modifiedLabel = if (label < MathConst.POSITIVE_RESPONSE_THRESHOLD) -1D else 1D
     val z = modifiedLabel * margin
 
@@ -73,7 +76,7 @@ object SmoothedHingeLossFunction {
     cumGradient: Vector[Double]): Double = {
 
     val margin = datum.computeMargin(coefficients)
-    val (loss, deriv) = lossAndDerivative(margin, datum.label)
+    val (loss, deriv) = lossAndDzLoss(margin, datum.label)
 
     // Eq. 5, page 2 (derivative multiplied by label in lossAndDerivative method)
     breeze.linalg.axpy(datum.weight * deriv, datum.features, cumGradient)

--- a/photon-ml/src/test/scala/com/linkedin/photon/ml/function/LogisticLossFunctionTest.scala
+++ b/photon-ml/src/test/scala/com/linkedin/photon/ml/function/LogisticLossFunctionTest.scala
@@ -38,13 +38,13 @@ class LogisticLossFunctionTest {
     val negativeLabel = 0D
 
     // Test positive label
-    val (value1, _) = LogisticLossFunction.loss(margin, positiveLabel)
+    val (value1, _) = LogisticLossFunction.lossAndDzLoss(margin, positiveLabel)
     // Compute the expected value by explicit computation
     val expected1 = math.log(1 + math.exp(-margin))
     assertEquals(value1, expected1, delta)
 
     // Test negative label
-    val (value2, _) = LogisticLossFunction.loss(margin, negativeLabel)
+    val (value2, _) = LogisticLossFunction.lossAndDzLoss(margin, negativeLabel)
     val expected2 = math.log(1 + math.exp(margin))
     assertEquals(value2, expected2, delta)
   }
@@ -60,14 +60,14 @@ class LogisticLossFunctionTest {
     val negativeLabel = 0D
 
     // Test positive label
-    val (_, gradient1) = LogisticLossFunction.loss(margin, positiveLabel)
+    val (_, gradient1) = LogisticLossFunction.lossAndDzLoss(margin, positiveLabel)
     // Calculate gradient explicitly
     val expected1 = -1.0 / (1.0 + math.exp(margin))
     assertEquals(gradient1, expected1, delta)
 
     // Test negative label
     val expected2 = 1.0 / (1.0 + math.exp(-margin))
-    val (_, gradient2) = LogisticLossFunction.loss(margin, negativeLabel)
+    val (_, gradient2) = LogisticLossFunction.lossAndDzLoss(margin, negativeLabel)
     assertEquals(gradient2, expected2, delta)
   }
 
@@ -83,7 +83,7 @@ class LogisticLossFunctionTest {
     val margin1 = offset + features1.dot(coefficients1)
     val sigma1 = 1.0 / (1.0 + math.exp(-margin1))
     val expected1 = sigma1 * (1 - sigma1)
-    val D_1 = LogisticLossFunction.d2lossdz2(margin1, label)
+    val D_1 = LogisticLossFunction.DzzLoss(margin1, label)
     assertEquals(D_1, expected1, delta)
 
     // Test non-zero vectors
@@ -92,7 +92,7 @@ class LogisticLossFunctionTest {
     val margin2 = offset + features2.dot(coefficients2)
     val sigma2 = 1.0 / (1.0 + math.exp(-margin2))
     val expected2 = sigma2 * (1 - sigma2)
-    val D_2 = LogisticLossFunction.d2lossdz2(margin2, label)
+    val D_2 = LogisticLossFunction.DzzLoss(margin2, label)
     assertEquals(D_2, expected2, delta)
   }
 }


### PR DESCRIPTION
This change was suggested by Frank for PR #131, but I forgot to add it.