### PR TITLE
Fix bug that incorrectly logged all random effect models as not converging

### DIFF
--- a/photon-api/src/main/scala/com/linkedin/photon/ml/data/FixedEffectDataSet.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/data/FixedEffectDataSet.scala
@@ -42,6 +42,7 @@ protected[ml] class FixedEffectDataSet(
    * @return An updated dataset with scores added to offsets
    */
   override def addScoresToOffsets(scores: CoordinateDataScores): FixedEffectDataSet = {
+
     val updatedLabeledPoints = labeledPoints
       .leftOuterJoin(scores.scores)
       .mapValues { case (LabeledPoint(label, features, offset, weight), scoredDatumOption) =>
@@ -67,7 +68,9 @@ protected[ml] class FixedEffectDataSet(
    * @return This object with the name of [[labeledPoints]] assigned
    */
   override def setName(name: String): FixedEffectDataSet = {
+
     labeledPoints.setName(name)
+
     this
   }
 
@@ -79,7 +82,9 @@ protected[ml] class FixedEffectDataSet(
    * @return This object with the storage level of [[labeledPoints]] set
    */
   override def persistRDD(storageLevel: StorageLevel): FixedEffectDataSet = {
+
     if (!labeledPoints.getStorageLevel.isValid) labeledPoints.persist(storageLevel)
+
     this
   }
 
@@ -89,7 +94,9 @@ protected[ml] class FixedEffectDataSet(
    * @return This object with [[labeledPoints]] marked non-persistent
    */
   override def unpersistRDD(): FixedEffectDataSet = {
+
     if (labeledPoints.getStorageLevel.isValid) labeledPoints.unpersist()
+
     this
   }
 
@@ -99,7 +106,9 @@ protected[ml] class FixedEffectDataSet(
    * @return This object with [[labeledPoints]] materialized
    */
   override def materialize(): FixedEffectDataSet = {
-    labeledPoints.count()
+
+    materializeOnce(labeledPoints)
+
     this
   }
 
@@ -109,10 +118,12 @@ protected[ml] class FixedEffectDataSet(
    * @return A String representation of the dataset
    */
   override def toSummaryString: String = {
+
     val numSamples = labeledPoints.count()
     val weightSum = labeledPoints.values.map(_.weight).sum()
     val responseSum = labeledPoints.values.map(_.label).sum()
     val featureStats = labeledPoints.values.map(_.features.activeSize).stats()
+
     s"numSamples: $numSamples\nweightSum: $weightSum\nresponseSum: $responseSum" +
         s"\nnumFeatures: $numFeatures\nfeatureStats: $featureStats"
   }

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/model/MatrixFactorizationModel.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/model/MatrixFactorizationModel.scala
@@ -126,6 +126,7 @@ class MatrixFactorizationModel(
     stringBuilder.append(s"\nnumLatentFactors: $numLatentFactors")
     stringBuilder.append(s"\nrowLatentFactors L2 norm: $rowLatentFactorsL2NormStats")
     stringBuilder.append(s"\ncolLatentFactors L2 norm: $colLatentFactorsL2NormStats")
+
     stringBuilder.toString()
   }
 
@@ -147,6 +148,7 @@ class MatrixFactorizationModel(
 
     rowLatentFactors.setName(s"$name: row latent factors")
     colLatentFactors.setName(s"$name: col latent factors")
+
     this
   }
 
@@ -161,6 +163,7 @@ class MatrixFactorizationModel(
 
     if (!rowLatentFactors.getStorageLevel.isValid) rowLatentFactors.persist(storageLevel)
     if (!colLatentFactors.getStorageLevel.isValid) colLatentFactors.persist(storageLevel)
+
     this
   }
 
@@ -174,6 +177,7 @@ class MatrixFactorizationModel(
 
     if (rowLatentFactors.getStorageLevel.isValid) rowLatentFactors.unpersist()
     if (colLatentFactors.getStorageLevel.isValid) colLatentFactors.unpersist()
+
     this
   }
 
@@ -185,8 +189,8 @@ class MatrixFactorizationModel(
    */
   override def materialize(): MatrixFactorizationModel = {
 
-    rowLatentFactors.count()
-    colLatentFactors.count()
+    materializeOnce(rowLatentFactors, colLatentFactors)
+
     this
   }
 

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/model/RandomEffectModel.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/model/RandomEffectModel.scala
@@ -167,7 +167,7 @@ protected[ml] class RandomEffectModel(
    */
   override def materialize(): RandomEffectModel = {
 
-    modelsRDD.count()
+    materializeOnce(modelsRDD)
 
     this
   }

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/model/RandomEffectModelInProjectedSpace.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/model/RandomEffectModelInProjectedSpace.scala
@@ -139,7 +139,7 @@ protected[ml] class RandomEffectModelInProjectedSpace(
    */
   override def materialize(): RandomEffectModelInProjectedSpace = {
 
-    modelsInProjectedSpaceRDD.count()
+    materializeOnce(modelsInProjectedSpaceRDD)
 
     this
   }

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/optimization/RandomEffectOptimizationTracker.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/optimization/RandomEffectOptimizationTracker.scala
@@ -47,7 +47,9 @@ protected[ml] class RandomEffectOptimizationTracker(val optimizationStatesTracke
    * @return This object with the name of [[optimizationStatesTrackers]] assigned
    */
   override def setName(name: String): RandomEffectOptimizationTracker = {
+
     optimizationStatesTrackers.setName(name)
+
     this
   }
 
@@ -59,7 +61,9 @@ protected[ml] class RandomEffectOptimizationTracker(val optimizationStatesTracke
    * @return This object with the storage level of [[optimizationStatesTrackers]] set
    */
   override def persistRDD(storageLevel: StorageLevel): RandomEffectOptimizationTracker = {
+
     if (!optimizationStatesTrackers.getStorageLevel.isValid) optimizationStatesTrackers.persist(storageLevel)
+
     this
   }
 
@@ -69,7 +73,9 @@ protected[ml] class RandomEffectOptimizationTracker(val optimizationStatesTracke
    * @return This object with [[optimizationStatesTrackers]] marked non-persistent
    */
   override def unpersistRDD(): RandomEffectOptimizationTracker = {
+
     if (optimizationStatesTrackers.getStorageLevel.isValid) optimizationStatesTrackers.unpersist()
+
     this
   }
 
@@ -80,7 +86,9 @@ protected[ml] class RandomEffectOptimizationTracker(val optimizationStatesTracke
    * @return This object with [[optimizationStatesTrackers]] materialized
    */
   override def materialize(): RandomEffectOptimizationTracker = {
-    optimizationStatesTrackers.count()
+
+    materializeOnce(optimizationStatesTrackers)
+
     this
   }
 
@@ -89,40 +97,43 @@ protected[ml] class RandomEffectOptimizationTracker(val optimizationStatesTracke
    *
    * @return A map of convergence reason to its count of occurrence from the random effect optimization problems
    */
-  def countConvergenceReasons: Map[String, Int] = {
-    optimizationStatesTrackers.map { optimizationStatesTracker =>
-      if (optimizationStatesTracker.convergenceReason.isDefined) {
-        (optimizationStatesTracker.convergenceReason.get.reason, 1)
-      } else {
-        (RandomEffectOptimizationTracker.NOT_CONVERGED, 1)
+  def countConvergenceReasons: Map[String, Int] =
+
+    optimizationStatesTrackers
+      .map { optimizationStatesTracker =>
+        (optimizationStatesTracker
+          .convergenceReason
+          .map(_.reason)
+          .getOrElse(RandomEffectOptimizationTracker.NOT_CONVERGED), 1)
       }
-    }.reduceByKey(_ + _).collectAsMap()
-  }
+      .reduceByKey(_ + _)
+      .collectAsMap()
 
   /**
    * Get stats counter of the number of iterations tracked in all optimization states trackers
    *
    * @return A [[StatCounter]] of the number of iterations tracked in all optimization states trackers
    */
-  def getNumIterationStats: StatCounter = {
-    optimizationStatesTrackers.map(_.getTrackedStates.length).stats()
-  }
+  def getNumIterationStats: StatCounter = optimizationStatesTrackers.map(_.getTrackedStates.length).stats()
 
   /**
    * Get stats counter on the elapsed time tracked in all optimization states trackers
    *
    * @return A [[StatCounter]] of the elapsed time tracked in all optimization states trackers
    */
-  def getElapsedTimeStats: StatCounter = {
-    optimizationStatesTrackers.map { optimizationStatesTracker =>
-      val timeHistory = optimizationStatesTracker.getTrackedTimeHistory
-      if (timeHistory.length > 0) {
-        timeHistory.last * 1e-6
-      } else {
-        0.0
+  def getElapsedTimeStats: StatCounter =
+
+    optimizationStatesTrackers
+      .map { optimizationStatesTracker =>
+        val timeHistory = optimizationStatesTracker.getTrackedTimeHistory
+
+        if (timeHistory.length > 0) {
+          timeHistory.last * 1e-6
+        } else {
+          0.0
+        }
       }
-    }.stats()
-  }
+      .stats()
 
   /**
    * Build a summary string for the tracker
@@ -130,16 +141,18 @@ protected[ml] class RandomEffectOptimizationTracker(val optimizationStatesTracke
    * @return string representation
    */
   override def toSummaryString: String = {
+
     val convergenceReasons = countConvergenceReasons
     val numIterationsStats = getNumIterationStats
     val timeElapsedStats = getElapsedTimeStats
+
     RandomEffectOptimizationTracker.SUMMARY_FORMAT.format(convergenceReasons, numIterationsStats, timeElapsedStats)
   }
 }
 
 object RandomEffectOptimizationTracker{
-  protected[optimization] val NOT_CONVERGED = "Not converged"
 
+  protected[optimization] val NOT_CONVERGED = "Not converged"
   protected[optimization] val SUMMARY_FORMAT = "Convergence reasons stats:\n%s\nNumber of iterations stats: %s\n" +
     "Time elapsed stats: %s"
 }

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/optimization/game/GameModelOptimizationConfiguration.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/optimization/game/GameModelOptimizationConfiguration.scala
@@ -15,22 +15,23 @@
 package com.linkedin.photon.ml.optimization.game
 
 /**
-  * Represents the complete Game optimization configuration as it appeared for a single run with a particular setting
-  * for each hyperparameter.
-  *
-  * @param fixedEffectOptimizationConfiguration the optimization configuration for each fixed effect
-  * @param randomEffectOptimizationConfiguration the optimization configuration for each random effect
-  * @param factoredRandomEffectOptimizationConfiguration the optimization configuration for each factored random effect
-  */
+ * Represents the complete Game optimization configuration as it appeared for a single run with a particular setting
+ * for each hyperparameter.
+ *
+ * @param fixedEffectOptimizationConfiguration the optimization configuration for each fixed effect
+ * @param randomEffectOptimizationConfiguration the optimization configuration for each random effect
+ * @param factoredRandomEffectOptimizationConfiguration the optimization configuration for each factored random effect
+ */
 case class GameModelOptimizationConfiguration(
     fixedEffectOptimizationConfiguration: Map[String, GLMOptimizationConfiguration],
     randomEffectOptimizationConfiguration: Map[String, GLMOptimizationConfiguration],
     factoredRandomEffectOptimizationConfiguration: Map[String, FactoredRandomEffectOptimizationConfiguration]) {
 
   /**
-    * Build a custom string representation of the configuration
-    */
-  override def toString() = Seq(fixedEffectOptimizationConfiguration.mkString("\n"),
+   * Build a custom string representation of the configuration
+   */
+  override def toString = Seq(
+    fixedEffectOptimizationConfiguration.mkString("\n"),
     randomEffectOptimizationConfiguration.mkString("\n"),
     factoredRandomEffectOptimizationConfiguration.mkString("\n")).mkString("\n")
 }

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/optimization/game/RandomEffectOptimizationProblem.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/optimization/game/RandomEffectOptimizationProblem.scala
@@ -59,7 +59,9 @@ protected[ml] class RandomEffectOptimizationProblem[Objective <: SingleNodeObjec
    * @return This object with the name of [[optimizationProblems]] assigned
    */
   override def setName(name: String): this.type = {
+
     optimizationProblems.setName(s"$name: Optimization problems")
+
     this
   }
 
@@ -71,9 +73,9 @@ protected[ml] class RandomEffectOptimizationProblem[Objective <: SingleNodeObjec
    * @return This object with the storage level of [[optimizationProblems]] set
    */
   override def persistRDD(storageLevel: StorageLevel): this.type = {
-    if (!optimizationProblems.getStorageLevel.isValid) {
-      optimizationProblems.persist(storageLevel)
-    }
+
+    if (!optimizationProblems.getStorageLevel.isValid) optimizationProblems.persist(storageLevel)
+
     this
   }
 
@@ -83,9 +85,9 @@ protected[ml] class RandomEffectOptimizationProblem[Objective <: SingleNodeObjec
    * @return This object with [[optimizationProblems]] marked non-persistent
    */
   override def unpersistRDD(): this.type = {
-    if (optimizationProblems.getStorageLevel.isValid) {
-      optimizationProblems.unpersist()
-    }
+
+    if (optimizationProblems.getStorageLevel.isValid) optimizationProblems.unpersist()
+
     this
   }
 
@@ -95,7 +97,9 @@ protected[ml] class RandomEffectOptimizationProblem[Objective <: SingleNodeObjec
    * @return This object with [[optimizationProblems]] materialized
    */
   override def materialize(): this.type = {
-    optimizationProblems.count()
+
+    materializeOnce(optimizationProblems)
+
     this
   }
 
@@ -114,14 +118,13 @@ protected[ml] class RandomEffectOptimizationProblem[Objective <: SingleNodeObjec
    * @param modelsRDD The trained models
    * @return The combined regularization term value
    */
-  def getRegularizationTermValue(modelsRDD: RDD[(String, GeneralizedLinearModel)]): Double = {
+  def getRegularizationTermValue(modelsRDD: RDD[(String, GeneralizedLinearModel)]): Double =
     optimizationProblems
       .join(modelsRDD)
       .map {
         case (_, (optimizationProblem, model)) => optimizationProblem.getRegularizationTermValue(model)
       }
       .reduce(_ + _)
-  }
 }
 
 object RandomEffectOptimizationProblem {

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/projector/IndexMapProjectorRDD.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/projector/IndexMapProjectorRDD.scala
@@ -38,6 +38,7 @@ protected[ml] class IndexMapProjectorRDD private (indexMapProjectorRDD: RDD[(Str
    * @return The sharded data set in the projected space
    */
   override def projectRandomEffectDataSet(randomEffectDataSet: RandomEffectDataSet): RandomEffectDataSet = {
+
     val activeData = randomEffectDataSet.activeData
     val passiveDataOption = randomEffectDataSet.passiveDataOption
     val passiveDataRandomEffectIdsOption = randomEffectDataSet.passiveDataRandomEffectIdsOption
@@ -108,7 +109,9 @@ protected[ml] class IndexMapProjectorRDD private (indexMapProjectorRDD: RDD[(Str
    * @return This object with the name of [[indexMapProjectorRDD]] assigned
    */
   override def setName(name: String): IndexMapProjectorRDD = {
+
     indexMapProjectorRDD.setName(name)
+
     this
   }
 
@@ -120,7 +123,9 @@ protected[ml] class IndexMapProjectorRDD private (indexMapProjectorRDD: RDD[(Str
    * @return This object with the storage level of [[indexMapProjectorRDD]] set
    */
   override def persistRDD(storageLevel: StorageLevel): IndexMapProjectorRDD = {
+
     if (!indexMapProjectorRDD.getStorageLevel.isValid) indexMapProjectorRDD.persist(storageLevel)
+
     this
   }
 
@@ -130,7 +135,9 @@ protected[ml] class IndexMapProjectorRDD private (indexMapProjectorRDD: RDD[(Str
    * @return This object with [[indexMapProjectorRDD]] marked non-persistent
    */
   override def unpersistRDD(): IndexMapProjectorRDD = {
+
     if (indexMapProjectorRDD.getStorageLevel.isValid) indexMapProjectorRDD.unpersist()
+
     this
   }
 
@@ -140,7 +147,9 @@ protected[ml] class IndexMapProjectorRDD private (indexMapProjectorRDD: RDD[(Str
    * @return This object with [[indexMapProjectorRDD]] materialized
    */
   override def materialize(): IndexMapProjectorRDD = {
-    indexMapProjectorRDD.count()
+
+    materializeOnce(indexMapProjectorRDD)
+
     this
   }
 }

--- a/photon-client/src/main/scala/com/linkedin/photon/ml/cli/game/training/Driver.scala
+++ b/photon-client/src/main/scala/com/linkedin/photon/ml/cli/game/training/Driver.scala
@@ -402,7 +402,7 @@ object Driver {
         val logsDir = new Path(params.outputDir, LOGS).toString
         implicit val logger = new PhotonLogger(logsDir, sc)
         // TODO: This Photon log level should be made configurable
-        logger.setLogLevel(PhotonLogger.LogLevelInfo)
+        logger.setLogLevel(PhotonLogger.LogLevelDebug)
         logger.debug(params.toString + "\n")
 
         try {

--- a/photon-client/src/main/scala/com/linkedin/photon/ml/estimators/GameEstimator.scala
+++ b/photon-client/src/main/scala/com/linkedin/photon/ml/estimators/GameEstimator.scala
@@ -347,13 +347,13 @@ class GameEstimator(val sc: SparkContext, val params: GameParams, implicit val l
             new RandomEffectCoordinateInProjectedSpace(
               randomEffectDataSetInProjectedSpace,
               RandomEffectOptimizationProblem(
-                randomEffectDataSetInProjectedSpace,
-                optimizationConfiguration,
-                selectSingleNodeLossFunction(optimizationConfiguration),
-                glmConstructor,
-                contextBroadcasts.extractOrElse(featureShardId)(defaultNormalizationContext),
-                TRACK_STATE,
-                params.computeVariance)
+                  randomEffectDataSetInProjectedSpace,
+                  optimizationConfiguration,
+                  selectSingleNodeLossFunction(optimizationConfiguration),
+                  glmConstructor,
+                  contextBroadcasts.extractOrElse(featureShardId)(defaultNormalizationContext),
+                  TRACK_STATE,
+                  params.computeVariance)
                 .setName(s"Random effect optimization problem of coordinate $coordinateId")
                 .persistRDD(StorageLevel.INFREQUENT_REUSE_RDD_STORAGE_LEVEL))
 

--- a/photon-lib/src/main/scala/com/linkedin/photon/ml/data/scoring/DataScores.scala
+++ b/photon-lib/src/main/scala/com/linkedin/photon/ml/data/scoring/DataScores.scala
@@ -29,7 +29,9 @@ import com.linkedin.photon.ml.spark.RDDLike
  *
  * @param scores Data point scores, as described above
  */
-abstract protected[ml] class DataScores[T : ClassTag, D <: DataScores[T, D]](val scores: RDD[(Long, T)]) extends RDDLike {
+abstract protected[ml] class DataScores[T : ClassTag, D <: DataScores[T, D]](
+    val scores: RDD[(Long, T)])
+  extends RDDLike {
 
   /**
    * The addition operation for [[DataScores]].
@@ -63,7 +65,9 @@ abstract protected[ml] class DataScores[T : ClassTag, D <: DataScores[T, D]](val
    * @return This object with the name of [[scores]] assigned
    */
   override def setName(name: String): RDDLike = {
+
     scores.setName(name)
+
     this
   }
 
@@ -74,7 +78,9 @@ abstract protected[ml] class DataScores[T : ClassTag, D <: DataScores[T, D]](val
    * @return This object with the storage level of [[scores]] set
    */
   override def persistRDD(storageLevel: StorageLevel): RDDLike = {
+
     if (!scores.getStorageLevel.isValid) scores.persist(storageLevel)
+
     this
   }
 
@@ -84,7 +90,9 @@ abstract protected[ml] class DataScores[T : ClassTag, D <: DataScores[T, D]](val
    * @return This object with [[scores]] marked non-persistent
    */
   override def unpersistRDD(): RDDLike = {
+
     if (scores.getStorageLevel.isValid) scores.unpersist()
+
     this
   }
 
@@ -94,7 +102,9 @@ abstract protected[ml] class DataScores[T : ClassTag, D <: DataScores[T, D]](val
    * @return This object with [[scores]] materialized
    */
   override def materialize(): RDDLike = {
-    scores.count()
+
+    materializeOnce(scores)
+
     this
   }
 

--- a/photon-lib/src/main/scala/com/linkedin/photon/ml/optimization/Optimizer.scala
+++ b/photon-lib/src/main/scala/com/linkedin/photon/ml/optimization/Optimizer.scala
@@ -171,13 +171,8 @@ abstract class Optimizer[-Function <: ObjectiveFunction](
   /**
    * Determine the convergence reason once optimization is complete.
    */
-  protected def determineConvergenceReason(): Unit = {
-    // Set the convergenceReason when the optimization is done
-    statesTracker match {
-      case Some(y) => y.convergenceReason = getConvergenceReason
-      case None =>
-    }
-  }
+  protected def determineConvergenceReason(): Unit =
+    statesTracker.foreach(_.convergenceReason = getConvergenceReason)
 
   /**
    * Check whether optimization has completed.


### PR DESCRIPTION
- The RandomEffectOptimizationTracker was initialized using OptimizationStateTrackers the RDD of SingleNodeOptimizationProblems stored in a RandomEffectOptimizationProblem after optimization - however, this RDD is persisted to disk, so it was pulling the trackers in their original empty state
- Added a 'smartMaterialize' method to the RDDLike trait to only materialize unmaterialized RDDs

These changes had no significant impact on performance locally (5 second speed-up on a  16 minute job). Performance tests on the cluster did not reveal any significant performance change(+/- 100 seconds of training for a 90 minute job with 50 minutes of training).