### PR TITLE
Exclude netty from dependency on avro-mapred

### DIFF
--- a/photon-ml/build.gradle
+++ b/photon-ml/build.gradle
@@ -23,7 +23,11 @@ dependencies {
 
   compile('org.apache.avro:avro:1.7.7')
   compile('org.apache.avro:avro-compiler:1.7.7')
-  compile('org.apache.avro:avro-mapred:1.7.7')
+
+  compile('org.apache.avro:avro-mapred:1.7.7') {
+    // We don't need to import netty, and including it can cause version conflicts in downstream projects
+    exclude group: 'io.netty'
+  }
 
   compile('com.xeiam.xchart:xchart:2.5.1') {
     // Cannot find this jar from Maven central or jcenter, and supposedly xcharts should be usable


### PR DESCRIPTION
We don't use this, and it causes version conflicts in downstream projects.