### PR TITLE
Fix Spark 2.1 compatibility issues

### DIFF
--- a/photon-client/src/integTest/scala/com/linkedin/photon/ml/estimators/GameEstimatorTest.scala
+++ b/photon-client/src/integTest/scala/com/linkedin/photon/ml/estimators/GameEstimatorTest.scala
@@ -80,7 +80,8 @@ class GameEstimatorTest extends SparkTestUtils with GameTestUtils {
           (point.label, x) })
       .toDF(label, featureShardId)
 
-    val stats = BasicStatisticalSummary(trainingData.select(featureShardId).map(_.getAs[SparkVector](0)))
+    // Calling rdd explicitly here to avoid a typed encoder lookup in Spark 2.1
+    val stats = BasicStatisticalSummary(trainingData.select(featureShardId).rdd.map(_.getAs[SparkVector](0)))
 
     // We set args for the GAMEEstimator - only: so this is the minimum set of params required by GAMEEstimator
     // Default number of passes over the coordinates (numIterations) is 1, which is all we need if
@@ -181,7 +182,8 @@ class GameEstimatorTest extends SparkTestUtils with GameTestUtils {
           })
         .toDF(label, featureShardId)
 
-      val stats = BasicStatisticalSummary(trainingData.select(featureShardId).map(_.getAs[SparkVector](0)))
+      // Calling rdd explicitly here to avoid a typed encoder lookup in Spark 2.1
+      val stats = BasicStatisticalSummary(trainingData.select(featureShardId).rdd.map(_.getAs[SparkVector](0)))
 
       // Compute normalization contexts based on statistics of the training data for this (unique) feature shard
       val normalizationContexts: Option[Map[String, NormalizationContext]] =

--- a/photon-client/src/main/scala/com/linkedin/photon/ml/cli/game/training/Driver.scala
+++ b/photon-client/src/main/scala/com/linkedin/photon/ml/cli/game/training/Driver.scala
@@ -173,7 +173,8 @@ final class Driver(val sc: SparkContext, val params: GameParams, implicit val lo
     featureIndexMapLoaders.keys
       .map {
         featureShardId =>
-          (featureShardId, BasicStatisticalSummary(data.select(featureShardId).map(_.getAs[SparkVector](0))))
+          // Calling rdd explicitly here to avoid a typed encoder lookup in Spark 2.1
+          (featureShardId, BasicStatisticalSummary(data.select(featureShardId).rdd.map(_.getAs[SparkVector](0))))
       }
 
   /**

--- a/photon-lib/src/integTest/scala/com/linkedin/photon/ml/stat/BasicStatisticalSummaryTest.scala
+++ b/photon-lib/src/integTest/scala/com/linkedin/photon/ml/stat/BasicStatisticalSummaryTest.scala
@@ -73,7 +73,8 @@ class BasicStatisticalSummaryTest extends SparkTestUtils {
         .map { point: LabeledPoint => (point.label, VectorUtils.breezeToMllib(point.features)) })
       .toDF("response", featureShardId)
 
-    val stats = BasicStatisticalSummary(trainingData.select(featureShardId).map(_.getAs[SparkVector](0)))
+    // Calling rdd explicitly here to avoid a typed encoder lookup in Spark 2.1
+    val stats = BasicStatisticalSummary(trainingData.select(featureShardId).rdd.map(_.getAs[SparkVector](0)))
 
     assertEquals(stats.count, 10)
     assertEquals(stats.mean(0), 0.3847210904276229, EPSILON)


### PR DESCRIPTION
In Spark 2.1, when you map over a DataFrame/Dataset, it tries to do an implicit lookup of the approriate encoder for the row type. This fails in our case, because we have no such encoder. Mapping over the rdd view of the DataFrame/Dataset gets around this issue.