### PR TITLE
Fix failure when reading Snappy-compressed avro data

### DIFF
--- a/photon-all/build.gradle
+++ b/photon-all/build.gradle
@@ -85,9 +85,13 @@ shadowJar {
   relocate 'org.apache.xmlcommons', 'photonml.shaded.org.apache.xmlcommons'
   relocate 'org.codehaus.jackson', 'photonml.shaded.org.codehaus.jackson'
   relocate 'org.tukaani', 'photonml.shaded.org.tukaani'
-  relocate 'org.xerial.snappy', 'photonml.shaded.org.xerial.snappy'
   relocate 'scopt', 'photonml.shaded.scopt'
   relocate 'org.joda.time', 'photonml.shaded.org.joda.time'
+
+  // Deliberately not relocating Snappy. The reason: Snappy includes native libraries that speed up the
+  // compression / decompression process. After relocation, it can't find the native libraries anymore.
+  //relocate 'org.xerial.snappy', 'org.xerial.snappy'
+
 }
 
 artifacts {


### PR DESCRIPTION
The failure was being caused by relocating the Snappy classes when building the shaded jar. Snappy includes native libraries that speed up the compression / decompression process. After relocation, it can't find the native libraries anymore. This change could potentially cause conflicts with other versions of Snappy on the classpath, but it doesn't work at all in its current state.