### PR TITLE
Change caching levels of RDDs

### DIFF
--- a/photon-client/src/main/scala/com/linkedin/photon/ml/cli/game/scoring/Driver.scala
+++ b/photon-client/src/main/scala/com/linkedin/photon/ml/cli/game/scoring/Driver.scala
@@ -115,7 +115,7 @@ class Driver(val params: Params, val sparkContext: SparkContext, val logger: Log
     // Load the model from HDFS, ignoring the feature index loader
     val (gameModel, _) =
       ModelProcessingUtils.loadGameModelFromHDFS(Some(featureShardIdToIndexMapLoader), gameModelInputDir, sparkContext)
-    gameModel.persist(StorageLevel.INFREQUENT_REUSE_RDD_STORAGE_LEVEL)
+    gameModel.persist(StorageLevel.VERY_FREQUENT_REUSE_RDD_STORAGE_LEVEL)
 
     if (logDatasetAndModelStats) {
       logger.debug(s"Loaded game model summary:\n${gameModel.toSummaryString}")
@@ -123,7 +123,7 @@ class Driver(val params: Params, val sparkContext: SparkContext, val logger: Log
 
     val scores = gameModel
       .score(gameDataSet)
-      .persistRDD(StorageLevel.INFREQUENT_REUSE_RDD_STORAGE_LEVEL)
+      .persistRDD(StorageLevel.FREQUENT_REUSE_RDD_STORAGE_LEVEL)
       .materialize()
 
     gameDataSet.unpersist()
@@ -146,7 +146,7 @@ class Driver(val params: Params, val sparkContext: SparkContext, val logger: Log
         Some(scoredGameDatum.weight),
         scoredGameDatum.idTypeToValueMap)
     }
-    scoredItems.setName("Scored items").persist(StorageLevel.INFREQUENT_REUSE_RDD_STORAGE_LEVEL)
+    scoredItems.setName("Scored items").persist(StorageLevel.FREQUENT_REUSE_RDD_STORAGE_LEVEL)
     if (logDatasetAndModelStats) {
       val numScoredItems = scoredItems.count()
       logger.info(s"Number of scored items to be written to HDFS: $numScoredItems \n")

--- a/photon-lib/src/main/scala/com/linkedin/photon/ml/constants/StorageLevel.scala
+++ b/photon-lib/src/main/scala/com/linkedin/photon/ml/constants/StorageLevel.scala
@@ -20,6 +20,7 @@ import org.apache.spark.storage.{StorageLevel => SparkStorageLevel}
  * Storage level constants.
  */
 object StorageLevel {
+  protected[ml] val VERY_FREQUENT_REUSE_RDD_STORAGE_LEVEL = SparkStorageLevel.MEMORY_ONLY
   protected[ml] val FREQUENT_REUSE_RDD_STORAGE_LEVEL = SparkStorageLevel.MEMORY_AND_DISK
   protected[ml] val INFREQUENT_REUSE_RDD_STORAGE_LEVEL = SparkStorageLevel.DISK_ONLY
 }


### PR DESCRIPTION
Based on experiments, changing levels of RDDs in scoring driver as follows:
1. gameDataSet: disk_only
2. gameModel: memory_only
3. scores: memory_and_disk