### PR TITLE
Fix bug that would unpersist models that are still in use

### DIFF
--- a/photon-api/src/main/scala/com/linkedin/photon/ml/data/RandomEffectDataSetInProjectedSpace.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/data/RandomEffectDataSetInProjectedSpace.scala
@@ -69,10 +69,12 @@ class RandomEffectDataSetInProjectedSpace(
    * @return This object with all its RDDs unpersisted
    */
   override def unpersistRDD(): this.type = {
-    randomEffectProjector match {
-      case rddLike: RDDLike => rddLike.unpersistRDD()
-      case _ =>
-    }
+    // TODO: Projection needs to be refactored in general - the RandomEffectProjector gets passed around between classes
+    // and has no one owner
+//    randomEffectProjector match {
+//      case rddLike: RDDLike => rddLike.unpersistRDD()
+//      case _ =>
+//    }
     super.unpersistRDD()
     this
   }

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/model/RandomEffectModelInProjectedSpace.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/model/RandomEffectModelInProjectedSpace.scala
@@ -107,6 +107,7 @@ protected[ml] class RandomEffectModelInProjectedSpace(
    */
   override def persistRDD(storageLevel: StorageLevel): RandomEffectModelInProjectedSpace = {
 
+    super.persistRDD(storageLevel)
     if (!modelsInProjectedSpaceRDD.getStorageLevel.isValid) modelsInProjectedSpaceRDD.persist(storageLevel)
 
     this
@@ -119,6 +120,7 @@ protected[ml] class RandomEffectModelInProjectedSpace(
   override def unpersistRDD(): RandomEffectModelInProjectedSpace = {
 
     if (modelsInProjectedSpaceRDD.getStorageLevel.isValid) modelsInProjectedSpaceRDD.unpersist()
+    super.unpersistRDD()
 
     this
   }
@@ -130,7 +132,8 @@ protected[ml] class RandomEffectModelInProjectedSpace(
    */
   override def setName(name: String): RandomEffectModelInProjectedSpace = {
 
-    modelsInProjectedSpaceRDD.setName(name)
+    super.setName(name)
+    modelsInProjectedSpaceRDD.setName(name + " (projected)")
 
     this
   }
@@ -141,6 +144,7 @@ protected[ml] class RandomEffectModelInProjectedSpace(
    */
   override def materialize(): RandomEffectModelInProjectedSpace = {
 
+    super.materialize()
     materializeOnce(modelsInProjectedSpaceRDD)
 
     this

--- a/photon-lib/src/test/scala/com/linkedin/photon/ml/algorithm/CoordinateDescentTest.scala
+++ b/photon-lib/src/test/scala/com/linkedin/photon/ml/algorithm/CoordinateDescentTest.scala
@@ -19,6 +19,7 @@ import org.mockito.Matchers
 import org.mockito.Mockito._
 import org.testng.annotations.{DataProvider, Test}
 
+import com.linkedin.photon.ml.Types.CoordinateId
 import com.linkedin.photon.ml.data._
 import com.linkedin.photon.ml.data.scoring.CoordinateDataScores
 import com.linkedin.photon.ml.evaluation.Evaluator
@@ -79,6 +80,7 @@ class CoordinateDescentTest {
       doReturn((model, Some(tracker))).when(coordinate).updateModel(model, score)
 
       // GameModel mock setup
+      doReturn(Map[CoordinateId, DatumScoringModel]()).when(gameModel).toMap
       doReturn(gameModel).when(gameModel).updateModel(coordinateId, model)
       doReturn(Some(model)).when(gameModel).getModel(coordinateId)
     }
@@ -141,6 +143,7 @@ class CoordinateDescentTest {
     // and GAME model #1 will be the first one to go through best model selection
     val gameModels = (0 to iterationCount + 1).map { _ => mock(classOf[GameModel]) }
     (0 until iterationCount).map { i =>
+      when(gameModels(i).toMap).thenReturn(Map[CoordinateId, DatumScoringModel]())
       when(gameModels(i).getModel(Matchers.any())).thenReturn(Some(coordinateModel))
       when(gameModels(i).updateModel(Matchers.any(), Matchers.any())).thenReturn(gameModels(i + 1))
     }
@@ -177,7 +180,7 @@ class CoordinateDescentTest {
     }
 
     // Verify the calls to the validation evaluator(s), if any
-    validationDataAndEvaluators.map { case (data, evaluators) =>
+    validationDataAndEvaluators.map { case (_, evaluators) =>
       evaluators.map { case (evaluator) =>
         verify(evaluator, times(iterationCount)).evaluate(modelScores)
       }


### PR DESCRIPTION
This bug has been giving us trouble. I've tested the solution internally, in addition to the unit and integration tests.

Prior to the patch, we were unpersisting the coordinates of the trained GAME model (stored in `updatedGameModel`) each time we computed a new one.

This caused an issue in the case that an iteration produced a worse overall model - the coordinate models that made up the GAME model had been unpersisted. When the best GAME model is returned and used, Spark would try to recompute the coordinate models using their lineage. However, since the `GameEstimator` had already unpersisted the training data, it would try to recompute that as well. For very large datasets, recomputing the training data potentially means doing reservoir sampling and limiting features by Pearson correlation score. The recomputed training data would not match the old training data in terms of the sizes of the RE models (or possibly order of features). This results in an error when attempting to perform joins with other RDDs which are still persisted (whether there should be any such RDDs available at that time is unclear - this could be another bug where we're not unpersisting RDDs correctly).

The solution is to only unpersist the coordinate models of the best GAME model when a new best GAME model is found, and to unpersist the coordinate models of the previous GAME model only if the previous GAME model is not the best GAME model.

We should have a unit/integ test for this case, however it's non-trivial to create one, so for the moment I have not.