### PR TITLE
Correct suggested regularization values

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ spark-submit \
   --output-directory "out" \
   --task "LOGISTIC_REGRESSION" \
   --num-iterations 50 \
-  --regularization-weights "0.1,1,10,100" \
+  --regularization-weights "0.001,0.01,0.1" \
   --job-name "demo_photon_ml_logistic_regression"
 ```
 
@@ -286,7 +286,7 @@ spark-submit \
   --output-directory "path/to/output/dir" \
   --task "LOGISTIC_REGRESSION" \
   --num-iterations 50 \
-  --regularization-weights "0.1,1,10" \
+  --regularization-weights "0.001,0.01,0.1" \
   --job-name "demo_photon_ml_logistic_regression"
 ```
 


### PR DESCRIPTION
If default regularization is L2, the regularization constant should be less than 1. 

For the case of gradient descent: `new_param = old_param - eta * ( lambda * old_param + gradient)` where `eta` is the learning rate. Suppose `eta = 1` for simplicity. If `lambda = 1`, this would annihilate the parameter and only learn the gradient at each step. If `lambda > 1`, this would oscillate.