### PR TITLE
Patch to keep model loading backwards compatible.

### DIFF
--- a/photon-client/src/main/scala/com/linkedin/photon/ml/avro/model/ModelProcessingUtils.scala
+++ b/photon-client/src/main/scala/com/linkedin/photon/ml/avro/model/ModelProcessingUtils.scala
@@ -214,7 +214,7 @@ object ModelProcessingUtils {
     val gameModel = new GAMEModel(models.toMap)
 
     require(
-      gameModel.modelType == modelType,
+      modelType == TaskType.NONE || gameModel.modelType == modelType,
       s"GAME model type ${gameModel.modelType} does not match type $modelType listed in metadata")
 
     (gameModel, featureIndexLoaders.toMap)
@@ -578,7 +578,7 @@ object ModelProcessingUtils {
         case Some(modelType) => TaskType.withName(modelType.group(1))
         case _ => throw new RuntimeException(s"Couldn't find 'modelType' in metadata file: $inputPath")
       }
-    }.getOrElse(TaskType.LINEAR_REGRESSION)
+    }.getOrElse(TaskType.NONE)
 
     params
   }

--- a/photon-lib/src/main/scala/com/linkedin/photon/ml/TaskType.scala
+++ b/photon-lib/src/main/scala/com/linkedin/photon/ml/TaskType.scala
@@ -19,5 +19,6 @@ package com.linkedin.photon.ml
  */
 object TaskType extends Enumeration {
   type TaskType = Value
+  // Currently 'NONE' is used for backwards compatibility when loading models of unrecorded type.
   val LINEAR_REGRESSION, POISSON_REGRESSION, LOGISTIC_REGRESSION, SMOOTHED_HINGE_LOSS_LINEAR_SVM, NONE = Value
 }


### PR DESCRIPTION
When loading old models without metadata, we should accept them as long as all of the sub-models have consistent type.