### PR TITLE
Enable identity projection

### DIFF
--- a/photon-api/src/main/scala/com/linkedin/photon/ml/projector/IdentityProjector.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/projector/IdentityProjector.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017 LinkedIn Corp. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linkedin.photon.ml.projector
+
+import org.apache.spark.rdd.RDD
+import breeze.linalg.Vector
+
+import com.linkedin.photon.ml.data.RandomEffectDataSet
+import com.linkedin.photon.ml.supervised.model.GeneralizedLinearModel
+
+/**
+ * A projector whose outputs are the same as its inputs
+ */
+protected[ml] class IdentityProjector extends RandomEffectProjector {
+
+  /**
+   * Project the sharded data set from the original space to the projected space.
+   *
+   * @param randomEffectDataSet The input sharded data set in the original space
+   * @return The sharded data set in the projected space
+   */
+  def projectRandomEffectDataSet(randomEffectDataSet: RandomEffectDataSet): RandomEffectDataSet =
+    randomEffectDataSet
+
+  /**
+   * Project a [[RDD]] of [[GeneralizedLinearModel]] [[Coefficients]] from the projected space back to the original
+   * space.
+   *
+   * @param modelsRDD The input [[RDD]] of [[GeneralizedLinearModel]] with [[Coefficients]] in the projected space
+   * @return The [[RDD]] of [[Coefficients]] in the original space
+   */
+  def projectCoefficientsRDD(modelsRDD: RDD[(String, GeneralizedLinearModel)]): RDD[(String, GeneralizedLinearModel)] =
+    modelsRDD
+
+}

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/projector/RandomEffectProjector.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/projector/RandomEffectProjector.scala
@@ -70,6 +70,7 @@ object RandomEffectProjector {
         ProjectionMatrixBroadcast.buildRandomProjectionBroadcastProjector(
           randomEffectDataSet, projectedSpaceDimension, isKeepingInterceptTerm = true)
 
+      case IdentityProjection => new IdentityProjector
       case IndexMapProjection => IndexMapProjectorRDD.buildIndexMapProjector(randomEffectDataSet)
       case _ => throw new UnsupportedOperationException(s"Projector type $projectorType for random effect data set " +
           s"is not supported")


### PR DESCRIPTION
Previously the code assumed that we're doing a factored random effect problem for identity projections. This would cause a failure when it tried to load from a nonexistent factored random effect configuration. This commit adds a dedicated identity projector and selects it when the IDENTITY projection option is selected.