### PR TITLE
Store per-model Game config snapshots in a struct rather than String

### DIFF
--- a/photon-api/src/main/scala/com/linkedin/photon/ml/optimization/game/FactoredRandomEffectOptimizationConfiguration.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/optimization/game/FactoredRandomEffectOptimizationConfiguration.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017 LinkedIn Corp. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linkedin.photon.ml.optimization.game
+
+/**
+ * Configuration object for a factored random effect
+ *
+ * @param randomEffectOptimizationConfiguration the random effect optimization configuration
+ * @param latentFactorOptimizationConfiguration the latent factor optimization configuration
+ * @param mfOptimizationConfiguration the matrix factorization optimization configuration
+ */
+protected[ml] case class FactoredRandomEffectOptimizationConfiguration(
+    randomEffectOptimizationConfiguration: GLMOptimizationConfiguration,
+    latentFactorOptimizationConfiguration: GLMOptimizationConfiguration,
+    mfOptimizationConfiguration: MFOptimizationConfiguration)

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/optimization/game/GameModelOptimizationConfiguration.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/optimization/game/GameModelOptimizationConfiguration.scala
@@ -25,8 +25,7 @@ package com.linkedin.photon.ml.optimization.game
 case class GameModelOptimizationConfiguration(
     fixedEffectOptimizationConfiguration: Map[String, GLMOptimizationConfiguration],
     randomEffectOptimizationConfiguration: Map[String, GLMOptimizationConfiguration],
-    factoredRandomEffectOptimizationConfiguration: Map[String,
-      (GLMOptimizationConfiguration, GLMOptimizationConfiguration, MFOptimizationConfiguration)]) {
+    factoredRandomEffectOptimizationConfiguration: Map[String, FactoredRandomEffectOptimizationConfiguration]) {
 
   /**
     * Build a custom string representation of the configuration

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/optimization/game/GameModelOptimizationConfiguration.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/optimization/game/GameModelOptimizationConfiguration.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017 LinkedIn Corp. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linkedin.photon.ml.optimization.game
+
+/**
+  * Represents the complete Game optimization configuration as it appeared for a single run with a particular setting
+  * for each hyperparameter.
+  *
+  * @param fixedEffectOptimizationConfiguration the optimization configuration for each fixed effect
+  * @param randomEffectOptimizationConfiguration the optimization configuration for each random effect
+  * @param factoredRandomEffectOptimizationConfiguration the optimization configuration for each factored random effect
+  */
+case class GameModelOptimizationConfiguration(
+    fixedEffectOptimizationConfiguration: Map[String, GLMOptimizationConfiguration],
+    randomEffectOptimizationConfiguration: Map[String, GLMOptimizationConfiguration],
+    factoredRandomEffectOptimizationConfiguration: Map[String,
+      (GLMOptimizationConfiguration, GLMOptimizationConfiguration, MFOptimizationConfiguration)]) {
+
+  /**
+    * Build a custom string representation of the configuration
+    */
+  override def toString() = Seq(fixedEffectOptimizationConfiguration.mkString("\n"),
+    randomEffectOptimizationConfiguration.mkString("\n"),
+    factoredRandomEffectOptimizationConfiguration.mkString("\n")).mkString("\n")
+}

--- a/photon-client/src/integTest/scala/com/linkedin/photon/ml/estimators/GameEstimatorTest.scala
+++ b/photon-client/src/integTest/scala/com/linkedin/photon/ml/estimators/GameEstimatorTest.scala
@@ -30,6 +30,7 @@ import com.linkedin.photon.ml.evaluation.EvaluatorType._
 import com.linkedin.photon.ml.evaluation.{EvaluatorType, ShardedAUC, ShardedPrecisionAtK}
 import com.linkedin.photon.ml.model.{FixedEffectModel, GAMEModel}
 import com.linkedin.photon.ml.normalization.{NormalizationContext, NormalizationType}
+import com.linkedin.photon.ml.optimization.game.GameModelOptimizationConfiguration
 import com.linkedin.photon.ml.stat.BasicStatisticalSummary
 import com.linkedin.photon.ml.test.{CommonTestUtils, SparkTestUtils}
 import com.linkedin.photon.ml.util._
@@ -107,7 +108,7 @@ class GameEstimatorTest extends SparkTestUtils with GameTestUtils {
 
     // Create GAMEEstimator and fit model
     // Returns (model, evaluation, optimizer config)
-    val models: Seq[(GAMEModel, Option[EvaluationResults], String)] =
+    val models: Seq[(GAMEModel, Option[EvaluationResults], GameModelOptimizationConfiguration)] =
         createEstimator(params, "simpleTest")._1.fit(trainingData, validationData = None, normalizationContexts)
 
     val model = models.head._1.getModel(coordinateId).head.asInstanceOf[FixedEffectModel].model
@@ -194,7 +195,7 @@ class GameEstimatorTest extends SparkTestUtils with GameTestUtils {
 
       // Create GAMEEstimator and fit model
       // Returns (model, evaluation, optimizer config)
-      val models: Seq[(GAMEModel, Option[EvaluationResults], String)] =
+      val models: Seq[(GAMEModel, Option[EvaluationResults], GameModelOptimizationConfiguration)] =
       createEstimator(params, "simpleTest")._1.fit(trainingData, validationData = None, normalizationContexts)
 
       val model = models.head._1.getModel(coordinateId).head.asInstanceOf[FixedEffectModel].model

--- a/photon-client/src/main/scala/com/linkedin/photon/ml/estimators/GameEstimator.scala
+++ b/photon-client/src/main/scala/com/linkedin/photon/ml/estimators/GameEstimator.scala
@@ -354,9 +354,9 @@ class GameEstimator(val sc: SparkContext, val params: GameParams, implicit val l
 
           case randomEffectDataSet: RandomEffectDataSet =>
             val featureShardId = params.randomEffectDataConfigurations(coordinateId).featureShardId
-            val (randomEffectOptimizationConfiguration,
-            latentFactorOptimizationConfiguration,
-            mfOptimizationConfiguration) = factoredRandomEffectOptimizationConfiguration(coordinateId)
+            val FactoredRandomEffectOptimizationConfiguration(randomEffectOptimizationConfiguration,
+              latentFactorOptimizationConfiguration,
+              mfOptimizationConfiguration) = factoredRandomEffectOptimizationConfiguration(coordinateId)
             val (randomObjectiveFunction, latentObjectiveFunction) =
               selectRandomLatentObjectiveFunction(randomEffectOptimizationConfiguration,
                 latentFactorOptimizationConfiguration)

--- a/photon-client/src/main/scala/com/linkedin/photon/ml/estimators/GameParams.scala
+++ b/photon-client/src/main/scala/com/linkedin/photon/ml/estimators/GameParams.scala
@@ -25,7 +25,7 @@ import com.linkedin.photon.ml.data.{FixedEffectDataConfiguration, RandomEffectDa
 import com.linkedin.photon.ml.io.deprecated.ModelOutputMode
 import com.linkedin.photon.ml.io.deprecated.ModelOutputMode.ModelOutputMode
 import com.linkedin.photon.ml.normalization.NormalizationType
-import com.linkedin.photon.ml.optimization.game.{GLMOptimizationConfiguration, MFOptimizationConfiguration}
+import com.linkedin.photon.ml.optimization.game._
 import com.linkedin.photon.ml.util.{PalDBIndexMapParams, Utils}
 
 /**
@@ -135,8 +135,7 @@ class GameParams extends FeatureParams with PalDBIndexMapParams with EvaluatorPa
    * accepted and separated by semi-colon
    */
   var factoredRandomEffectOptimizationConfigurations:
-    Array[Map[CoordinateId,
-    (GLMOptimizationConfiguration, GLMOptimizationConfiguration, MFOptimizationConfiguration)]] = Array(Map())
+    Array[Map[CoordinateId, FactoredRandomEffectOptimizationConfiguration]] = Array(Map())
 
   /**
    * Configurations for all the random effect data sets.
@@ -415,7 +414,8 @@ object GameParams {
                 val randomEffectOptConfig = GLMOptimizationConfiguration.parseAndBuildFromString(s1)
                 val latentFactorOptConfig = GLMOptimizationConfiguration.parseAndBuildFromString(s2)
                 val mfOptimizationOptConfig = MFOptimizationConfiguration.parseAndBuildFromString(s3)
-                (key, (randomEffectOptConfig, latentFactorOptConfig, mfOptimizationOptConfig))
+                (key, FactoredRandomEffectOptimizationConfiguration(
+                  randomEffectOptConfig, latentFactorOptConfig, mfOptimizationOptConfig))
               }
               .toMap)
         )

--- a/photon-client/src/test/scala/com/linkedin/photon/ml/estimators/GameParamsTest.scala
+++ b/photon-client/src/test/scala/com/linkedin/photon/ml/estimators/GameParamsTest.scala
@@ -21,7 +21,7 @@ import com.linkedin.photon.ml.TaskType
 import com.linkedin.photon.ml.data.{FixedEffectDataConfiguration, RandomEffectDataConfiguration}
 import com.linkedin.photon.ml.io.deprecated.ModelOutputMode
 import com.linkedin.photon.ml.normalization.NormalizationType
-import com.linkedin.photon.ml.optimization.game.{GLMOptimizationConfiguration, MFOptimizationConfiguration}
+import com.linkedin.photon.ml.optimization.game._
 import com.linkedin.photon.ml.test.CommonTestUtils._
 
 /**
@@ -227,10 +227,10 @@ class GameParamsTest {
     val latentFactorOptConfig2 = GLMOptimizationConfiguration.parseAndBuildFromString(latentFactorOptConfig2InStr)
     val mfOptimizationOptConfig2 = MFOptimizationConfiguration.parseAndBuildFromString(mfOptimizationOptConfig2InStr)
     val expectedValue = Array(
-      Map("factor1" -> (randomEffectOptConfig1, latentFactorOptConfig1, mfOptimizationOptConfig1),
-        "factor2" -> (randomEffectOptConfig2, latentFactorOptConfig2, mfOptimizationOptConfig2)),
-      Map("factor1" -> (randomEffectOptConfig2, latentFactorOptConfig2, mfOptimizationOptConfig2),
-        "factor2" -> (randomEffectOptConfig1, latentFactorOptConfig1, mfOptimizationOptConfig1))
+      Map("factor1" -> FactoredRandomEffectOptimizationConfiguration(randomEffectOptConfig1, latentFactorOptConfig1, mfOptimizationOptConfig1),
+        "factor2" -> FactoredRandomEffectOptimizationConfiguration(randomEffectOptConfig2, latentFactorOptConfig2, mfOptimizationOptConfig2)),
+      Map("factor1" -> FactoredRandomEffectOptimizationConfiguration(randomEffectOptConfig2, latentFactorOptConfig2, mfOptimizationOptConfig2),
+        "factor2" -> FactoredRandomEffectOptimizationConfiguration(randomEffectOptConfig1, latentFactorOptConfig1, mfOptimizationOptConfig1))
     )
     assertEquals(params.factoredRandomEffectOptimizationConfigurations.deep, expectedValue.deep)
   }


### PR DESCRIPTION
In some cases (e.g. hyperparameter tuning) we need programmatic access to the configuration of the Game optimizers for a trained model. This exposes those settings in a struct and provides `toString` for the previous usages.