### PR TITLE
Fix map zipping bug in ModelProcessingUtilsTest

### DIFF
--- a/photon-ml/src/integTest/scala/com/linkedin/photon/ml/avro/ModelProcessingUtilsTest.scala
+++ b/photon-ml/src/integTest/scala/com/linkedin/photon/ml/avro/ModelProcessingUtilsTest.scala
@@ -190,7 +190,8 @@ class ModelProcessingUtilsTest extends SparkTestUtils with TestTemplateWithTmpDi
     def features(glm: GeneralizedLinearModel, featureIndexLoader: IndexMapLoader): Array[(String, Double)] =
       ModelProcessingUtils.extractGLMFeatures(glm, featureIndexLoader.indexMapForRDD())
 
-    (gameModel.toMap zip loadedGameModel.toMap) foreach {
+    // calling zip directly on maps doesn't zip on keys but just zips the underlying (key, value) iterables
+    (gameModel.toSortedMap zip loadedGameModel.toSortedMap) foreach {
 
       case ((n1: String, m1: FixedEffectModel), (n2: String, m2: FixedEffectModel)) =>
 

--- a/photon-ml/src/main/scala/com/linkedin/photon/ml/model/GAMEModel.scala
+++ b/photon-ml/src/main/scala/com/linkedin/photon/ml/model/GAMEModel.scala
@@ -14,7 +14,7 @@
  */
 package com.linkedin.photon.ml.model
 
-import scala.collection.Map
+import scala.collection.{Map, SortedMap}
 
 import org.apache.spark.rdd.RDD
 import org.apache.spark.storage.StorageLevel
@@ -92,6 +92,13 @@ class GAMEModel(gameModels: Map[String, DatumScoringModel], val taskType: TaskTy
    * @return The (modelName -> model) map representation of the models
    */
   protected[ml] def toMap: Map[String, DatumScoringModel] = gameModels
+
+  /**
+    * Convert the GAME model into a (modelName -> model) map representation that has a reliable order on keys
+    *
+    * @return The (modelName -> model) map representation of the models
+    */
+  protected[ml] def toSortedMap: SortedMap[String, DatumScoringModel] = SortedMap(gameModels.toSeq: _*)
 
   /**
    * Persist each model with the specified storage level if it's a RDD


### PR DESCRIPTION
Calling zip directly on maps doesn't zip on keys but just zips the underlying (key, value) iterables. So our current test is incorrect