### PR TITLE
Minor changes so that Photon-ML compiles within IntelliJ IDEA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ bin
 build
 ligradle
 out
+photon-avro-schemas/src/main/java/*
 photon-ml/LOGISTIC*
 photon-ml/LINEAR*
 photon-ml/POISSON*

--- a/build.gradle
+++ b/build.gradle
@@ -92,6 +92,7 @@ rat {
     'log4j.properties',
     'photon-api/src/integTest/resources/**',
     'photon-api/src/test/resources/**',
+    'photon-avro-schemas/src/main/java/**',
     'photon-client/src/integTest/resources/**',
     'travis/**'
   ]

--- a/photon-api/build.gradle
+++ b/photon-api/build.gradle
@@ -16,19 +16,14 @@ apply plugin: 'scala'
 apply from: '../build-scripts/integration-test.gradle'
 
 dependencies {
-  // Compile
   compile(project(":photon-lib$scalaSuffix"))
   compile(project(":photon-test-utils$scalaSuffix"))
-
   compile("org.scalanlp:breeze$scalaSuffix:0.11.2")
-
   compile('com.linkedin.paldb:paldb:1.1.0')
 
-  // TestCompile
   testCompile(project(":photon-test-utils$scalaSuffix"))
   testCompile("org.mockito:mockito-core:1.+")
 
-  // TestRuntime
   testRuntime("org.scalanlp:breeze$scalaSuffix:0.11.2")
   testRuntime("org.scalanlp:breeze-macros$scalaSuffix:0.11.2")
 }

--- a/photon-api/src/integTest/scala/com/linkedin/photon/ml/algorithm/FixedEffectCoordinateIntegTest.scala
+++ b/photon-api/src/integTest/scala/com/linkedin/photon/ml/algorithm/FixedEffectCoordinateIntegTest.scala
@@ -23,8 +23,9 @@ import com.linkedin.photon.ml.util.{GameTestUtils, MathUtils}
 /**
  * Tests for the FixedEffectCoordinate implementation.
  */
-class FixedEffectCoordinateTest extends SparkTestUtils with GameTestUtils {
-  import FixedEffectCoordinateTest._
+class FixedEffectCoordinateIntegTest extends SparkTestUtils with GameTestUtils {
+
+  import FixedEffectCoordinateIntegTest._
 
   private val featureShardId = "shard1"
 
@@ -61,7 +62,7 @@ class FixedEffectCoordinateTest extends SparkTestUtils with GameTestUtils {
   }
 }
 
-object FixedEffectCoordinateTest {
+object FixedEffectCoordinateIntegTest {
   private val NUM_TRAINING_SAMPLES = 1000
   private val DIMENSIONALITY = 10
 }

--- a/photon-api/src/integTest/scala/com/linkedin/photon/ml/supervised/BaseGLMTest.scala
+++ b/photon-api/src/integTest/scala/com/linkedin/photon/ml/supervised/BaseGLMTest.scala
@@ -235,8 +235,9 @@ object BaseGLMTest {
     var lastValue: Double = Double.MaxValue
 
     history.getTrackedStates.foreach { state =>
-      assertTrue(lastValue >= state.loss, "Objective should be monotonically decreasing (current=[" + state.loss +
-        "], previous=[" + lastValue + "])")
+      assertTrue(
+        lastValue >= state.loss,
+        s"Objective should be monotonically decreasing (current=[${state.loss}], previous=[$lastValue])")
       lastValue = state.loss
     }
   }

--- a/photon-avro-schemas/build.gradle
+++ b/photon-avro-schemas/build.gradle
@@ -13,13 +13,20 @@
  * under the License.
  */
 apply plugin: 'java'
-apply plugin: 'com.commercehub.gradle.plugin.avro'
-
-avro {
-  // TODO: the current photon-ml codes, assumes we are using CharSequence.
-  stringType = "CharSequence"
-}
+apply plugin: 'com.commercehub.gradle.plugin.avro-base'
 
 dependencies {
   compile 'org.apache.avro:avro:1.7.7'
 }
+
+task generateAvro(type: com.commercehub.gradle.plugin.avro.GenerateAvroJavaTask) {
+  source("src/main/avro")
+  outputDir = file("src/main/java")
+}
+
+avro {
+  // TODO: The current code assumes we are using CharSequence
+  stringType = "CharSequence"
+}
+
+compileJava.source(generateAvro.outputs)

--- a/photon-client/build.gradle
+++ b/photon-client/build.gradle
@@ -16,13 +16,12 @@ apply plugin: 'scala'
 apply from: '../build-scripts/integration-test.gradle'
 
 dependencies {
-
   compile(project(':photon-avro-schemas'))
   compile(project(":photon-core$scalaSuffix"))
   compile(project(":photon-diagnostics$scalaSuffix"))
   compile('joda-time:joda-time:2.7')
-  compile('org.joda:joda-convert:1.8.1') // stub warnings without this
-
+  // Stub warnings without this
+  compile('org.joda:joda-convert:1.8.1')
   // This is Scala's option parsing library
   compile("com.github.scopt:scopt$scalaSuffix:3.5.0")
 

--- a/photon-client/src/integTest/scala/com/linkedin/photon/ml/data/DataValidatorsIntegTest.scala
+++ b/photon-client/src/integTest/scala/com/linkedin/photon/ml/data/DataValidatorsIntegTest.scala
@@ -29,7 +29,7 @@ import com.linkedin.photon.ml.{DataValidationType, TaskType}
 /**
  * Integration tests for [[DataValidators]].
  */
-class DataValidatorsTest extends SparkTestUtils {
+class DataValidatorsIntegTest extends SparkTestUtils {
 
   @DataProvider
   def getSuccessArgumentsForSanityCheckData: Array[Array[Any]] = {
@@ -203,10 +203,9 @@ class DataValidatorsTest extends SparkTestUtils {
     )
   }
 
-  // TODO This test does not work because the spark context ends up being null in the data provider. Unlike other tests
-  // we have, this test requires the spark context in the data provider and not the test. I believe this test does not
-  // work because our sparkTest framework initializes the context after the data provider rather than before. I have
-  // temporarily implemented the test without using DataProvider annotation
+  // TODO: Unlike other tests, these tests require the Spark context in the data provider. These tests do not work as
+  // usual because our sparkTest framework initializes the context after the data provider rather than before. The tests
+  // have been temporarily implemented without using the DataProvider annotation.
 
   @Test
   def testSuccessSanityCheckData(): Unit = sparkTest("testSanityCheckData") {

--- a/photon-client/src/integTest/scala/com/linkedin/photon/ml/data/avro/AvroDataReaderIntegTest.scala
+++ b/photon-client/src/integTest/scala/com/linkedin/photon/ml/data/avro/AvroDataReaderIntegTest.scala
@@ -28,9 +28,9 @@ import com.linkedin.photon.ml.util._
 /**
  * Unit tests for AvroDataReader
  */
-class AvroDataReaderTest extends SparkTestUtils {
+class AvroDataReaderIntegTest extends SparkTestUtils {
 
-  import AvroDataReaderTest._
+  import AvroDataReaderIntegTest._
 
   @Test
   def testRead(): Unit = sparkTest("testRead") {
@@ -108,7 +108,7 @@ class AvroDataReaderTest extends SparkTestUtils {
   }
 }
 
-object AvroDataReaderTest {
+object AvroDataReaderIntegTest {
 
   private val inputDir = "GameIntegTest/input"
   private val inputPath = getClass.getClassLoader.getResource(inputDir + "/train").getPath

--- a/photon-client/src/integTest/scala/com/linkedin/photon/ml/data/avro/AvroUtilsIntegTest.scala
+++ b/photon-client/src/integTest/scala/com/linkedin/photon/ml/data/avro/AvroUtilsIntegTest.scala
@@ -28,7 +28,7 @@ import com.linkedin.photon.ml.test.{SparkTestUtils, TestTemplateWithTmpDir}
 /**
  * This class tests basic IO utilities.
  */
-class AvroUtilsTest extends SparkTestUtils with TestTemplateWithTmpDir {
+class AvroUtilsIntegTest extends SparkTestUtils with TestTemplateWithTmpDir {
   @Test
   def testAvroReadWrite(): Unit = sparkTest("testAvroReadWrite") {
     val schemaString = FeatureAvro.getClassSchema.toString

--- a/photon-client/src/integTest/scala/com/linkedin/photon/ml/io/deprecated/GLMSuiteIntegTest.scala
+++ b/photon-client/src/integTest/scala/com/linkedin/photon/ml/io/deprecated/GLMSuiteIntegTest.scala
@@ -42,8 +42,9 @@ import com.linkedin.photon.ml.util.{DefaultIndexMap, Utils}
  * This class tests components of GLMSuite that requires integration with real RDD or other runtime environments.
  * Also see [[GLMSuiteTest]].
  */
-class GLMSuiteTest extends SparkTestUtils with TestTemplateWithTmpDir {
-  import GLMSuiteTest._
+class GLMSuiteIntegTest extends SparkTestUtils with TestTemplateWithTmpDir {
+
+  import GLMSuiteIntegTest._
 
   @Test(expectedExceptions = Array(classOf[SparkException]))
   def testLoadFeatureMapWithIllegalFeatureList(): Unit = sparkTest("testLoadFeatureMapWithIllegalFeatureList") {
@@ -537,7 +538,7 @@ class GLMSuiteTest extends SparkTestUtils with TestTemplateWithTmpDir {
   }
 }
 
-private object GLMSuiteTest {
+private object GLMSuiteIntegTest {
 
   private val EPSILON = 1e-6
 

--- a/photon-client/src/integTest/scala/com/linkedin/photon/ml/util/IOUtilsIntegTest.scala
+++ b/photon-client/src/integTest/scala/com/linkedin/photon/ml/util/IOUtilsIntegTest.scala
@@ -28,7 +28,7 @@ import com.linkedin.photon.ml.test.{SparkTestUtils, TestTemplateWithTmpDir}
 /**
  * This class tests [[IOUtils]].
  */
-class IOUtilsTest extends SparkTestUtils with TestTemplateWithTmpDir {
+class IOUtilsIntegTest extends SparkTestUtils with TestTemplateWithTmpDir {
 
   private val baseDir = getClass.getClassLoader.getResource("IOUtilsTest/input").getPath
   private val path1 = s"$baseDir/daily/2016/01/01"

--- a/photon-client/src/main/scala/com/linkedin/photon/ml/data/DataValidators.scala
+++ b/photon-client/src/main/scala/com/linkedin/photon/ml/data/DataValidators.scala
@@ -112,7 +112,7 @@ object DataValidators extends Logging {
 
         (result, msg)
       }
-      .filter(!_._1)
+      .filterNot(_._1)
       .map(_._2)
 
   /**

--- a/photon-diagnostics/build.gradle
+++ b/photon-diagnostics/build.gradle
@@ -16,24 +16,19 @@ apply plugin: 'scala'
 apply from: '../build-scripts/integration-test.gradle'
 
 dependencies {
-  // Compile
   compile(project(":photon-core$scalaSuffix"))
-
   compile('com.xeiam.xchart:xchart:2.5.1') {
     // Cannot find this jar from Maven central or jcenter, and supposedly xcharts should be usable
     // even without this.
     exclude group: 'de.erichseifert.vectorgraphics2d'
   }
-
   compile("org.apache.spark:spark-core$scalaSuffix:$sparkVersion") {
     exclude group: 'org.apache.avro', module: 'avro-mapred'
   }
   compile('org.apache.xmlgraphics:batik-svggen:1.7')
 
-  // TestCompile
   testCompile(project(":photon-test-utils$scalaSuffix"))
 
-  // TestRuntime
   testRuntime("org.scalanlp:breeze$scalaSuffix:0.11.2")
   testRuntime("org.scalanlp:breeze-macros$scalaSuffix:0.11.2")
 }

--- a/photon-diagnostics/src/integTest/scala/com/linkedin/photon/ml/BootstrapTrainingIntegTest.scala
+++ b/photon-diagnostics/src/integTest/scala/com/linkedin/photon/ml/BootstrapTrainingIntegTest.scala
@@ -27,7 +27,7 @@ import com.linkedin.photon.ml.test.SparkTestUtils
 /**
  * Integration tests for bootstrapping. Most of the heavy lifting has already been done in the unit tests
  */
-class BootstrapTrainingTest extends SparkTestUtils {
+class BootstrapTrainingIntegTest extends SparkTestUtils {
 
   import org.testng.Assert._
 

--- a/photon-lib/build.gradle
+++ b/photon-lib/build.gradle
@@ -19,7 +19,6 @@ apply from: '../build-scripts/integration-test.gradle'
 def modifier = avroMapReduceModifier
 
 dependencies {
-  // Compile
   compile("org.apache.avro:avro-mapred:1.7.7$modifier" as String) {
     // We don't need to import netty, and including it can cause version conflicts in downstream projects
     exclude group: 'io.netty'
@@ -30,14 +29,10 @@ dependencies {
   compile("org.apache.spark:spark-mllib$scalaSuffix:$sparkVersion") {
     exclude group: 'org.apache.avro', module: 'avro-mapred'
   }
-
   compile('org.slf4j:slf4j-api:1.7.9')
 
-  // TestCompile
   testCompile(project(":photon-test-utils$scalaSuffix"))
   testCompile("org.mockito:mockito-core:1.+")
 
-  // TestRuntime
   testRuntime("org.scalanlp:breeze$scalaSuffix:0.11.2")
-//  testRuntime("org.scalanlp:breeze-macros$scalaSuffix:0.11.2")
 }

--- a/photon-lib/src/integTest/scala/com/linkedin/photon/ml/optimization/OptimizerIntegTest.scala
+++ b/photon-lib/src/integTest/scala/com/linkedin/photon/ml/optimization/OptimizerIntegTest.scala
@@ -141,8 +141,9 @@ object OptimizerIntegTest extends Logging {
     var lastValue: Double = Double.MaxValue
 
     history.getTrackedStates.foreach { state =>
-      assertTrue(lastValue >= state.loss, "Objective should be monotonically decreasing (current=[" + state.loss +
-        "], previous=[" + lastValue + "])")
+      assertTrue(
+        lastValue >= state.loss,
+        s"Objective should be monotonically decreasing (current=[${state.loss}], previous=[$lastValue])")
       lastValue = state.loss
     }
   }

--- a/photon-lib/src/main/scala/com/linkedin/photon/ml/algorithm/CoordinateDescent.scala
+++ b/photon-lib/src/main/scala/com/linkedin/photon/ml/algorithm/CoordinateDescent.scala
@@ -250,8 +250,8 @@ class CoordinateDescent(
                 regularizationTermValueContainer.updated(coordinateId, updatedRegularizationTermValue)
 
               // TODO: Move this logging to debug level?
-              logger.info(s"""Objective value after updating coordinate with id $coordinateId at iteration $iteration is:
-                |$objectiveValueString""".stripMargin)
+              logger.info(s"Objective value after updating coordinate $coordinateId, iteration $iteration:")
+              logger.info(s"$objectiveValueString")
 
               //
               // Validate the updated GAME model

--- a/photon-lib/src/test/scala/com/linkedin/photon/ml/optimization/OptimizerTest.scala
+++ b/photon-lib/src/test/scala/com/linkedin/photon/ml/optimization/OptimizerTest.scala
@@ -136,8 +136,9 @@ object OptimizerTest extends Logging {
     var lastValue: Double = Double.MaxValue
 
     history.getTrackedStates.foreach { state =>
-      assertTrue(lastValue >= state.loss, "Objective should be monotonically decreasing (current=[" + state.loss +
-        "], previous=[" + lastValue + "])")
+      assertTrue(
+        lastValue >= state.loss,
+        s"Objective should be monotonically decreasing (current=[${state.loss}], previous=[$lastValue])")
       lastValue = state.loss
     }
   }

--- a/photon-test-utils/build.gradle
+++ b/photon-test-utils/build.gradle
@@ -16,16 +16,13 @@ apply plugin: 'scala'
 apply from: '../build-scripts/integration-test.gradle'
 
 dependencies {
-  compile("org.testng:testng:6.9.9")
-
+  compile('commons-io:commons-io:2.4')
+  compile('org.apache.commons:commons-math3:3.5')
   compile("org.apache.spark:spark-core$scalaSuffix:$sparkVersion") {
     exclude group: 'org.apache.avro', module: 'avro-mapred'
   }
   compile("org.apache.spark:spark-sql$scalaSuffix:$sparkVersion")
-
   compile("org.scalanlp:breeze$scalaSuffix:0.11.2")
   compile("org.scalanlp:breeze-macros$scalaSuffix:0.11.2")
-
-  compile('commons-io:commons-io:2.4')
-  compile('org.apache.commons:commons-math3:3.5')
+  compile("org.testng:testng:6.9.9")
 }


### PR DESCRIPTION
- Renamed integration tests that had the same name as their unit tests counterparts
- Changed the location of Java classes generated from Avro schemas to be within the `photon-avro-schemas` module
- Minor comment and logging changes