### PR TITLE
Fix issue where IndexMapProjector incorrectly projects dense vectors

### DIFF
--- a/photon-api/src/test/scala/com/linkedin/photon/ml/projector/IndexMapProjectorTest.scala
+++ b/photon-api/src/test/scala/com/linkedin/photon/ml/projector/IndexMapProjectorTest.scala
@@ -27,7 +27,7 @@ class IndexMapProjectorTest {
     List[Vector[Double]](
       new SparseVector[Double](Array(0, 4, 6, 7, 9), Array(1.0, 4.0, 6.0, 7.0, 9.0), 10),
       new SparseVector[Double](Array(0, 1), Array(1.0, 1.0), 10),
-      new SparseVector[Double](Array(4, 5, 7), Array(4.0, 5.0, 7.0), 10)))
+      new DenseVector[Double](Array(0.0, 0.0, 0.0, 0.0, 4.0, 5.0, 0.0, 7.0, 0.0, 0.0))))
 
   @Test
   def testBuilder(): Unit = {


### PR DESCRIPTION
The idea behind building this projecting mapping is that we can reduce feature dimensionality for a RE problem if there are features in the full space that are all zeros in the RE sub-problem. The previous method used "activeKeysIterator" for this, but for DenseVector, this method just returns all indices. Hence reduction was never happening.