### PR TITLE
Add a way to preserve metadata map in the input records after scoring

### DIFF
--- a/photon-api/src/main/scala/com/linkedin/photon/ml/data/GameConverters.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/data/GameConverters.scala
@@ -43,6 +43,7 @@ object GameConverters {
    * @param isResponseRequired Whether a response column is mandatory. For example: [[GameDatum]] used for training
    *                           require a response for each [[Row]]; [[GameDatum]] used for scoring do not.
    * @param inputColumnsNames User-supplied input column names to read the input data
+   * @param preserveMetadataMap Whether the metadata map in the row, if it exists, should be copied into [[GameDatum]]
    * @return An [[RDD]] of type [[GameDatum]]
    */
   protected[ml] def getGameDataSetFromDataFrame(
@@ -50,16 +51,17 @@ object GameConverters {
       featureShards: Set[FeatureShardId],
       idTagSet: Set[String],
       isResponseRequired: Boolean,
-      inputColumnsNames: InputColumnsNames = InputColumnsNames()): RDD[(Long, GameDatum)] = {
+      inputColumnsNames: InputColumnsNames = InputColumnsNames(),
+      preserveMetadataMap: Boolean = false): RDD[(Long, GameDatum)] = {
 
-    val recordsWithUniqueId = data.withColumn(UNIQUE_ID_COLUMN_NAME, monotonicallyIncreasingId)
+    val recordsWithUniqueId = data.withColumn(UNIQUE_ID_COLUMN_NAME, monotonically_increasing_id())
     val inputColumnsNamesBroadcast = data.sqlContext.sparkContext.broadcast(inputColumnsNames)
 
     recordsWithUniqueId
       .rdd
       .map { row: Row =>
         (row.getAs[Long](UNIQUE_ID_COLUMN_NAME),
-          getGameDatumFromRow(row, featureShards, idTagSet, isResponseRequired, inputColumnsNamesBroadcast))
+          getGameDatumFromRow(row, featureShards, idTagSet, isResponseRequired, inputColumnsNamesBroadcast, preserveMetadataMap))
       }
   }
 
@@ -72,6 +74,7 @@ object GameConverters {
    * @param isResponseRequired Whether a response column is mandatory. For example: [[GameDatum]] used for training
    *                           require a response for the [[Row]]; [[GameDatum]] used for scoring do not.
    * @param columnsBroadcast The names of the columns to look for in the input rows, in order
+   * @param preserveMetadataMap Whether the metadata map in the row, if it exists, should be copied into [[GameDatum]]
    * @return A [[GameDatum]]
    */
   protected[data] def getGameDatumFromRow(
@@ -79,7 +82,8 @@ object GameConverters {
       featureShards: Set[String],
       idTagSet: Set[String],
       isResponseRequired: Boolean,
-      columnsBroadcast: Broadcast[InputColumnsNames]): GameDatum = {
+      columnsBroadcast: Broadcast[InputColumnsNames],
+      preserveMetadataMap: Boolean = false): GameDatum = {
 
     val columns = columnsBroadcast.value
 
@@ -114,10 +118,10 @@ object GameConverters {
       // TODO: find a better way to handle the field "uid", which is used in ScoringResult
       if (row.schema.fieldNames.contains(columns(InputColumnsNames.UID))
           && row.getAs[Any](columns(InputColumnsNames.UID)) != null) {
-        getIdTagToValueMapFromRow(row, idTagSet, columns) +
+        getIdTagToValueMapFromRow(row, idTagSet, columns, preserveMetadataMap) +
             (InputColumnsNames.UID.toString -> row.getAs[Any](columns(InputColumnsNames.UID)).toString)
       } else {
-        getIdTagToValueMapFromRow(row, idTagSet, columns)
+        getIdTagToValueMapFromRow(row, idTagSet, columns, preserveMetadataMap)
       }
 
     new GameDatum(
@@ -129,16 +133,23 @@ object GameConverters {
   }
 
   /**
-   * Given a [[DataFrame]] [[Row]], build a map of ID tag to ID value.
+   * Given a [[DataFrame]] [[Row]], we return the ID tags mapped to their corresponding ID values. If the user intends
+   * to preserve the metadata map, preserveMetadataMap flag must be set to true
+   *
+   * Note that if the existing metadata map contains one of the ID tags as a key as well as contains that ID tag as a
+   * field within the [[Row]], the value of the field takes preference. So in such a case, the value in the id tag
+   * map in the output will be the value of the field in the [[Row]]
    *
    * @param row The source DataFrame row
    * @param idTagSet The set of columns/metadata fields expected for the [[Row]]
-   * @return The map of ID tag to ID value map for the [[Row]]
+   * @param preserveMetadataMap Whether the metadata map in the row, if it exists, should be copied into [[GameDatum]]
+   * @return The map containing ID tag keys mapped to ID values along with metadata map, depending on user intent
    */
   protected[data] def getIdTagToValueMapFromRow(
     row: Row,
     idTagSet: Set[String],
-    columns: InputColumnsNames = InputColumnsNames()): Map[String, String] = {
+    columns: InputColumnsNames = InputColumnsNames(),
+    preserveMetadataMap: Boolean = false): Map[String, String] = {
 
     val metaMap: Option[Map[String, String]] = if (row.schema.fieldNames.contains(columns(InputColumnsNames.META_DATA_MAP))) {
       Some(row.getAs[Map[String, String]](columns(InputColumnsNames.META_DATA_MAP)))
@@ -146,7 +157,7 @@ object GameConverters {
       None
     }
 
-    idTagSet
+    val idMap = idTagSet
       .map { idTag =>
         val idFromRow: Option[String] = if (row.schema.fieldNames.contains(idTag)) {
           Some(row.getAs[Any](idTag).toString)
@@ -167,5 +178,9 @@ object GameConverters {
         (idTag, id)
       }
       .toMap
+    metaMap match {
+      case Some(x) => if (preserveMetadataMap) x ++ idMap else idMap
+      case None => idMap
+    }
   }
 }

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/estimators/GameEstimator.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/estimators/GameEstimator.scala
@@ -264,7 +264,7 @@ class GameEstimator(val sc: SparkContext, implicit val logger: Logger) {
           featureShardColumnNames,
           idTagSet,
           isResponseRequired = true,
-          rowInputColumnNames)
+          inputColumnsNames = rowInputColumnNames)
         .partitionBy(gameDataPartitioner)
         .setName("GAME training data")
         .persist(StorageLevel.INFREQUENT_REUSE_RDD_STORAGE_LEVEL)
@@ -392,7 +392,7 @@ class GameEstimator(val sc: SparkContext, implicit val logger: Logger) {
             featureShardColumnNames,
             additionalCols,
             isResponseRequired = true,
-            rowInputColumnNames)
+            inputColumnsNames = rowInputColumnNames)
           .partitionBy(partitioner)
           .setName("Validating Game data set")
           .persist(StorageLevel.INFREQUENT_REUSE_RDD_STORAGE_LEVEL)

--- a/photon-client/src/integTest/scala/com/linkedin/photon/ml/cli/game/training/DriverTest.scala
+++ b/photon-client/src/integTest/scala/com/linkedin/photon/ml/cli/game/training/DriverTest.scala
@@ -581,7 +581,7 @@ class DriverTest extends SparkTestUtils with GameTestUtils with TestTemplateWith
           featureSectionMap.keys.toSet,
           idTagSet,
           isResponseRequired = true,
-          driver.params.inputColumnsNames)
+          inputColumnsNames = driver.params.inputColumnsNames)
         .partitionBy(partitioner)
 
     val validatingLabelsAndOffsetsAndWeights =

--- a/photon-client/src/main/scala/com/linkedin/photon/ml/cli/game/scoring/Driver.scala
+++ b/photon-client/src/main/scala/com/linkedin/photon/ml/cli/game/scoring/Driver.scala
@@ -69,7 +69,8 @@ class Driver(val params: Params, val sc: SparkContext, val logger: Logger)
         featureShardIdToFeatureSectionKeysMap.keys.toSet,
         idTagSet,
         isResponseRequired = false,
-        params.inputColumnsNames)
+        inputColumnsNames = params.inputColumnsNames,
+        preserveMetadataMap = true)
       .partitionBy(partitioner)
       .setName("Game data set with UIDs for scoring")
       .persist(StorageLevel.INFREQUENT_REUSE_RDD_STORAGE_LEVEL)


### PR DESCRIPTION
If the records being scored have an identity, we currently lose that information after scoring except via the UID field, if one exists.

If one wants to preserve some meta information about the record, this PR adds a way of doing this. The user can add simple flags that they want to preserve in the metadata map and after scoring the map in the output will preserve all fields in the input metadata map and add to them, information about the random effect ids. Before this PR, the metadata map in the output would only contain the random effect id information and the input metadata map would be ignored.