### PR TITLE
Fix type of "modelClass" in BayesianLinearModelAvro

### DIFF
--- a/photon-avro-schemas/src/main/avro/BayesianLinearModelAvro.avsc
+++ b/photon-avro-schemas/src/main/avro/BayesianLinearModelAvro.avsc
@@ -11,7 +11,10 @@
         {
             "default": null,
             "name": "modelClass",
-            "type": "string",
+            "type": [
+                "null",
+                "string"
+            ],
             "doc": "The fully-qualified class name of enclosing GLM model class. E.g.: com.linkedin.photon.ml.supervised.classification.LogisticRegressionModel"
         },
         {


### PR DESCRIPTION
This was previously generating a warning, since "string" cannot be null.