### PR TITLE
Minor MathConst and GLMSuite changes

### DIFF
--- a/photon-api/src/integTest/scala/com/linkedin/photon/ml/evaluation/ShardedAreaUnderROCCurveEvaluatorTest.scala
+++ b/photon-api/src/integTest/scala/com/linkedin/photon/ml/evaluation/ShardedAreaUnderROCCurveEvaluatorTest.scala
@@ -19,7 +19,7 @@ import org.testng.annotations.Test
 
 import com.linkedin.photon.ml.constants.MathConst
 import com.linkedin.photon.ml.test.CommonTestUtils.zipWithIndex
-import com.linkedin.photon.ml.test.SparkTestUtils
+import com.linkedin.photon.ml.test.{CommonTestUtils, SparkTestUtils}
 
 /**
  *
@@ -39,7 +39,7 @@ class ShardedAreaUnderROCCurveEvaluatorTest extends SparkTestUtils {
   private val labelsInCornerCase = zipWithIndex(Array[Double](0, 1, 0, 0, 1, 1, 1), startIndex)
   private val scoresInCornerCase = zipWithIndex(Array[Double](-0.1, -1, 0, -1, 2, 6, 8), startIndex)
   private val idsInCornerCase = zipWithIndex(Array.fill[String](scoresInCornerCase.length)("corner"), startIndex)
-  private val expectedAUCInCornerCase = 0.79166667
+  private val expectedAUCInCornerCase = 0.791666666667
   startIndex += labelsInCornerCase.length
 
   // where all examples have positive label
@@ -80,7 +80,7 @@ class ShardedAreaUnderROCCurveEvaluatorTest extends SparkTestUtils {
     val actualResult = evaluator.evaluate(sc.parallelize(scores.map { case (id, score) =>
       (id, score)
     }))
-    assertEquals(actualResult, expectedResult, MathConst.MEDIUM_PRECISION_TOLERANCE_THRESHOLD)
+    assertEquals(actualResult, expectedResult, CommonTestUtils.HIGH_PRECISION_TOLERANCE)
   }
 
   @Test

--- a/photon-api/src/integTest/scala/com/linkedin/photon/ml/evaluation/ShardedPrecisionAtKEvaluatorTest.scala
+++ b/photon-api/src/integTest/scala/com/linkedin/photon/ml/evaluation/ShardedPrecisionAtKEvaluatorTest.scala
@@ -17,9 +17,8 @@ package com.linkedin.photon.ml.evaluation
 import org.testng.Assert.assertEquals
 import org.testng.annotations.{DataProvider, Test}
 
-import com.linkedin.photon.ml.constants.MathConst
 import com.linkedin.photon.ml.test.CommonTestUtils.zipWithIndex
-import com.linkedin.photon.ml.test.SparkTestUtils
+import com.linkedin.photon.ml.test.{CommonTestUtils, SparkTestUtils}
 
 /**
  *
@@ -80,6 +79,6 @@ class ShardedPrecisionAtKEvaluatorTest extends SparkTestUtils {
     val actualResult = evaluator.evaluate(sc.parallelize(scores.map { case (id, score) =>
       (id, score)
     }))
-    assertEquals(actualResult, expectedResult, MathConst.MEDIUM_PRECISION_TOLERANCE_THRESHOLD)
+    assertEquals(actualResult, expectedResult, CommonTestUtils.HIGH_PRECISION_TOLERANCE)
   }
 }

--- a/photon-api/src/integTest/scala/com/linkedin/photon/ml/optimization/DistributedOptimizationProblemTest.scala
+++ b/photon-api/src/integTest/scala/com/linkedin/photon/ml/optimization/DistributedOptimizationProblemTest.scala
@@ -230,34 +230,34 @@ class DistributedOptimizationProblemTest extends SparkTestUtils {
       isComputingVariances = false)
 
     // Check update to L1/L2 weights individually
-    assertNotEquals(optimizerL1.l1RegularizationWeight, finalL1Weight, TOLERANCE)
-    assertNotEquals(objectiveFunctionL2.l2RegularizationWeight, finalL2Weight, TOLERANCE)
-    assertEquals(optimizerL1.l1RegularizationWeight, initL1Weight, TOLERANCE)
-    assertEquals(objectiveFunctionL2.l2RegularizationWeight, initL2Weight, TOLERANCE)
+    assertNotEquals(optimizerL1.l1RegularizationWeight, finalL1Weight, CommonTestUtils.HIGH_PRECISION_TOLERANCE)
+    assertNotEquals(objectiveFunctionL2.l2RegularizationWeight, finalL2Weight, CommonTestUtils.HIGH_PRECISION_TOLERANCE)
+    assertEquals(optimizerL1.l1RegularizationWeight, initL1Weight, CommonTestUtils.HIGH_PRECISION_TOLERANCE)
+    assertEquals(objectiveFunctionL2.l2RegularizationWeight, initL2Weight, CommonTestUtils.HIGH_PRECISION_TOLERANCE)
 
     l1Problem.updateRegularizationWeight(finalL1Weight)
     l2Problem.updateRegularizationWeight(finalL2Weight)
 
-    assertNotEquals(optimizerL1.l1RegularizationWeight, initL1Weight, TOLERANCE)
-    assertNotEquals(objectiveFunctionL2.l2RegularizationWeight, initL2Weight, TOLERANCE)
-    assertEquals(optimizerL1.l1RegularizationWeight, finalL1Weight, TOLERANCE)
-    assertEquals(objectiveFunctionL2.l2RegularizationWeight, finalL2Weight, TOLERANCE)
+    assertNotEquals(optimizerL1.l1RegularizationWeight, initL1Weight, CommonTestUtils.HIGH_PRECISION_TOLERANCE)
+    assertNotEquals(objectiveFunctionL2.l2RegularizationWeight, initL2Weight, CommonTestUtils.HIGH_PRECISION_TOLERANCE)
+    assertEquals(optimizerL1.l1RegularizationWeight, finalL1Weight, CommonTestUtils.HIGH_PRECISION_TOLERANCE)
+    assertEquals(objectiveFunctionL2.l2RegularizationWeight, finalL2Weight, CommonTestUtils.HIGH_PRECISION_TOLERANCE)
 
     // Check updates to L1/L2 weights together
     optimizerL1.l1RegularizationWeight = initL1Weight
     objectiveFunctionL2.l2RegularizationWeight = initL2Weight
 
-    assertNotEquals(optimizerL1.l1RegularizationWeight, elasticFinalL1Weight, TOLERANCE)
-    assertNotEquals(objectiveFunctionL2.l2RegularizationWeight, elasticFinalL2Weight, TOLERANCE)
-    assertEquals(optimizerL1.l1RegularizationWeight, initL1Weight, TOLERANCE)
-    assertEquals(objectiveFunctionL2.l2RegularizationWeight, initL2Weight, TOLERANCE)
+    assertNotEquals(optimizerL1.l1RegularizationWeight, elasticFinalL1Weight, CommonTestUtils.HIGH_PRECISION_TOLERANCE)
+    assertNotEquals(objectiveFunctionL2.l2RegularizationWeight, elasticFinalL2Weight, CommonTestUtils.HIGH_PRECISION_TOLERANCE)
+    assertEquals(optimizerL1.l1RegularizationWeight, initL1Weight, CommonTestUtils.HIGH_PRECISION_TOLERANCE)
+    assertEquals(objectiveFunctionL2.l2RegularizationWeight, initL2Weight, CommonTestUtils.HIGH_PRECISION_TOLERANCE)
 
     elasticProblem.updateRegularizationWeight(finalElasticWeight)
 
-    assertNotEquals(optimizerL1.l1RegularizationWeight, initL1Weight, TOLERANCE)
-    assertNotEquals(objectiveFunctionL2.l2RegularizationWeight, initL2Weight, TOLERANCE)
-    assertEquals(optimizerL1.l1RegularizationWeight, elasticFinalL1Weight, TOLERANCE)
-    assertEquals(objectiveFunctionL2.l2RegularizationWeight, elasticFinalL2Weight, TOLERANCE)
+    assertNotEquals(optimizerL1.l1RegularizationWeight, initL1Weight, CommonTestUtils.HIGH_PRECISION_TOLERANCE)
+    assertNotEquals(objectiveFunctionL2.l2RegularizationWeight, initL2Weight, CommonTestUtils.HIGH_PRECISION_TOLERANCE)
+    assertEquals(optimizerL1.l1RegularizationWeight, elasticFinalL1Weight, CommonTestUtils.HIGH_PRECISION_TOLERANCE)
+    assertEquals(objectiveFunctionL2.l2RegularizationWeight, elasticFinalL2Weight, CommonTestUtils.HIGH_PRECISION_TOLERANCE)
   }
 
   @Test(dataProvider = "variancesSimpleInput")
@@ -290,13 +290,13 @@ class DistributedOptimizationProblemTest extends SparkTestUtils {
         combOp = (vector1: Vector[Double], vector2: Vector[Double]) => vector1 + vector2,
         depth = 1)
       // Simple estimate of the diagonal of the covariance matrix (instead of a full inverse).
-      val expected = hessianDiagonal.map( v => 1D / (v + TOLERANCE))
+      val expected = hessianDiagonal.map( v => 1D / (v + MathConst.EPSILON))
       val actual: Vector[Double] = optimizationProblem.computeVariances(input, coefficients).get
 
       assertEquals(actual.length, DIMENSIONS)
       assertEquals(actual.length, expected.length)
       for (i <- 0 until DIMENSIONS) {
-        assertEquals(actual(i), expected(i), TOLERANCE)
+        assertEquals(actual(i), expected(i), CommonTestUtils.HIGH_PRECISION_TOLERANCE)
       }
     }
 
@@ -335,13 +335,13 @@ class DistributedOptimizationProblemTest extends SparkTestUtils {
         depth = 1)
       val hessianDiagonalWithL2 = hessianDiagonal + regularizationWeight
       // Simple estimate of the diagonal of the covariance matrix (instead of a full inverse).
-      val expected = hessianDiagonalWithL2.map( v => 1D / (v + TOLERANCE))
+      val expected = hessianDiagonalWithL2.map( v => 1D / (v + MathConst.EPSILON))
       val actual: Vector[Double] = optimizationProblem.computeVariances(input, coefficients).get
 
       assertEquals(actual.length, DIMENSIONS)
       assertEquals(actual.length, expected.length)
       for (i <- 0 until DIMENSIONS) {
-        assertEquals(actual(i), expected(i), TOLERANCE)
+        assertEquals(actual(i), expected(i), CommonTestUtils.HIGH_PRECISION_TOLERANCE)
       }
     }
 
@@ -386,7 +386,6 @@ object DistributedOptimizationProblemTest {
   private val WEIGHT_RANDOM_MAX = 10
   private val DIMENSIONS: Int = 5
   private val TRAINING_SAMPLES: Int = DIMENSIONS * DIMENSIONS
-  private val TOLERANCE = MathConst.HIGH_PRECISION_TOLERANCE_THRESHOLD
   private val NORMALIZATION = NoNormalization()
   private val NORMALIZATION_MOCK: Broadcast[NormalizationContext] = mock(classOf[Broadcast[NormalizationContext]])
 

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/algorithm/RandomEffectCoordinateInProjectedSpace.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/algorithm/RandomEffectCoordinateInProjectedSpace.scala
@@ -132,7 +132,8 @@ object RandomEffectCoordinateInProjectedSpace {
 
     val glm = randomEffectOptimizationProblem.initializeModel(0)
     val randomEffectModelsRDD = randomEffectDataSetInProjectedSpace.activeData.mapValues { localDataSet =>
-      glm.updateCoefficients(Coefficients.initializeZeroCoefficients(localDataSet.numFeatures))
+      glm
+        .updateCoefficients(Coefficients.initializeZeroCoefficients(localDataSet.numFeatures))
         .asInstanceOf[GeneralizedLinearModel]
     }
     val randomEffectType = randomEffectDataSetInProjectedSpace.randomEffectType

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/data/LocalDataSet.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/data/LocalDataSet.scala
@@ -250,22 +250,20 @@ object LocalDataSet {
       val std = math.sqrt(math.abs(numSamples * featureSecondOrderSum - featureFirstOrderSum * featureFirstOrderSum))
       val denominator = std * math.sqrt(numSamples * labelSecondOrderSum - labelFirstOrderSum * labelFirstOrderSum)
 
-      val score =
       // When the standard deviation of the feature is close to 0, we treat it as the intercept term
-        if (std < MathConst.MEDIUM_PRECISION_TOLERANCE_THRESHOLD) {
-          if (interceptAdded) {
-            0.0
-          } else {
-            interceptAdded = true
-            1.0
-          }
+      val score = if (std < MathConst.EPSILON) {
+        if (interceptAdded) {
+          0.0
         } else {
-          numerator / (denominator + MathConst.HIGH_PRECISION_TOLERANCE_THRESHOLD)
+          interceptAdded = true
+          1.0
         }
+      } else {
+        numerator / (denominator + MathConst.EPSILON)
+      }
 
-      assert(math.abs(score) <= 1 + MathConst.MEDIUM_PRECISION_TOLERANCE_THRESHOLD,
-        s"Computed pearson correlation score is $score, " +
-        s"while the score's magnitude should be less than 1. " +
+      require(math.abs(score) <= 1 + MathConst.EPSILON,
+        s"Computed pearson correlation score is $score, while the score's magnitude should be less than 1. " +
         s"(Diagnosis:\n" +
         s"numerator=$numerator\n" +
         s"denominator=$denominator\n" +

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/model/FactoredRandomEffectModel.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/model/FactoredRandomEffectModel.scala
@@ -17,6 +17,7 @@ package com.linkedin.photon.ml.model
 import org.apache.spark.rdd.RDD
 
 import com.linkedin.photon.ml.TaskType.TaskType
+import com.linkedin.photon.ml.Types.{FeatureShardId, REType, REId}
 import com.linkedin.photon.ml.projector.ProjectionMatrixBroadcast
 import com.linkedin.photon.ml.spark.BroadcastLike
 import com.linkedin.photon.ml.supervised.model.GeneralizedLinearModel
@@ -30,15 +31,16 @@ import com.linkedin.photon.ml.supervised.model.GeneralizedLinearModel
  * @param featureShardId The feature shard id
  */
 protected[ml] class FactoredRandomEffectModel(
-    override val modelsInProjectedSpaceRDD: RDD[(String, GeneralizedLinearModel)],
+    override val modelsInProjectedSpaceRDD: RDD[(REId, GeneralizedLinearModel)],
     val projectionMatrixBroadcast: ProjectionMatrixBroadcast,
-    override val randomEffectType: String,
-    override val featureShardId: String)
+    override val randomEffectType: REType,
+    override val featureShardId: FeatureShardId)
   extends RandomEffectModelInProjectedSpace(
     modelsInProjectedSpaceRDD,
     projectionMatrixBroadcast,
     randomEffectType,
-    featureShardId) with BroadcastLike {
+    featureShardId)
+  with BroadcastLike {
 
   /**
    * Update the factored random effect model with new models per individual.
@@ -48,8 +50,8 @@ protected[ml] class FactoredRandomEffectModel(
    * @return The updated factored random effect model in projected space
    */
   def updateFactoredRandomEffectModel(
-    updatedModelsInProjectedSpaceRDD: RDD[(String, GeneralizedLinearModel)],
-    updatedProjectionMatrixBroadcast: ProjectionMatrixBroadcast): FactoredRandomEffectModel = {
+      updatedModelsInProjectedSpaceRDD: RDD[(REId, GeneralizedLinearModel)],
+      updatedProjectionMatrixBroadcast: ProjectionMatrixBroadcast): FactoredRandomEffectModel = {
 
     val currType = this.modelType
 

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/model/FixedEffectModel.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/model/FixedEffectModel.scala
@@ -34,7 +34,7 @@ protected[ml] class FixedEffectModel(
   extends DatumScoringModel
   with BroadcastLike {
 
-  override lazy val modelType = modelBroadcast.value.modelType
+  override val modelType = modelBroadcast.value.modelType
 
   /**
    * Get the underlying [[GeneralizedLinearModel]].

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/model/RandomEffectModelInProjectedSpace.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/model/RandomEffectModelInProjectedSpace.scala
@@ -16,8 +16,10 @@ package com.linkedin.photon.ml.model
 
 import org.apache.spark.rdd.RDD
 import org.apache.spark.storage.StorageLevel
+import org.dmg.pmml.GeneralRegressionModel.ModelType
 
 import com.linkedin.photon.ml.TaskType.TaskType
+import com.linkedin.photon.ml.Types.{FeatureShardId, REType, REId}
 import com.linkedin.photon.ml.projector.RandomEffectProjector
 import com.linkedin.photon.ml.supervised.model.GeneralizedLinearModel
 
@@ -30,10 +32,10 @@ import com.linkedin.photon.ml.supervised.model.GeneralizedLinearModel
  * @param featureShardId The feature shard id
  */
 protected[ml] class RandomEffectModelInProjectedSpace(
-    val modelsInProjectedSpaceRDD: RDD[(String, GeneralizedLinearModel)],
+    val modelsInProjectedSpaceRDD: RDD[(REId, GeneralizedLinearModel)],
     val randomEffectProjector: RandomEffectProjector,
-    override val randomEffectType: String,
-    override val featureShardId: String)
+    override val randomEffectType: REType,
+    override val featureShardId: FeatureShardId)
   extends RandomEffectModel(
     randomEffectProjector.projectCoefficientsRDD(modelsInProjectedSpaceRDD),
     randomEffectType,
@@ -63,7 +65,7 @@ protected[ml] class RandomEffectModelInProjectedSpace(
    * @return The updated random effect model in projected space
    */
   override def update(
-    updatedModelsRDDInProjectedSpace: RDD[(String, GeneralizedLinearModel)]): RandomEffectModelInProjectedSpace = {
+      updatedModelsRDDInProjectedSpace: RDD[(REId, GeneralizedLinearModel)]): RandomEffectModelInProjectedSpace = {
 
     val currType = this.modelType
 

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/optimization/DistributedOptimizationProblem.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/optimization/DistributedOptimizationProblem.scala
@@ -83,7 +83,7 @@ protected[ml] class DistributedOptimizationProblem[Objective <: DistributedObjec
         val broadcastCoefficients = input.sparkContext.broadcast(coefficients)
         val result = Some(twiceDiffFunc
           .hessianDiagonal(input, broadcastCoefficients)
-          .map(v => 1.0 / (v + MathConst.HIGH_PRECISION_TOLERANCE_THRESHOLD)))
+          .map(v => 1.0 / (v + MathConst.EPSILON)))
 
         broadcastCoefficients.unpersist()
         result

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/optimization/SingleNodeOptimizationProblem.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/optimization/SingleNodeOptimizationProblem.scala
@@ -59,7 +59,7 @@ protected[ml] class SingleNodeOptimizationProblem[Objective <: SingleNodeObjecti
       case (true, twiceDiffFunc: TwiceDiffFunction) =>
         Some(twiceDiffFunc
           .hessianDiagonal(input, coefficients)
-          .map(v => 1.0 / (v + MathConst.HIGH_PRECISION_TOLERANCE_THRESHOLD)))
+          .map(v => 1.0 / (v + MathConst.EPSILON)))
 
       case _ =>
         None

--- a/photon-api/src/test/scala/com/linkedin/photon/ml/data/LocalDataSetTest.scala
+++ b/photon-api/src/test/scala/com/linkedin/photon/ml/data/LocalDataSetTest.scala
@@ -21,188 +21,221 @@ import org.testng.Assert._
 import org.testng.annotations.Test
 
 import com.linkedin.photon.ml.constants.MathConst
+import com.linkedin.photon.ml.test.CommonTestUtils
 
 /**
  *
  */
 class LocalDataSetTest {
 
-   @Test(dependsOnGroups = Array[String]("testReservoirSampling", "testCore"))
-   def testReservoirSamplingOnAllSamples(): Unit = {
-     val numSamples = 10
-     val random = new Random(MathConst.RANDOM_SEED)
-     val weight = random.nextDouble()
-     val localDataSet = LocalDataSet(Array.tabulate(numSamples)(i => (i.toLong, new LabeledPoint(label = 1.0, features = Vector(), weight = weight))))
+  @Test(dependsOnGroups = Array[String]("testReservoirSampling", "testCore"))
+  def testReservoirSamplingOnAllSamples(): Unit = {
 
-     // don't keep any sample
-     val filteredDataPoints0 = localDataSet.reservoirSamplingOnAllSamples(numSamplesToKeep = 0).dataPoints
-     assertEquals(filteredDataPoints0.length, 0)
+    val numSamples = 10
+    val random = new Random(MathConst.RANDOM_SEED)
+    val weight = random.nextDouble()
+    val localDataSet =
+      LocalDataSet(
+        Array.tabulate(numSamples)(i => (i.toLong, new LabeledPoint(label = 1.0, features = Vector(), weight = weight))))
 
-     // keep 1 sample
-     val filteredDataPoints1 = localDataSet.reservoirSamplingOnAllSamples(numSamplesToKeep = 1).dataPoints
-     assertEquals(filteredDataPoints1.length, 1)
-     filteredDataPoints1.foreach { case(_, labeledPoint) => assertEquals(labeledPoint.weight, numSamples * weight, MathConst.LOW_PRECISION_TOLERANCE_THRESHOLD) }
+    // don't keep any sample
+    val filteredDataPoints0 = localDataSet.reservoirSamplingOnAllSamples(numSamplesToKeep = 0).dataPoints
+    assertEquals(filteredDataPoints0.length, 0)
 
-     // keep numSamples samples
-     val filteredDataPoints2 = localDataSet.reservoirSamplingOnAllSamples(numSamplesToKeep = numSamples).dataPoints
-     assertEquals(filteredDataPoints2.length, numSamples)
-     filteredDataPoints2.foreach { case(_, labeledPoint) => assertEquals(labeledPoint.weight, weight, MathConst.LOW_PRECISION_TOLERANCE_THRESHOLD) }
+    // keep 1 sample
+    val filteredDataPoints1 = localDataSet.reservoirSamplingOnAllSamples(numSamplesToKeep = 1).dataPoints
+    assertEquals(filteredDataPoints1.length, 1)
+    filteredDataPoints1.foreach { case(_, labeledPoint) =>
+      assertEquals(labeledPoint.weight, numSamples * weight, CommonTestUtils.HIGH_PRECISION_TOLERANCE)
+    }
 
-     // keep numSamples + 1 samples
-     val filteredDataPoints3 = localDataSet.reservoirSamplingOnAllSamples(numSamplesToKeep = numSamples + 1).dataPoints
-     assertEquals(filteredDataPoints3.length, numSamples)
-     filteredDataPoints3.foreach { case(_, labeledPoint) => assertEquals(labeledPoint.weight, weight, MathConst.LOW_PRECISION_TOLERANCE_THRESHOLD) }
+    // keep numSamples samples
+    val filteredDataPoints2 = localDataSet.reservoirSamplingOnAllSamples(numSamplesToKeep = numSamples).dataPoints
+    assertEquals(filteredDataPoints2.length, numSamples)
+    filteredDataPoints2.foreach { case(_, labeledPoint) =>
+      assertEquals(labeledPoint.weight, weight, CommonTestUtils.HIGH_PRECISION_TOLERANCE)
+    }
 
-   }
+    // keep numSamples + 1 samples
+    val filteredDataPoints3 = localDataSet.reservoirSamplingOnAllSamples(numSamplesToKeep = numSamples + 1).dataPoints
+    assertEquals(filteredDataPoints3.length, numSamples)
+    filteredDataPoints3.foreach { case(_, labeledPoint) =>
+      assertEquals(labeledPoint.weight, weight, CommonTestUtils.HIGH_PRECISION_TOLERANCE)
+    }
+  }
 
-   @Test(dependsOnGroups = Array[String]("testPearsonCorrelationScore", "testCore"))
-   def testFilterFeaturesByPearsonCorrelationScore(): Unit = {
-     val numSamples = 10
-     val random = new Random(MathConst.RANDOM_SEED)
-     val labels = Array.fill(numSamples)(if (random.nextDouble() > 0.5) 1.0 else -1.0)
-     val numFeatures = 10
-     // Each data point has 10 features, and each of them is designed as following:
-     // 0: Intercept
-     // 1: Positively correlated with the label
-     // 2: Negatively correlated with the label
-     // 3: Un-correlated with the label
-     // 4: Dummy feature 1
-     // 5: Dummy feature 2
-     // 6-9: Missing features
-     val intercept = 1.0
-     val variance = 0.001
-     val featureIndices = Array(0, 1, 2, 3, 4, 5)
-     val features = Array.tabulate(numSamples) { i =>
-       val featureValues = Array(
-         intercept,
-         labels(i) + variance * random.nextGaussian(),
-         -labels(i) + variance * random.nextGaussian(),
-         random.nextDouble(),
-         1.0,
-         1.0)
-       new SparseVector[Double](featureIndices, featureValues, numFeatures)
-     }
-     val localDataSet = LocalDataSet(Array.tabulate(numSamples)(i => (i.toLong, LabeledPoint(labels(i), features(i), offset = 0.0, weight = 1.0))))
+  @Test(dependsOnGroups = Array[String]("testPearsonCorrelationScore", "testCore"))
+  def testFilterFeaturesByPearsonCorrelationScore(): Unit = {
 
-     // don't keep any features
-     val filteredDataPoints0 = localDataSet.filterFeaturesByPearsonCorrelationScore(numFeaturesToKeep = 0).dataPoints
-     assertEquals(filteredDataPoints0.length, numSamples)
-     assertTrue(filteredDataPoints0.forall(_._2.features.activeSize == 0))
+    val numSamples = 10
+    val random = new Random(MathConst.RANDOM_SEED)
+    val labels = Array.fill(numSamples)(if (random.nextDouble() > 0.5) 1.0 else -1.0)
+    val numFeatures = 10
+    // Each data point has 10 features, and each of them is designed as following:
+    // 0: Intercept
+    // 1: Positively correlated with the label
+    // 2: Negatively correlated with the label
+    // 3: Un-correlated with the label
+    // 4: Dummy feature 1
+    // 5: Dummy feature 2
+    // 6-9: Missing features
+    val intercept = 1.0
+    val variance = 0.001
+    val featureIndices = Array(0, 1, 2, 3, 4, 5)
+    val features = Array.tabulate(numSamples) { i =>
+      val featureValues = Array(
+        intercept,
+        labels(i) + variance * random.nextGaussian(),
+        -labels(i) + variance * random.nextGaussian(),
+        random.nextDouble(),
+        1.0,
+        1.0)
+      new SparseVector[Double](featureIndices, featureValues, numFeatures)
+    }
+    val localDataSet =
+      LocalDataSet(
+        Array.tabulate(numSamples)(i => (i.toLong, LabeledPoint(labels(i), features(i), offset = 0.0, weight = 1.0))))
 
-     // keep 1 feature
-     val filteredDataPoints1 = localDataSet.filterFeaturesByPearsonCorrelationScore(numFeaturesToKeep = 1).dataPoints
-     val filteredDataPointsKeySet1 = filteredDataPoints1.flatMap(_._2.features.activeKeysIterator).toSet
-     assertEquals(filteredDataPoints1.length, numSamples)
-     assertTrue(filteredDataPoints1.forall(_._2.features.activeSize == 1))
-     assertTrue(filteredDataPointsKeySet1.size == 1 &&
-       (filteredDataPointsKeySet1.contains(0) || filteredDataPointsKeySet1.contains(4) || filteredDataPointsKeySet1.contains(5)),
-       s"$filteredDataPointsKeySet1")
+    // don't keep any features
+    val filteredDataPoints0 = localDataSet.filterFeaturesByPearsonCorrelationScore(numFeaturesToKeep = 0).dataPoints
+    assertEquals(filteredDataPoints0.length, numSamples)
+    assertTrue(filteredDataPoints0.forall(_._2.features.activeSize == 0))
 
-     // keep 3 features
-     val filteredDataPoints3 = localDataSet.filterFeaturesByPearsonCorrelationScore(numFeaturesToKeep = 3).dataPoints
-     val filteredDataPointsKeySet3 = filteredDataPoints3.flatMap(_._2.features.activeKeysIterator).toSet
-     assertEquals(filteredDataPoints3.length, numSamples)
-     assertTrue(filteredDataPoints3.forall(_._2.features.activeSize == 3))
-     assertTrue(filteredDataPointsKeySet3.size == 3 && filteredDataPointsKeySet3.contains(1) && filteredDataPointsKeySet3.contains(2) &&
-       (filteredDataPointsKeySet3.contains(0) || filteredDataPointsKeySet3.contains(4) || filteredDataPointsKeySet3.contains(5)),
-       s"$filteredDataPointsKeySet3")
+    // keep 1 feature
+    val filteredDataPoints1 = localDataSet.filterFeaturesByPearsonCorrelationScore(numFeaturesToKeep = 1).dataPoints
+    val filteredDataPointsKeySet1 = filteredDataPoints1.flatMap(_._2.features.activeKeysIterator).toSet
+    assertEquals(filteredDataPoints1.length, numSamples)
+    assertTrue(filteredDataPoints1.forall(_._2.features.activeSize == 1))
+    assertTrue(
+      filteredDataPointsKeySet1.size == 1 &&
+        (filteredDataPointsKeySet1.contains(0) ||
+          filteredDataPointsKeySet1.contains(4) ||
+          filteredDataPointsKeySet1.contains(5)),
+      s"$filteredDataPointsKeySet1")
 
-     // keep 5 features
-     val filteredDataPoints5 = localDataSet.filterFeaturesByPearsonCorrelationScore(numFeaturesToKeep = 5).dataPoints
-     val filteredDataPointsKeySet5 = filteredDataPoints5.flatMap(_._2.features.activeKeysIterator).toSet
-     assertEquals(filteredDataPoints5.length, numSamples)
-     assertTrue(filteredDataPoints5.forall(_._2.features.activeSize == 5))
-     assertTrue(filteredDataPointsKeySet5.forall(_ < 6), s"$filteredDataPointsKeySet5")
+    // keep 3 features
+    val filteredDataPoints3 = localDataSet.filterFeaturesByPearsonCorrelationScore(numFeaturesToKeep = 3).dataPoints
+    val filteredDataPointsKeySet3 = filteredDataPoints3.flatMap(_._2.features.activeKeysIterator).toSet
+    assertEquals(filteredDataPoints3.length, numSamples)
+    assertTrue(filteredDataPoints3.forall(_._2.features.activeSize == 3))
+    assertTrue(
+      filteredDataPointsKeySet3.size == 3 &&
+        filteredDataPointsKeySet3.contains(1) &&
+        filteredDataPointsKeySet3.contains(2) &&
+        (filteredDataPointsKeySet3.contains(0) ||
+          filteredDataPointsKeySet3.contains(4) ||
+          filteredDataPointsKeySet3.contains(5)),
+      s"$filteredDataPointsKeySet3")
 
-     // keep all features
-     val filteredDataPointsAll = localDataSet.filterFeaturesByPearsonCorrelationScore(numFeaturesToKeep = numFeatures).dataPoints
-     assertEquals(filteredDataPointsAll.length, numSamples)
-     assertTrue(filteredDataPointsAll.forall(dataPoint => dataPoint._2.features.activeKeysIterator.toSet == Set(0, 1, 2, 3, 4, 5)))
-   }
+    // keep 5 features
+    val filteredDataPoints5 = localDataSet.filterFeaturesByPearsonCorrelationScore(numFeaturesToKeep = 5).dataPoints
+    val filteredDataPointsKeySet5 = filteredDataPoints5.flatMap(_._2.features.activeKeysIterator).toSet
+    assertEquals(filteredDataPoints5.length, numSamples)
+    assertTrue(filteredDataPoints5.forall(_._2.features.activeSize == 5))
+    assertTrue(filteredDataPointsKeySet5.forall(_ < 6), s"$filteredDataPointsKeySet5")
 
-   @Test(dependsOnGroups = Array[String]("testCore"))
-   def testFilterFeaturesBySupport(): Unit = {
-     val numSamples = 4
-     val numFeatures = 4
-     val random = new Random(MathConst.RANDOM_SEED)
-     val labels = Array.fill(numSamples)(if (random.nextDouble() > 0.5) 1.0 else -1.0)
-     val features = Array(
-       new SparseVector[Double](Array(0, 1, 2, 3), Array.fill(4)(random.nextDouble()), numFeatures),
-       new SparseVector[Double](Array(0, 1, 2), Array.fill(3)(random.nextDouble()), numFeatures),
-       new SparseVector[Double](Array(0, 1), Array.fill(2)(random.nextDouble()), numFeatures),
-       new SparseVector[Double](Array(0), Array.fill(1)(random.nextDouble()), numFeatures)
-     )
-     val localDataSet = LocalDataSet(Array.tabulate(numSamples)(i => (i.toLong, LabeledPoint(labels(i), features(i), offset = 0.0, weight = 1.0))))
+    // keep all features
+    val filteredDataPointsAll = localDataSet.filterFeaturesByPearsonCorrelationScore(numFeaturesToKeep = numFeatures).dataPoints
+    assertEquals(filteredDataPointsAll.length, numSamples)
+    assertTrue(
+      filteredDataPointsAll
+        .forall(dataPoint => dataPoint._2.features.activeKeysIterator.toSet == Set(0, 1, 2, 3, 4, 5)))
+  }
 
-     // don't keep any features
-     val filteredDataPoints0 = localDataSet.filterFeaturesBySupport(minNumSupportThreshold = 5).dataPoints
-     assertEquals(filteredDataPoints0.length, numSamples)
-     assertTrue(filteredDataPoints0.forall(_._2.features.activeSize == 0))
+  @Test(dependsOnGroups = Array[String]("testCore"))
+  def testFilterFeaturesBySupport(): Unit = {
 
-     // keep 1 feature
-     val filteredDataPoints1 = localDataSet.filterFeaturesBySupport(minNumSupportThreshold = 4).dataPoints
-     assertEquals(filteredDataPoints1.length, numSamples)
-     filteredDataPoints1.zip(localDataSet.dataPoints).foreach { case((_, filteredLabeledPoint), (_, labeledPoint)) =>
-       assertEquals(filteredLabeledPoint.features.activeSize, 1)
-       assertTrue(filteredLabeledPoint.features.activeKeysIterator.toSet.contains(0))
-     }
+    val numSamples = 4
+    val numFeatures = 4
+    val random = new Random(MathConst.RANDOM_SEED)
+    val labels = Array.fill(numSamples)(if (random.nextDouble() > 0.5) 1.0 else -1.0)
+    val features = Array(
+      new SparseVector[Double](Array(0, 1, 2, 3), Array.fill(4)(random.nextDouble()), numFeatures),
+      new SparseVector[Double](Array(0, 1, 2), Array.fill(3)(random.nextDouble()), numFeatures),
+      new SparseVector[Double](Array(0, 1), Array.fill(2)(random.nextDouble()), numFeatures),
+      new SparseVector[Double](Array(0), Array.fill(1)(random.nextDouble()), numFeatures)
+    )
+    val localDataSet =
+      LocalDataSet(
+        Array.tabulate(numSamples)(i => (i.toLong, LabeledPoint(labels(i), features(i), offset = 0.0, weight = 1.0))))
 
-     // keep 3 features
-     val filteredDataPoints3 = localDataSet.filterFeaturesBySupport(minNumSupportThreshold = 2).dataPoints
-     assertTrue(filteredDataPoints3.length == numSamples)
-     filteredDataPoints3.zip(localDataSet.dataPoints).foreach { case((_, filteredLabeledPoint), (_, labeledPoint)) =>
-       assertTrue(filteredLabeledPoint.features.activeSize == 3 || filteredLabeledPoint.features.activeSize == labeledPoint.features.activeSize)
-       assertTrue(!filteredLabeledPoint.features.activeKeysIterator.toSet.contains(3))
-     }
+    // don't keep any features
+    val filteredDataPoints0 = localDataSet.filterFeaturesBySupport(minNumSupportThreshold = 5).dataPoints
+    assertEquals(filteredDataPoints0.length, numSamples)
+    assertTrue(filteredDataPoints0.forall(_._2.features.activeSize == 0))
 
-     // keep all features
-     val filteredDataPoints4 = localDataSet.filterFeaturesBySupport(minNumSupportThreshold = 0).dataPoints
-     assertTrue(filteredDataPoints4.length == numSamples)
-     filteredDataPoints4.zip(localDataSet.dataPoints).foreach { case((_, filteredLabeledPoint), (_, labeledPoint)) =>
-       assertTrue(filteredLabeledPoint.features.activeSize == numFeatures || filteredLabeledPoint.features.activeSize == labeledPoint.features.activeSize)
-     }
-   }
+    // keep 1 feature
+    val filteredDataPoints1 = localDataSet.filterFeaturesBySupport(minNumSupportThreshold = 4).dataPoints
+    assertEquals(filteredDataPoints1.length, numSamples)
+    filteredDataPoints1.zip(localDataSet.dataPoints).foreach { case((_, filteredLabeledPoint), (_, labeledPoint)) =>
+      assertEquals(filteredLabeledPoint.features.activeSize, 1)
+      assertTrue(filteredLabeledPoint.features.activeKeysIterator.toSet.contains(0))
+    }
 
-   /**
-    * Test the Pearson correlation score
-    */
-   @Test(groups = Array[String]("testPearsonCorrelationScore", "testCore"))
-   def testPearsonCorrelationScore(): Unit = {
-     //test input data
-     val labels = Array(1.0, 4.0, 6.0, 9.0)
-     val features = Array(
-       Vector(0.0, 0.0, 2.0), Vector(5.0, 0.0, -3.0), Vector(7.0, 0.0, -8.0), Vector(0.0, 0.0, -1.0)
-     )
-     val expected = Map(0 -> 0.05564149, 1 -> 1.0, 2 -> -0.40047142)
-     val labelAndFeatures = labels.zip(features)
-     val computed = LocalDataSet.computePearsonCorrelationScore(labelAndFeatures)
-     computed.foreach { case (key, value) =>
-       assertEquals(expected(key), value, MathConst.LOW_PRECISION_TOLERANCE_THRESHOLD,
-         s"Computed Pearson correlation score is $value, while the expected value is ${expected(key)}.")
-     }
-   }
+    // keep 3 features
+    val filteredDataPoints3 = localDataSet.filterFeaturesBySupport(minNumSupportThreshold = 2).dataPoints
+    assertTrue(filteredDataPoints3.length == numSamples)
+    filteredDataPoints3.zip(localDataSet.dataPoints).foreach { case((_, filteredLabeledPoint), (_, labeledPoint)) =>
+      assertTrue(
+        filteredLabeledPoint.features.activeSize == 3 ||
+          filteredLabeledPoint.features.activeSize == labeledPoint.features.activeSize)
+      assertTrue(!filteredLabeledPoint.features.activeKeysIterator.toSet.contains(3))
+    }
 
-   /**
-    * Test the reservoir sampling
-    */
-   @Test(groups = Array[String]("testReservoirSampling", "testCore"))
-   def testReservoirSampling(): Unit = {
-     val random = new Random(MathConst.RANDOM_SEED)
+    // keep all features
+    val filteredDataPoints4 = localDataSet.filterFeaturesBySupport(minNumSupportThreshold = 0).dataPoints
+    assertTrue(filteredDataPoints4.length == numSamples)
+    filteredDataPoints4.zip(localDataSet.dataPoints).foreach { case((_, filteredLabeledPoint), (_, labeledPoint)) =>
+      assertTrue(
+        filteredLabeledPoint.features.activeSize == numFeatures ||
+          filteredLabeledPoint.features.activeSize == labeledPoint.features.activeSize)
+    }
+  }
 
-     val input = Seq.fill(100)(random.nextInt())
+  /**
+   * Test the Pearson correlation score
+   */
+  @Test(groups = Array[String]("testPearsonCorrelationScore", "testCore"))
+  def testPearsonCorrelationScore(): Unit = {
 
-     // input size < k
-     val sample1 = LocalDataSet.reservoirSampling(input.iterator, 150)
-     assertEquals(sample1.length, 100, s"Expected number of samples is 100, while ${sample1.length} is obtained")
-     assertTrue(input == sample1.toSeq)
+    // Test input data
+    val labels = Array(1.0, 4.0, 6.0, 9.0)
+    val features = Array(
+      Vector(0.0, 0.0, 2.0), Vector(5.0, 0.0, -3.0), Vector(7.0, 0.0, -8.0), Vector(0.0, 0.0, -1.0))
+    val expected = Map(0 -> 0.05564149, 1 -> 1.0, 2 -> -0.40047142)
+    val labelAndFeatures = labels.zip(features)
+    val computed = LocalDataSet.computePearsonCorrelationScore(labelAndFeatures)
 
-     // input size == k
-     val sample2 = LocalDataSet.reservoirSampling(input.iterator, 100)
-     assertEquals(sample2.length, 100, s"Expected number of samples is 100, while ${sample2.length} is obtained")
-     assertTrue(input.zip(sample2).forall { case(i1, i2) => i1 == i2 })
+    computed.foreach { case (key, value) =>
+      assertEquals(
+        expected(key),
+        value,
+        CommonTestUtils.LOW_PRECISION_TOLERANCE,
+        s"Computed Pearson correlation score is $value, while the expected value is ${expected(key)}.")
+    }
+  }
 
-     // input size > k
-     val sample3 = LocalDataSet.reservoirSampling(input.iterator, 10)
-     assertEquals(sample3.length, 10, s"Expected number of samples is 10, while ${sample3.length} is obtained")
-   }
- }
+  /**
+   * Test the reservoir sampling
+   */
+  @Test(groups = Array[String]("testReservoirSampling", "testCore"))
+  def testReservoirSampling(): Unit = {
+
+    val random = new Random(MathConst.RANDOM_SEED)
+    val input = Seq.fill(100)(random.nextInt())
+
+    // input size < k
+    val sample1 = LocalDataSet.reservoirSampling(input.iterator, 150)
+    assertEquals(sample1.length, 100, s"Expected number of samples is 100, while ${sample1.length} is obtained")
+    assertTrue(input == sample1.toSeq)
+
+    // input size == k
+    val sample2 = LocalDataSet.reservoirSampling(input.iterator, 100)
+    assertEquals(sample2.length, 100, s"Expected number of samples is 100, while ${sample2.length} is obtained")
+    assertTrue(input.zip(sample2).forall { case(i1, i2) => i1 == i2 })
+
+    // input size > k
+    val sample3 = LocalDataSet.reservoirSampling(input.iterator, 10)
+    assertEquals(sample3.length, 10, s"Expected number of samples is 10, while ${sample3.length} is obtained")
+  }
+}

--- a/photon-api/src/test/scala/com/linkedin/photon/ml/evaluation/AreaUnderROCCurveLocalEvaluatorTest.scala
+++ b/photon-api/src/test/scala/com/linkedin/photon/ml/evaluation/AreaUnderROCCurveLocalEvaluatorTest.scala
@@ -17,7 +17,7 @@ package com.linkedin.photon.ml.evaluation
 import org.testng.Assert._
 import org.testng.annotations.Test
 
-import com.linkedin.photon.ml.constants.MathConst
+import com.linkedin.photon.ml.test.CommonTestUtils
 import com.linkedin.photon.ml.test.CommonTestUtils.getScoreLabelAndWeights
 
 /**
@@ -34,15 +34,15 @@ class AreaUnderROCCurveLocalEvaluatorTest {
     val scoreLabelAndWeightsInNormalCase = getScoreLabelAndWeights(scoresInNormalCase, labelsInNormalCase)
     val expectedAUCInNormalCase = 0.75
     val computedAUCInNormalCase = AreaUnderROCCurveLocalEvaluator.evaluate(scoreLabelAndWeightsInNormalCase)
-    assertEquals(computedAUCInNormalCase, expectedAUCInNormalCase, MathConst.MEDIUM_PRECISION_TOLERANCE_THRESHOLD)
+    assertEquals(computedAUCInNormalCase, expectedAUCInNormalCase, CommonTestUtils.HIGH_PRECISION_TOLERANCE)
 
     // if we have two identical scores with conflicting ground-truth labels
     val labelsInCornerCase1 = Array[Double](0, 1, 0, 0, 1, 1, 1)
     val scoresInCornerCase1 = Array[Double](-0.1, -1, 0, -1, 2, 6, 8)
     val scoreLabelAndWeightsInCornerCase1 = getScoreLabelAndWeights(scoresInCornerCase1, labelsInCornerCase1)
-    val expectedAUCInCornerCase1 = 0.79166667
+    val expectedAUCInCornerCase1 = 0.791666666667
     val computedAUCInCornerCase1 = AreaUnderROCCurveLocalEvaluator.evaluate(scoreLabelAndWeightsInCornerCase1)
-    assertEquals(computedAUCInCornerCase1, expectedAUCInCornerCase1, MathConst.MEDIUM_PRECISION_TOLERANCE_THRESHOLD)
+    assertEquals(computedAUCInCornerCase1, expectedAUCInCornerCase1, CommonTestUtils.HIGH_PRECISION_TOLERANCE)
 
     // where all examples have positive label
     val positiveLabelsOnly = Array[Double](1, 1)

--- a/photon-api/src/test/scala/com/linkedin/photon/ml/evaluation/PrecisionAtKLocalEvaluatorTest.scala
+++ b/photon-api/src/test/scala/com/linkedin/photon/ml/evaluation/PrecisionAtKLocalEvaluatorTest.scala
@@ -17,7 +17,7 @@ package com.linkedin.photon.ml.evaluation
 import org.testng.Assert._
 import org.testng.annotations.{DataProvider, Test}
 
-import com.linkedin.photon.ml.constants.MathConst
+import com.linkedin.photon.ml.test.CommonTestUtils
 import com.linkedin.photon.ml.test.CommonTestUtils.getScoreLabelAndWeights
 
 /**
@@ -85,6 +85,6 @@ class PrecisionAtKLocalEvaluatorTest {
 
     val evaluator = new PrecisionAtKLocalEvaluator(k)
     val actualResult = evaluator.evaluate(scoreLabelAndWeights)
-    assertEquals(actualResult, expectedResult, MathConst.MEDIUM_PRECISION_TOLERANCE_THRESHOLD)
+    assertEquals(actualResult, expectedResult, CommonTestUtils.HIGH_PRECISION_TOLERANCE)
   }
 }

--- a/photon-api/src/test/scala/com/linkedin/photon/ml/function/glm/LogisticLossFunctionTest.scala
+++ b/photon-api/src/test/scala/com/linkedin/photon/ml/function/glm/LogisticLossFunctionTest.scala
@@ -18,7 +18,7 @@ import breeze.linalg.DenseVector
 import org.testng.Assert._
 import org.testng.annotations.Test
 
-import com.linkedin.photon.ml.constants.MathConst
+import com.linkedin.photon.ml.test.CommonTestUtils
 
 /**
  * Test some edge cases of the functions in [[LogisticLossFunction]]. For more tests by numerical methods please see
@@ -28,7 +28,6 @@ class LogisticLossFunctionTest {
 
   @Test
   def testCalculate(): Unit = {
-    val delta = MathConst.MEDIUM_PRECISION_TOLERANCE_THRESHOLD
     val features = DenseVector[Double](12.21, 10.0, -0.03, 10.3)
     val coefficients = DenseVector[Double](1.0, 12.3, -21.0, 0.0)
     val offset = 1.5
@@ -40,17 +39,16 @@ class LogisticLossFunctionTest {
     val (value1, _) = LogisticLossFunction.lossAndDzLoss(margin, positiveLabel)
     // Compute the expected value by explicit computation
     val expected1 = math.log(1 + math.exp(-margin))
-    assertEquals(value1, expected1, delta)
+    assertEquals(value1, expected1, CommonTestUtils.HIGH_PRECISION_TOLERANCE)
 
     // Test negative label
     val (value2, _) = LogisticLossFunction.lossAndDzLoss(margin, negativeLabel)
     val expected2 = math.log(1 + math.exp(margin))
-    assertEquals(value2, expected2, delta)
+    assertEquals(value2, expected2, CommonTestUtils.HIGH_PRECISION_TOLERANCE)
   }
 
   @Test
   def testGradient(): Unit = {
-    val delta = MathConst.MEDIUM_PRECISION_TOLERANCE_THRESHOLD
     val features = DenseVector[Double](12.21, 10.0, -0.03, 10.3)
     val coefficients = DenseVector[Double](1.0, 1.0, 1.0, 1.0)
     val offset = 0D
@@ -62,17 +60,16 @@ class LogisticLossFunctionTest {
     val (_, gradient1) = LogisticLossFunction.lossAndDzLoss(margin, positiveLabel)
     // Calculate gradient explicitly
     val expected1 = -1.0 / (1.0 + math.exp(margin))
-    assertEquals(gradient1, expected1, delta)
+    assertEquals(gradient1, expected1, CommonTestUtils.HIGH_PRECISION_TOLERANCE)
 
     // Test negative label
     val expected2 = 1.0 / (1.0 + math.exp(-margin))
     val (_, gradient2) = LogisticLossFunction.lossAndDzLoss(margin, negativeLabel)
-    assertEquals(gradient2, expected2, delta)
+    assertEquals(gradient2, expected2, CommonTestUtils.HIGH_PRECISION_TOLERANCE)
   }
 
   @Test
   def testHessianVector(): Unit = {
-    val delta = MathConst.MEDIUM_PRECISION_TOLERANCE_THRESHOLD
     val label = 1D
     val offset = 0D
 
@@ -83,7 +80,7 @@ class LogisticLossFunctionTest {
     val sigma1 = 1.0 / (1.0 + math.exp(-margin1))
     val expected1 = sigma1 * (1 - sigma1)
     val D_1 = LogisticLossFunction.DzzLoss(margin1, label)
-    assertEquals(D_1, expected1, delta)
+    assertEquals(D_1, expected1, CommonTestUtils.HIGH_PRECISION_TOLERANCE)
 
     // Test non-zero vectors
     val features2 = DenseVector[Double](1.0, 0.0, 0.0, 0.0)
@@ -92,6 +89,6 @@ class LogisticLossFunctionTest {
     val sigma2 = 1.0 / (1.0 + math.exp(-margin2))
     val expected2 = sigma2 * (1 - sigma2)
     val D_2 = LogisticLossFunction.DzzLoss(margin2, label)
-    assertEquals(D_2, expected2, delta)
+    assertEquals(D_2, expected2, CommonTestUtils.HIGH_PRECISION_TOLERANCE)
   }
 }

--- a/photon-api/src/test/scala/com/linkedin/photon/ml/optimization/GeneralizedLinearOptimizationProblemTest.scala
+++ b/photon-api/src/test/scala/com/linkedin/photon/ml/optimization/GeneralizedLinearOptimizationProblemTest.scala
@@ -21,7 +21,6 @@ import org.mockito.Mockito._
 import org.testng.Assert._
 import org.testng.annotations.Test
 
-import com.linkedin.photon.ml.constants.MathConst.HIGH_PRECISION_TOLERANCE_THRESHOLD
 import com.linkedin.photon.ml.data.LabeledPoint
 import com.linkedin.photon.ml.function._
 import com.linkedin.photon.ml.function.svm.SingleNodeSmoothedHingeLossFunction
@@ -29,6 +28,7 @@ import com.linkedin.photon.ml.model.Coefficients
 import com.linkedin.photon.ml.supervised.classification.{LogisticRegressionModel, SmoothedHingeLossLinearSVMModel}
 import com.linkedin.photon.ml.supervised.model.GeneralizedLinearModel
 import com.linkedin.photon.ml.supervised.regression.{LinearRegressionModel, PoissonRegressionModel}
+import com.linkedin.photon.ml.test.CommonTestUtils
 import com.linkedin.photon.ml.test.CommonTestUtils.generateDenseVector
 
 /**
@@ -180,13 +180,19 @@ class GeneralizedLinearOptimizationProblemTest {
     doReturn(l2RegWeight).when(objectiveL2Reg).l2RegularizationWeight
     doReturn(coefficients).when(initialModel).coefficients
 
-    assertEquals(0.0, problemNone.getRegularizationTermValue(initialModel), HIGH_PRECISION_TOLERANCE_THRESHOLD)
-    assertEquals(expectedL1Term, problemL1.getRegularizationTermValue(initialModel), HIGH_PRECISION_TOLERANCE_THRESHOLD)
-    assertEquals(expectedL2Term, problemL2.getRegularizationTermValue(initialModel), HIGH_PRECISION_TOLERANCE_THRESHOLD)
+    assertEquals(0.0, problemNone.getRegularizationTermValue(initialModel), CommonTestUtils.HIGH_PRECISION_TOLERANCE)
+    assertEquals(
+      expectedL1Term,
+      problemL1.getRegularizationTermValue(initialModel),
+      CommonTestUtils.HIGH_PRECISION_TOLERANCE)
+    assertEquals(
+      expectedL2Term,
+      problemL2.getRegularizationTermValue(initialModel),
+      CommonTestUtils.HIGH_PRECISION_TOLERANCE)
     assertEquals(
       expectedElasticNetTerm,
       problemElasticNet.getRegularizationTermValue(initialModel),
-      HIGH_PRECISION_TOLERANCE_THRESHOLD)
+      CommonTestUtils.HIGH_PRECISION_TOLERANCE)
   }
 }
 

--- a/photon-client/src/integTest/scala/com/linkedin/photon/ml/DriverTest.scala
+++ b/photon-client/src/integTest/scala/com/linkedin/photon/ml/DriverTest.scala
@@ -27,7 +27,6 @@ import org.testng.annotations.{DataProvider, Test}
 
 import com.linkedin.photon.ml.PhotonOptionNames._
 import com.linkedin.photon.ml.TaskType.TaskType
-import com.linkedin.photon.ml.constants.MathConst
 import com.linkedin.photon.ml.diagnostics.DiagnosticMode
 import com.linkedin.photon.ml.io.deprecated.{FieldNamesType, InputFormatType}
 import com.linkedin.photon.ml.model.Coefficients
@@ -151,7 +150,7 @@ class DriverTest extends SparkTestUtils with TestTemplateWithTmpDir {
     val bestModel = loadAllModels(new Path(outputDir, Driver.BEST_MODEL_TEXT).toString)
     assertEquals(bestModel.length, 1)
     // Verify lambda
-    assertEquals(bestModel(0)._1, 10, MathConst.HIGH_PRECISION_TOLERANCE_THRESHOLD)
+    assertEquals(bestModel(0)._1, 10, CommonTestUtils.HIGH_PRECISION_TOLERANCE)
   }
 
   @Test(expectedExceptions = Array(classOf[IllegalArgumentException]))
@@ -332,7 +331,7 @@ class DriverTest extends SparkTestUtils with TestTemplateWithTmpDir {
     val bestModel = loadAllModels(new Path(outputDir, Driver.BEST_MODEL_TEXT).toString)
     assertEquals(bestModel.length, 1)
     // Verify lambda
-    assertEquals(bestModel(0)._1, 10, MathConst.HIGH_PRECISION_TOLERANCE_THRESHOLD)
+    assertEquals(bestModel(0)._1, 10, CommonTestUtils.HIGH_PRECISION_TOLERANCE)
   }
 
   @Test
@@ -371,7 +370,7 @@ class DriverTest extends SparkTestUtils with TestTemplateWithTmpDir {
       val bestModel = loadAllModels(new Path(outputDir, Driver.BEST_MODEL_TEXT).toString)
       assertEquals(bestModel.length, 1)
       // Verify lambda
-      assertEquals(bestModel(0)._1, 10, MathConst.HIGH_PRECISION_TOLERANCE_THRESHOLD)
+      assertEquals(bestModel(0)._1, 10, CommonTestUtils.HIGH_PRECISION_TOLERANCE)
     }
 
   @Test
@@ -727,7 +726,7 @@ class DriverTest extends SparkTestUtils with TestTemplateWithTmpDir {
     val bestModel = loadAllModels(new Path(outputDir, Driver.BEST_MODEL_TEXT).toString)
     assertEquals(bestModel.length, 1)
     // Verify lambda
-    assertEquals(bestModel(0)._1, 10, MathConst.HIGH_PRECISION_TOLERANCE_THRESHOLD)
+    assertEquals(bestModel(0)._1, 10, CommonTestUtils.HIGH_PRECISION_TOLERANCE)
   }
 
   @Test
@@ -764,7 +763,7 @@ class DriverTest extends SparkTestUtils with TestTemplateWithTmpDir {
     val bestModel = loadAllModels(new Path(outputDir, Driver.BEST_MODEL_TEXT).toString)
     assertEquals(bestModel.length, 1)
     // Verify lambda
-    assertEquals(bestModel(0)._1, 10, MathConst.HIGH_PRECISION_TOLERANCE_THRESHOLD)
+    assertEquals(bestModel(0)._1, 10, CommonTestUtils.HIGH_PRECISION_TOLERANCE)
   }
 
   @DataProvider

--- a/photon-client/src/integTest/scala/com/linkedin/photon/ml/cli/game/scoring/DriverTest.scala
+++ b/photon-client/src/integTest/scala/com/linkedin/photon/ml/cli/game/scoring/DriverTest.scala
@@ -111,7 +111,7 @@ class DriverTest extends SparkTestUtils with TestTemplateWithTmpDir {
     val rootMeanSquaredError = new RegressionMetrics(predictionAndObservations).rootMeanSquaredError
 
     // Compare with the RMSE capture from an assumed-correct implementation on 5/20/2016
-    assertEquals(rootMeanSquaredError, 1.32106, MathConst.LOW_PRECISION_TOLERANCE_THRESHOLD)
+    assertEquals(rootMeanSquaredError, 1.32106001, CommonTestUtils.LOW_PRECISION_TOLERANCE)
   }
 
   @Test
@@ -129,7 +129,7 @@ class DriverTest extends SparkTestUtils with TestTemplateWithTmpDir {
     val rootMeanSquaredError = new RegressionMetrics(predictionAndObservations).rootMeanSquaredError
 
     // Compare with the RMSE capture from an assumed-correct implementation on 7/27/2016
-    assertEquals(rootMeanSquaredError, 1.321715, MathConst.LOW_PRECISION_TOLERANCE_THRESHOLD)
+    assertEquals(rootMeanSquaredError, 1.32171515, CommonTestUtils.LOW_PRECISION_TOLERANCE)
   }
 
   @Test
@@ -222,7 +222,7 @@ class DriverTest extends SparkTestUtils with TestTemplateWithTmpDir {
       val computedMetric = Driver.evaluateScores(evaluatorType, scores, gameDataSet)
       val evaluator = EvaluatorFactory.buildEvaluator(evaluatorType, gameDataSet)
       val expectedMetric = evaluator.evaluate(scores.scores.mapValues(_.score))
-      assertEquals(computedMetric, expectedMetric, MathConst.MEDIUM_PRECISION_TOLERANCE_THRESHOLD)
+      assertEquals(computedMetric, expectedMetric, CommonTestUtils.HIGH_PRECISION_TOLERANCE)
     }
   }
 
@@ -243,7 +243,7 @@ class DriverTest extends SparkTestUtils with TestTemplateWithTmpDir {
     val rootMeanSquaredError = new RegressionMetrics(predictionAndObservations).rootMeanSquaredError
 
     // Compare with the RMSE capture from an assumed-correct implementation on 5/20/2016
-    assertEquals(rootMeanSquaredError, 1.32106, MathConst.LOW_PRECISION_TOLERANCE_THRESHOLD)
+    assertEquals(rootMeanSquaredError, 1.32106001, CommonTestUtils.LOW_PRECISION_TOLERANCE)
   }
 
   /**

--- a/photon-client/src/integTest/scala/com/linkedin/photon/ml/data/avro/AvroDataReaderTest.scala
+++ b/photon-client/src/integTest/scala/com/linkedin/photon/ml/data/avro/AvroDataReaderTest.scala
@@ -22,8 +22,7 @@ import org.apache.spark.sql.functions._
 import org.testng.Assert._
 import org.testng.annotations.Test
 
-import com.linkedin.photon.ml.constants.MathConst
-import com.linkedin.photon.ml.test.SparkTestUtils
+import com.linkedin.photon.ml.test.{CommonTestUtils, SparkTestUtils}
 import com.linkedin.photon.ml.util._
 
 /**
@@ -31,18 +30,7 @@ import com.linkedin.photon.ml.util._
  */
 class AvroDataReaderTest extends SparkTestUtils {
 
-  private val tol = MathConst.HIGH_PRECISION_TOLERANCE_THRESHOLD
-  private val inputDir = "GameIntegTest/input"
-  private val inputPath = getClass.getClassLoader.getResource(inputDir + "/train").getPath
-  private val inputPath2 = getClass.getClassLoader.getResource(inputDir + "/test").getPath
-  private val duplicateFeaturesPath = getClass.getClassLoader.getResource(inputDir + "/duplicateFeatures").getPath
-  private val indexMapPath = getClass.getClassLoader.getResource(inputDir + "/feature-indexes").getPath
-  private val numPartitions = 4
-  private val featureSectionMap = Map(
-    "shard1" -> Set("userFeatures", "songFeatures"),
-    "shard2" -> Set("userFeatures"),
-    "shard3" -> Set("songFeatures")
-  )
+  import AvroDataReaderTest._
 
   @Test
   def testRead(): Unit = sparkTest("testRead") {
@@ -118,6 +106,21 @@ class AvroDataReaderTest extends SparkTestUtils {
     val dr = new AvroDataReader(sc)
     dr.read(emptyInputPath, numPartitions)
   }
+}
+
+object AvroDataReaderTest {
+
+  private val inputDir = "GameIntegTest/input"
+  private val inputPath = getClass.getClassLoader.getResource(inputDir + "/train").getPath
+  private val inputPath2 = getClass.getClassLoader.getResource(inputDir + "/test").getPath
+  private val duplicateFeaturesPath = getClass.getClassLoader.getResource(inputDir + "/duplicateFeatures").getPath
+  private val indexMapPath = getClass.getClassLoader.getResource(inputDir + "/feature-indexes").getPath
+  private val numPartitions = 4
+  private val featureSectionMap = Map(
+    "shard1" -> Set("userFeatures", "songFeatures"),
+    "shard2" -> Set("userFeatures"),
+    "shard3" -> Set("songFeatures")
+  )
 
   /**
    * Verifies that the DataFrame has expected shape and statistics.
@@ -132,26 +135,26 @@ class AvroDataReaderTest extends SparkTestUtils {
     assertTrue(df.columns.contains("shard1"))
     val vector1 = df.select(col("shard1")).take(1)(0).getAs[SparseVector](0)
     assertEquals(vector1.numActives, 61)
-    assertEquals(Vectors.norm(vector1, 2), 3.2298996752519407, tol)
+    assertEquals(Vectors.norm(vector1, 2), 3.2298996752519407, CommonTestUtils.HIGH_PRECISION_TOLERANCE)
     val (mu1: Double, _, var1: Double) = DescriptiveStats.meanAndCov(vector1.values, vector1.values)
-    assertEquals(mu1, 0.044020727910406766, tol)
-    assertEquals(var1, 0.17190074364268512, tol)
+    assertEquals(mu1, 0.044020727910406766, CommonTestUtils.HIGH_PRECISION_TOLERANCE)
+    assertEquals(var1, 0.17190074364268512, CommonTestUtils.HIGH_PRECISION_TOLERANCE)
 
     assertTrue(df.columns.contains("shard2"))
     val vector2 = df.select(col("shard2")).take(1)(0).getAs[SparseVector](0)
     assertEquals(vector2.numActives, 31)
-    assertEquals(Vectors.norm(vector2, 2), 2.509607963949448, tol)
+    assertEquals(Vectors.norm(vector2, 2), 2.509607963949448, CommonTestUtils.HIGH_PRECISION_TOLERANCE)
     val (mu2: Double, _, var2: Double) = DescriptiveStats.meanAndCov(vector2.values, vector2.values)
-    assertEquals(mu2, 0.05196838235602745, tol)
-    assertEquals(var2, 0.20714700123375754, tol)
+    assertEquals(mu2, 0.05196838235602745, CommonTestUtils.HIGH_PRECISION_TOLERANCE)
+    assertEquals(var2, 0.20714700123375754, CommonTestUtils.HIGH_PRECISION_TOLERANCE)
 
     assertTrue(df.columns.contains("shard3"))
     val vector3 = df.select(col("shard3")).take(1)(0).getAs[SparseVector](0)
     assertEquals(vector3.numActives, 31)
-    assertEquals(Vectors.norm(vector3, 2), 2.265859611598675, tol)
+    assertEquals(Vectors.norm(vector3, 2), 2.265859611598675, CommonTestUtils.HIGH_PRECISION_TOLERANCE)
     val (mu3: Double, _, var3: Double) = DescriptiveStats.meanAndCov(vector3.values, vector3.values)
-    assertEquals(mu3, 0.06691111449993427, tol)
-    assertEquals(var3, 0.16651099216405915, tol)
+    assertEquals(mu3, 0.06691111449993427, CommonTestUtils.HIGH_PRECISION_TOLERANCE)
+    assertEquals(var3, 0.16651099216405915, CommonTestUtils.HIGH_PRECISION_TOLERANCE)
 
     // Relationship between columns is the same across the entire dataframe
     df.foreach { row =>

--- a/photon-client/src/main/scala/com/linkedin/photon/ml/io/deprecated/GLMSuite.scala
+++ b/photon-client/src/main/scala/com/linkedin/photon/ml/io/deprecated/GLMSuite.scala
@@ -322,10 +322,21 @@ class GLMSuite(
             val featureFullName = Constants.INTERCEPT_KEY
             pairsArr += ((indexMap.getIndex(featureFullName), 1.0))
           }
+
           val sortedPairsArray = pairsArr.toArray.sortBy(_._1)
+
+          // Check for duplicate features (copied from AvroDataReader)
+          val duplicateFeatures = sortedPairsArray
+            .groupBy(_._1)
+            .filter(_._2.length > 1)
+            .map { case (k, v) => (k, v.map(_._2).toList) }
+          require(duplicateFeatures.isEmpty, s"Duplicate features found: ${duplicateFeatures.toString}")
+
           val index = sortedPairsArray.map(_._1)
           val value = sortedPairsArray.map(_._2)
+
           new SparseVector[Double](index, value, numFeatures)
+
         case other =>
           throw new IOException(s"Avro field [${fieldNames.FEATURES}] (val = ${String.valueOf(other)}) is not a list")
       }

--- a/photon-client/src/test/scala/com/linkedin/photon/ml/util/UtilsTest.scala
+++ b/photon-client/src/test/scala/com/linkedin/photon/ml/util/UtilsTest.scala
@@ -91,9 +91,6 @@ class UtilsTest extends TestTemplateWithTmpDir {
     assertEquals(prototypeSparseVector.length, initializedSparseVector.length,
       s"Length of the initialized vector (${initializedSparseVector.length}) " +
         s"is different from the prototype vector (${prototypeSparseVector.length}})")
-    assertEquals(prototypeSparseVector.activeSize, initializedSparseVector.activeSize,
-      s"Active size of the initialized vector (${initializedSparseVector.activeSize}) " +
-        s"is different from the prototype vector (${prototypeSparseVector.activeSize}})")
     assertTrue(initializedSparseVector.isInstanceOf[SparseVector[Double]],
       s"The initialized sparse vector (${initializedSparseVector.getClass}) " +
         s"is not an instance of the prototype vectors' class (${prototypeSparseVector.getClass})")

--- a/photon-lib/src/integTest/scala/com/linkedin/photon/ml/sampler/BinaryClassificationDownSamplerTest.scala
+++ b/photon-lib/src/integTest/scala/com/linkedin/photon/ml/sampler/BinaryClassificationDownSamplerTest.scala
@@ -65,10 +65,10 @@ class BinaryClassificationDownSamplerTest extends SparkTestUtils {
 
       assertEquals(pos.count(), NUM_POSITIVES_TO_GENERATE)
       pos.foreach { case (_, point) =>
-        assertEquals(point.weight, 1.0, MathConst.MEDIUM_PRECISION_TOLERANCE_THRESHOLD)
+        assertEquals(point.weight, 1.0, CommonTestUtils.LOW_PRECISION_TOLERANCE)
       }
       neg.foreach{ case (_, point) =>
-        assertEquals(point.weight, 1.0 / downSamplingRate, MathConst.MEDIUM_PRECISION_TOLERANCE_THRESHOLD)
+        assertEquals(point.weight, 1.0 / downSamplingRate, CommonTestUtils.LOW_PRECISION_TOLERANCE)
       }
     }
 

--- a/photon-lib/src/integTest/scala/com/linkedin/photon/ml/stat/BasicStatisticalSummaryTest.scala
+++ b/photon-lib/src/integTest/scala/com/linkedin/photon/ml/stat/BasicStatisticalSummaryTest.scala
@@ -22,18 +22,15 @@ import org.testng.Assert._
 import org.testng.annotations.{DataProvider, Test}
 
 import com.linkedin.photon.ml.Types.SparkVector
-import com.linkedin.photon.ml.constants.MathConst
 import com.linkedin.photon.ml.data.LabeledPoint
 import com.linkedin.photon.ml.test.Assertions.assertIterableEqualsWithTolerance
-import com.linkedin.photon.ml.test.SparkTestUtils
+import com.linkedin.photon.ml.test.{CommonTestUtils, SparkTestUtils}
 import com.linkedin.photon.ml.util.VectorUtils
 
 /**
  * Tests for BasicStatisticalSummary.
  */
 class BasicStatisticalSummaryTest extends SparkTestUtils {
-
-  private val EPSILON: Double = MathConst.HIGH_PRECISION_TOLERANCE_THRESHOLD
 
   /**
    * A trivial set of fixed labeled points for simple tests to verify by hand.
@@ -77,22 +74,22 @@ class BasicStatisticalSummaryTest extends SparkTestUtils {
     val stats = BasicStatisticalSummary(trainingData.select(featureShardId).rdd.map(_.getAs[SparkVector](0)))
 
     assertEquals(stats.count, 10)
-    assertEquals(stats.mean(0), 0.3847210904276229, EPSILON)
-    assertEquals(stats.mean(1), -0.26976712031174965, EPSILON)
-    assertEquals(stats.variance(0), 0.40303763661250336, EPSILON)
-    assertEquals(stats.variance(1), 0.13748971393448942, EPSILON)
+    assertEquals(stats.mean(0), 0.3847210904276229, CommonTestUtils.HIGH_PRECISION_TOLERANCE)
+    assertEquals(stats.mean(1), -0.26976712031174965, CommonTestUtils.HIGH_PRECISION_TOLERANCE)
+    assertEquals(stats.variance(0), 0.40303763661250336, CommonTestUtils.HIGH_PRECISION_TOLERANCE)
+    assertEquals(stats.variance(1), 0.13748971393448942, CommonTestUtils.HIGH_PRECISION_TOLERANCE)
     assertEquals(stats.numNonzeros(0), 10.0)
     assertEquals(stats.numNonzeros(1), 4.0)
-    assertEquals(stats.max(0), 0.9699938346531928, EPSILON)
-    assertEquals(stats.max(1), 0.0, EPSILON)
-    assertEquals(stats.min(0), -0.7306653538519616, EPSILON)
-    assertEquals(stats.min(1), -0.8972778242305388, EPSILON)
-    assertEquals(stats.normL1(0), 6.652510022278823, EPSILON)
-    assertEquals(stats.normL1(1), 2.6976712031174963, EPSILON)
-    assertEquals(stats.normL2(0), 2.2599650226741836, EPSILON)
-    assertEquals(stats.normL2(1), 1.401838227979015, EPSILON)
-    assertEquals(stats.meanAbs(0), 0.6652510022278822, EPSILON)
-    assertEquals(stats.meanAbs(1), 0.26976712031174965, EPSILON)
+    assertEquals(stats.max(0), 0.9699938346531928, CommonTestUtils.HIGH_PRECISION_TOLERANCE)
+    assertEquals(stats.max(1), 0.0, CommonTestUtils.HIGH_PRECISION_TOLERANCE)
+    assertEquals(stats.min(0), -0.7306653538519616, CommonTestUtils.HIGH_PRECISION_TOLERANCE)
+    assertEquals(stats.min(1), -0.8972778242305388, CommonTestUtils.HIGH_PRECISION_TOLERANCE)
+    assertEquals(stats.normL1(0), 6.652510022278823, CommonTestUtils.HIGH_PRECISION_TOLERANCE)
+    assertEquals(stats.normL1(1), 2.6976712031174963, CommonTestUtils.HIGH_PRECISION_TOLERANCE)
+    assertEquals(stats.normL2(0), 2.2599650226741836, CommonTestUtils.HIGH_PRECISION_TOLERANCE)
+    assertEquals(stats.normL2(1), 1.401838227979015, CommonTestUtils.HIGH_PRECISION_TOLERANCE)
+    assertEquals(stats.meanAbs(0), 0.6652510022278822, CommonTestUtils.HIGH_PRECISION_TOLERANCE)
+    assertEquals(stats.meanAbs(1), 0.26976712031174965, CommonTestUtils.HIGH_PRECISION_TOLERANCE)
   }
 
   /**
@@ -137,13 +134,13 @@ class BasicStatisticalSummaryTest extends SparkTestUtils {
     val variance = items.map(_._6)
     val numNonzeros = items.map(_._7)
 
-    assertIterableEqualsWithTolerance(summary.max.toArray, max, EPSILON)
-    assertIterableEqualsWithTolerance(summary.min.toArray, min, EPSILON)
-    assertIterableEqualsWithTolerance(summary.mean.toArray, mean, EPSILON)
-    assertIterableEqualsWithTolerance(summary.variance.toArray, variance, EPSILON)
-    assertIterableEqualsWithTolerance(summary.normL1.toArray, normL1, EPSILON)
-    assertIterableEqualsWithTolerance(summary.normL2.toArray, normL2, EPSILON)
-    assertIterableEqualsWithTolerance(summary.numNonzeros.toArray, numNonzeros, EPSILON)
-    assertIterableEqualsWithTolerance(summary.meanAbs.toArray, meanAbs, EPSILON)
+    assertIterableEqualsWithTolerance(summary.max.toArray, max, CommonTestUtils.HIGH_PRECISION_TOLERANCE)
+    assertIterableEqualsWithTolerance(summary.min.toArray, min, CommonTestUtils.HIGH_PRECISION_TOLERANCE)
+    assertIterableEqualsWithTolerance(summary.mean.toArray, mean, CommonTestUtils.HIGH_PRECISION_TOLERANCE)
+    assertIterableEqualsWithTolerance(summary.variance.toArray, variance, CommonTestUtils.HIGH_PRECISION_TOLERANCE)
+    assertIterableEqualsWithTolerance(summary.normL1.toArray, normL1, CommonTestUtils.HIGH_PRECISION_TOLERANCE)
+    assertIterableEqualsWithTolerance(summary.normL2.toArray, normL2, CommonTestUtils.HIGH_PRECISION_TOLERANCE)
+    assertIterableEqualsWithTolerance(summary.numNonzeros.toArray, numNonzeros, CommonTestUtils.HIGH_PRECISION_TOLERANCE)
+    assertIterableEqualsWithTolerance(summary.meanAbs.toArray, meanAbs, CommonTestUtils.HIGH_PRECISION_TOLERANCE)
   }
 }

--- a/photon-lib/src/main/scala/com/linkedin/photon/ml/constants/MathConst.scala
+++ b/photon-lib/src/main/scala/com/linkedin/photon/ml/constants/MathConst.scala
@@ -18,9 +18,7 @@ package com.linkedin.photon.ml.constants
  * Math constants.
  */
 object MathConst {
-  protected[ml] val HIGH_PRECISION_TOLERANCE_THRESHOLD: Double = 1e-12
-  protected[ml] val MEDIUM_PRECISION_TOLERANCE_THRESHOLD: Double = 1e-8
-  protected[ml] val LOW_PRECISION_TOLERANCE_THRESHOLD: Double = 1e-4
+  protected[ml] val EPSILON: Double = 1e-12
   protected[ml] val RANDOM_SEED: Long = 1234567890L
   protected[ml] val POSITIVE_RESPONSE_THRESHOLD = 0.5
   protected[ml] val DEFAULT_WEIGHT = 1.0

--- a/photon-lib/src/main/scala/com/linkedin/photon/ml/model/DatumScoringModel.scala
+++ b/photon-lib/src/main/scala/com/linkedin/photon/ml/model/DatumScoringModel.scala
@@ -26,10 +26,8 @@ import com.linkedin.photon.ml.util.Summarizable
  */
 protected[ml] trait DatumScoringModel extends Summarizable {
 
-  /** The model type: even though a model may have many sub-problems, there is only one loss function type for a given
-   *  DatumScoringModel.
-   *
-   *  @return The type of model which is scored
+  /**
+   * Even though a model may have many sub-problems, there is only one loss function type for a given DatumScoringModel.
    */
   def modelType: TaskType
 

--- a/photon-lib/src/main/scala/com/linkedin/photon/ml/optimization/LBFGS.scala
+++ b/photon-lib/src/main/scala/com/linkedin/photon/ml/optimization/LBFGS.scala
@@ -69,7 +69,7 @@ class LBFGS(
         val breezeState = breezeStates.next()
         // Project coefficients into constrained space, if any, before updating the state
         OptimizerState(
-          OptimizationUtils.projectCoefficientsToHypercube(breezeState.x, constraintMap),
+          OptimizationUtils.projectCoefficientsToSubspace(breezeState.x, constraintMap),
           breezeState.adjustedValue,
           breezeState.adjustedGradient,
           state.iter + 1)

--- a/photon-lib/src/main/scala/com/linkedin/photon/ml/optimization/TRON.scala
+++ b/photon-lib/src/main/scala/com/linkedin/photon/ml/optimization/TRON.scala
@@ -220,7 +220,7 @@ class TRON(
 
         improved = true
         /* project coefficients into constrained space, if any, after the optimization step */
-        val projectedCoefficients = OptimizationUtils.projectCoefficientsToHypercube(coefficients, constraintMap)
+        val projectedCoefficients = OptimizationUtils.projectCoefficientsToSubspace(coefficients, constraintMap)
         finalState = OptimizerState(
           projectedCoefficients,
           updatedFunctionValue,

--- a/photon-lib/src/main/scala/com/linkedin/photon/ml/util/ClassUtils.scala
+++ b/photon-lib/src/main/scala/com/linkedin/photon/ml/util/ClassUtils.scala
@@ -22,7 +22,7 @@ object ClassUtils {
   private val ANON_CLASS_MARKER = "$anon$"
 
   /**
-   * Method for detecting anonymous classes (the isAnonymousClass method is broken in Scala).
+   * Method for detecting anonymous classes (the isAnonymousClass method is broken in Scala as late as 2.11).
    *
    * @param clazz A class
    * @return True if the given class is anonymous, false otherwise.
@@ -30,7 +30,7 @@ object ClassUtils {
   def isAnonClass(clazz: Class[_]): Boolean = clazz.getName.contains(ANON_CLASS_MARKER)
 
   /**
-   * Get the true class type of an object, if it can be of anonymous type.
+   * Get the true class type of an object, if it is an anonymous derived class.
    *
    * @tparam T Any type
    * @param obj An object

--- a/photon-lib/src/main/scala/com/linkedin/photon/ml/util/MathUtils.scala
+++ b/photon-lib/src/main/scala/com/linkedin/photon/ml/util/MathUtils.scala
@@ -22,7 +22,7 @@ import com.linkedin.photon.ml.constants.MathConst
 object MathUtils {
 
   /**
-   * This function is copied from MLlib's MLUtils.log1pExp.
+   * This function is copied from MLlib's MLUtils.log1pExp (it is copied instead of imported because it is private).
    *
    * When `x` is positive and large, computing `math.log(1 + math.exp(x))` will lead to arithmetic overflow. This will
    * happen when `x > 709.78` which is not a very large number. It can be addressed by rewriting the formula into
@@ -45,5 +45,5 @@ object MathUtils {
    * @param x The value to test for near-equality to zero
    * @return True if x is "as good as" zero, false if it is "significantly" different from zero
    */
-  def isAlmostZero(x: Double): Boolean = math.abs(x) < MathConst.HIGH_PRECISION_TOLERANCE_THRESHOLD
+  def isAlmostZero(x: Double): Boolean = math.abs(x) < MathConst.EPSILON
 }

--- a/photon-lib/src/test/scala/com/linkedin/photon/ml/model/CoefficientsTest.scala
+++ b/photon-lib/src/test/scala/com/linkedin/photon/ml/model/CoefficientsTest.scala
@@ -18,30 +18,14 @@ import breeze.linalg.{DenseVector, SparseVector, Vector}
 import org.testng.Assert._
 import org.testng.annotations.{DataProvider, Test}
 
-import com.linkedin.photon.ml.constants.MathConst
+import com.linkedin.photon.ml.test.CommonTestUtils
 
 /**
  * Unit tests for Coefficients.
  */
 class CoefficientsTest {
 
-  /**
-   *
-   * @param values
-   * @return
-   */
-  private def dense(values: Double*) =
-    new DenseVector[Double](Array[Double](values: _*))
-
-  /**
-   *
-   * @param length
-   * @param indices
-   * @param nnz
-   * @return
-   */
-  private def sparse(length: Int)(indices: Int*)(nnz: Double*) =
-    new SparseVector[Double](Array[Int](indices: _*), Array[Double](nnz: _*), length)
+  import CoefficientsTest._
 
   @DataProvider(name = "invalidVectorProvider")
   def makeInvalidVectors(): Array[Array[Vector[Double]]] =
@@ -69,6 +53,27 @@ class CoefficientsTest {
   @Test
   def testComputeScore(): Unit =
     for { v1 <- List(dense(1,0,3,0), sparse(4)(0,2)(1,3))
-          v2 <- List(dense(-1,0,0,1), sparse(4)(0,3)(-1,1)) }
-      assertEquals(Coefficients(v1).computeScore(v2), v1.dot(v2), MathConst.HIGH_PRECISION_TOLERANCE_THRESHOLD)
+          v2 <- List(dense(-1,0,0,1), sparse(4)(0,3)(-1,1)) } {
+      assertEquals(Coefficients(v1).computeScore(v2), v1.dot(v2), CommonTestUtils.HIGH_PRECISION_TOLERANCE)
+    }
+}
+
+object CoefficientsTest {
+
+  /**
+   *
+   * @param values
+   * @return
+   */
+  private def dense(values: Double*) = new DenseVector[Double](Array[Double](values: _*))
+
+  /**
+   *
+   * @param length
+   * @param indices
+   * @param nnz
+   * @return
+   */
+  private def sparse(length: Int)(indices: Int*)(nnz: Double*) =
+    new SparseVector[Double](Array[Int](indices: _*), Array[Double](nnz: _*), length)
 }

--- a/photon-lib/src/test/scala/com/linkedin/photon/ml/optimization/OptimizationUtilsTest.scala
+++ b/photon-lib/src/test/scala/com/linkedin/photon/ml/optimization/OptimizationUtilsTest.scala
@@ -52,6 +52,6 @@ class OptimizationUtilsTest {
       expectedVectorOutput: Vector[Double]): Unit =
 
     Assert.assertEquals(
-      OptimizationUtils.projectCoefficientsToHypercube(coefficients, constraints),
+      OptimizationUtils.projectCoefficientsToSubspace(coefficients, constraints),
       expectedVectorOutput)
 }

--- a/photon-test-utils/src/main/scala/com/linkedin/photon/ml/test/CommonTestUtils.scala
+++ b/photon-test-utils/src/main/scala/com/linkedin/photon/ml/test/CommonTestUtils.scala
@@ -20,9 +20,12 @@ import scala.util.Random
 import breeze.linalg.{DenseVector, Vector}
 
 /**
- * A collection of methods useful for tests.
+ * A collection of methods/constants useful for tests.
  */
 object CommonTestUtils {
+
+  val LOW_PRECISION_TOLERANCE = 1e-8
+  val HIGH_PRECISION_TOLERANCE = 1e-12
 
   /**
    * Append prefix to a CMD line option name, forming an argument string.


### PR DESCRIPTION
- Replace "high", "medium", and "low" tolerances with one "epsilon" for representing values close to 0
- Replace unit/integration test dependencies on 3 tolerance values in `MathConst` on 2 tolerance values in `CommonTestUtils`
- Move the old "low" tolerance into `VectorUtils` as a sparsity threshold (**As discussed in the comments below and offline, this should become a configurable parameter with a default value determined through testing**)
- Replace `String` and `Long` with `REId`, `REType`, and `UniqueSampleId` helper types where possible
- Copy `AvroDataReader` duplicate checking code to the `GLMSuite` until we're ready to deprecate the original Photon driver
- Add a unit test for the above `GLMSuite` change