### PR TITLE
Verifying sample weights for training and validation data (optionally)

### DIFF
--- a/photon-client/src/integTest/scala/com/linkedin/photon/ml/DriverTest.scala
+++ b/photon-client/src/integTest/scala/com/linkedin/photon/ml/DriverTest.scala
@@ -38,7 +38,7 @@ import com.linkedin.photon.ml.optimization.{OptimizerType, RegularizationType}
 import com.linkedin.photon.ml.supervised.classification.LogisticRegressionModel
 import com.linkedin.photon.ml.supervised.model.GeneralizedLinearModel
 import com.linkedin.photon.ml.test.{CommonTestUtils, SparkTestUtils, TestTemplateWithTmpDir}
-import com.linkedin.photon.ml.util.{PhotonLogger, Utils}
+import com.linkedin.photon.ml.util.Utils
 
 /**
   * This class tests Driver with a set of important configuration parameters
@@ -46,39 +46,6 @@ import com.linkedin.photon.ml.util.{PhotonLogger, Utils}
 class DriverTest extends SparkTestUtils with TestTemplateWithTmpDir {
 
   import DriverTest._
-
-
-  @Test
-  def fromAvroTest(): Unit = sparkTest("fromAvroTest") {
-
-    val args = "--training-data-directory /Users/fastier/work/data" +
-      " --output-directory /Users/fastier/work/data/model" +
-      " --optimization-tracker true --job-name run-spark-train --task POISSON_REGRESSION --min-partitions 60" +
-      " --normalization-type STANDARDIZATION --regularization-type L2" +
-      " --regularization-weights 0.0001,0.001,0.01,0.1,1,10,100 --num-iterations 100 --format TRAINING_EXAMPLE" +
-      " --summarization-output-dir /Users/fastier/work/data/summarization" +
-      " --delete-output-dirs-if-exist true --convergence-tolerance 1e-8"
-    val params = PhotonMLCmdLineParser.parseFromCommandLine(args.split(" "))
-
-    val logPath = new Path(params.outputDir, "log-message.txt")
-    val logger = new PhotonLogger(logPath, sc)
-
-    logger.setLogLevel(PhotonLogger.LogLevelDebug)
-
-    try {
-      val job = new Driver(params, sc, logger)
-      job.run()
-
-    } catch {
-      case e: Exception =>
-        logger.error("Failure while running the driver", e)
-        throw e
-
-    } finally {
-      logger.close()
-      sc.stop()
-    }
-  }
 
   @Test
   def testRunWithMinimalArguments(): Unit = sparkTest("testRunWithMinimalArguments") {

--- a/photon-client/src/main/scala/com/linkedin/photon/ml/estimators/GameParams.scala
+++ b/photon-client/src/main/scala/com/linkedin/photon/ml/estimators/GameParams.scala
@@ -16,7 +16,6 @@ package com.linkedin.photon.ml.estimators
 
 import scopt.OptionParser
 
-import com.linkedin.photon.ml.PhotonOptionNames._
 import com.linkedin.photon.ml.TaskType
 import com.linkedin.photon.ml.TaskType.TaskType
 import com.linkedin.photon.ml.Types._
@@ -172,6 +171,11 @@ class GameParams extends FeatureParams with PalDBIndexMapParams with EvaluatorPa
    */
   var applicationName: String = "Game-Full-Model-Training"
 
+  /**
+   * Turn on additional tests on the training and validation data
+   */
+  var checkData: Boolean = false
+
   override def toString: String =
     s"trainDirs: ${trainDirs.mkString(", ")}\n" +
       s"trainDateRangeOpt: $trainDateRangeOpt\n" +
@@ -204,7 +208,8 @@ class GameParams extends FeatureParams with PalDBIndexMapParams with EvaluatorPa
       s"offHeapIndexMapDir: $offHeapIndexMapDir\n" +
       s"offHeapIndexMapNumPartitions: $offHeapIndexMapNumPartitions\n" +
       s"normalizationType: $normalizationType\n" +
-      s"summarizationOutputDirOpt: $summarizationOutputDirOpt"
+      s"summarizationOutputDirOpt: $summarizationOutputDirOpt\n" +
+      s"checkData: $checkData"
 }
 
 object GameParams {
@@ -242,6 +247,9 @@ object GameParams {
   val EVALUATOR_TYPE = "evaluator-type"
   val SUMMARIZATION_OUTPUT_DIR = "summarization-output-dir"
   val NORMALIZATION_TYPE = "normalization-type"
+  val OFFHEAP_INDEXMAP_DIR = "offheap-indexmap-dir"
+  val OFFHEAP_INDEXMAP_NUM_PARTITIONS = "offheap-indexmap-num-partitions"
+  val CHECK_DATA = "check-data"
 
   /**
    * Parse parameters for GAME from the arguments on the command line.
@@ -480,6 +488,11 @@ object GameParams {
       opt[String](SUMMARIZATION_OUTPUT_DIR)
         .text("An optional directory to output statistics about the training data")
         .foreach(x => params.summarizationOutputDirOpt = Some(x))
+
+      opt[Boolean](CHECK_DATA)
+        .text(s"Whether to check the data or not. " +
+          s"default: ${defaultParams.checkData}")
+        .foreach(x => params.checkData = x)
 
       help("help").text("prints usage text.")
 

--- a/photon-lib/src/main/scala/com/linkedin/photon/ml/util/Implicits.scala
+++ b/photon-lib/src/main/scala/com/linkedin/photon/ml/util/Implicits.scala
@@ -16,6 +16,8 @@ package com.linkedin.photon.ml.util
 
 import scala.language.higherKinds
 
+import org.apache.spark.sql.DataFrame
+
 /**
  * This object contains a few implicits that we used to make the syntax cleaner, by removing unessential details.
  * Note that as a team, we tend to avoid implicits when they make tracing harder ("invisible" implicits). In that
@@ -79,6 +81,15 @@ protected[ml] object Implicits {
    */
   implicit class TapOption[T](o: Option[T]) {
     def tap(f: T => Unit): Option[T] = { o.foreach(f); o }
+  }
+
+  /**
+   * Tap for DataFrame. See documentation for TapMap.
+   *
+   * @param o A DataFrame to tap
+   */
+  implicit class TapDataFrame(o: DataFrame) {
+    def tap(f: DataFrame => Unit): DataFrame = { f(o); o }
   }
 
   /**


### PR DESCRIPTION
We had a case where the weights for all the training samples were zero, causing the optimizer to not even start. 

This PR introduces code to check that the weights are all >= 0 and that at least one is > 0. Since this test could be costly, there is a new boolean parameter (`checkData`) to turn this check on or off. 