### PR TITLE
Fix issue where IndexMapProjector produces nondeterministic results

### DIFF
--- a/photon-api/src/integTest/scala/com/linkedin/photon/ml/projector/IndexMapProjectorRDDTest.scala
+++ b/photon-api/src/integTest/scala/com/linkedin/photon/ml/projector/IndexMapProjectorRDDTest.scala
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2017 LinkedIn Corp. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linkedin.photon.ml.projector
+
+import breeze.linalg.{DenseVector, Vector}
+import org.apache.spark.HashPartitioner
+import org.testng.Assert._
+import org.testng.annotations.Test
+
+import com.linkedin.photon.ml.data._
+import com.linkedin.photon.ml.test.SparkTestUtils
+import com.linkedin.photon.ml.util.{GameTestUtils, MathUtils, VectorUtils}
+
+/**
+ * Integration tests for [[IndexMapProjectorRDD]].
+ */
+class IndexMapProjectorRDDTest extends SparkTestUtils with GameTestUtils {
+
+  @Test
+  def testBuildIndexMapProjector(): Unit = sparkTest("testBuildIndexMapProjector") {
+    val dataSet1 = generateRandomEffectDataSetWithFeatures(
+      randomEffectIds = Seq("1"),
+      randomEffectType = "per-item",
+      featureShardId = "itemShard",
+      features = List(
+        DenseVector(0.0, 2.0, 3.0, 4.0, 0.0),
+        DenseVector(1.0, 5.0, 6.0, 7.0, 0.0)))
+
+    val dataSet2 = generateRandomEffectDataSet(
+      randomEffectIds = Seq("1"),
+      randomEffectType = "per-item",
+      featureShardId = "itemShard",
+      size = 20,
+      dimensions = 10)
+
+    val projector = IndexMapProjectorRDD.buildIndexMapProjector(dataSet1)
+    val projected = projector.projectRandomEffectDataSet(dataSet2)
+
+    val projectedDimentions = projected
+      .activeData
+      .map { case (_, localDataSet) => localDataSet.dataPoints.head }
+      .map { case (_, labeledPoint) => labeledPoint.features.length }
+      .take(1)(0)
+
+    assertEquals(projectedDimentions, 4)
+  }
+
+  /**
+   * Generates a random effect dataset, allowing specific feature vectors.
+   *
+   * @param randomEffectIds A set of random effect IDs
+   * @param randomEffectType The random effect type
+   * @param featureShardId The feature shard ID
+   * @param features the feature vectors
+   * @param numPartitions The number of Spark partitions
+   * @return A newly generated random effect dataset
+   */
+  private def generateRandomEffectDataSetWithFeatures(
+      randomEffectIds: Seq[String],
+      randomEffectType: String,
+      featureShardId: String,
+      features: Seq[Vector[Double]],
+      numPartitions: Int = 4): RandomEffectDataSet = {
+
+    val datasets = randomEffectIds.map((_,
+      new LocalDataSet(
+        features
+          .map(vector => new LabeledPoint(0, vector))
+          .map(addUniqueId)
+          .toArray)))
+
+    val partitioner = new HashPartitioner(numPartitions)
+    val uniqueIdToRandomEffectIds = sc.parallelize(
+      randomEffectIds.map(addUniqueId)).partitionBy(partitioner)
+    val activeData = sc.parallelize(datasets).partitionBy(partitioner)
+
+    new RandomEffectDataSet(
+      activeData, uniqueIdToRandomEffectIds, None, None, randomEffectType, featureShardId)
+  }
+}

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/projector/IndexMapProjector.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/projector/IndexMapProjector.scala
@@ -16,9 +16,9 @@ package com.linkedin.photon.ml.projector
 
 import scala.collection.Map
 
-import breeze.linalg.{DenseVector, SparseVector, Vector}
+import breeze.linalg.Vector
 
-import com.linkedin.photon.ml.util.{MathUtils, VectorUtils}
+import com.linkedin.photon.ml.util.VectorUtils
 
 /**
  * A projection map that maintains the one-to-one mapping of indices between the original and projected space.
@@ -39,12 +39,12 @@ import com.linkedin.photon.ml.util.{MathUtils, VectorUtils}
  * @param originalSpaceDimension Dimensionality of the original space
  * @param projectedSpaceDimension Dimensionality of the projected space
  */
-protected[ml] class IndexMapProjector private (
+protected[ml] class IndexMapProjector (
     val originalToProjectedSpaceMap: Map[Int, Int],
     override val originalSpaceDimension: Int,
     override val projectedSpaceDimension: Int) extends Projector {
 
-  val projectedToOriginalSpaceMap = originalToProjectedSpaceMap.map(_.swap)
+  val projectedToOriginalSpaceMap: Map[Int, Int] = originalToProjectedSpaceMap.map(_.swap)
 
   assert(originalToProjectedSpaceMap.size == projectedToOriginalSpaceMap.size, s"The size of " +
       s"originalToProjectedSpaceMap (${originalToProjectedSpaceMap.size}) and the size of " +
@@ -73,28 +73,6 @@ protected[ml] class IndexMapProjector private (
 }
 
 object IndexMapProjector {
-
-  /**
-   * Generate the index map projector given an iterator of feature vectors.
-   *
-   * @param features An [[Iterable]] of feature vectors
-   * @return The generated projection map
-   */
-  protected[ml] def buildIndexMapProjector(features: Iterable[Vector[Double]]): IndexMapProjector = {
-    val originalToProjectedSpaceMap = features.flatMap {
-      case vector: SparseVector[Double] => vector.activeKeysIterator
-      case vector: DenseVector[Double] => vector
-          .toArray
-          .zipWithIndex
-          .filter(x => !MathUtils.isAlmostZero(x._1))
-          .map(_._2)
-    }.toSet.zipWithIndex.toMap
-
-    val originalSpaceDimension = features.head.length
-    val projectedSpaceDimension = originalToProjectedSpaceMap.values.max + 1
-
-    new IndexMapProjector(originalToProjectedSpaceMap, originalSpaceDimension, projectedSpaceDimension)
-  }
 
   /**
    * Project the indices of the input vector with the given map.

--- a/photon-api/src/test/scala/com/linkedin/photon/ml/projector/IndexMapProjectorTest.scala
+++ b/photon-api/src/test/scala/com/linkedin/photon/ml/projector/IndexMapProjectorTest.scala
@@ -18,12 +18,16 @@ import breeze.linalg.{DenseVector, SparseVector, Vector}
 import org.testng.Assert
 import org.testng.annotations.Test
 
+import com.linkedin.photon.ml.util.VectorUtils
+
 /**
  *
  */
 class IndexMapProjectorTest {
 
-  private val projector = IndexMapProjector.buildIndexMapProjector(
+  import IndexMapProjectorTest._
+
+  private val projector = buildIndexMapProjector(
     List[Vector[Double]](
       new SparseVector[Double](Array(0, 4, 6, 7, 9), Array(1.0, 4.0, 6.0, 7.0, 9.0), 10),
       new SparseVector[Double](Array(0, 1), Array(1.0, 1.0), 10),
@@ -71,4 +75,27 @@ class IndexMapProjectorTest {
       .filter(x => math.abs(x._2) > 0.0)
       .toSet, expectedActiveTuples)
   }
+}
+
+object IndexMapProjectorTest {
+
+  /**
+   * Generate the index map projector given an iterator of feature vectors.
+   *
+   * @param features An [[Iterable]] of feature vectors
+   * @return The generated projection map
+   */
+  private def buildIndexMapProjector(features: Iterable[Vector[Double]]): IndexMapProjector = {
+    val originalToProjectedSpaceMap = features
+      .flatMap(VectorUtils.getActiveIndices)
+      .toSet
+      .zipWithIndex
+      .toMap
+
+    val originalSpaceDimension = features.head.length
+    val projectedSpaceDimension = originalToProjectedSpaceMap.values.max + 1
+
+    new IndexMapProjector(originalToProjectedSpaceMap, originalSpaceDimension, projectedSpaceDimension)
+  }
+
 }

--- a/photon-lib/src/main/scala/com/linkedin/photon/ml/util/VectorUtils.scala
+++ b/photon-lib/src/main/scala/com/linkedin/photon/ml/util/VectorUtils.scala
@@ -206,4 +206,22 @@ object VectorUtils {
     v1.length == v2.length && v1.toArray.zip(v2.toArray).forall { case (m1, m2) =>
       MathUtils.isAlmostZero(m2 - m1)
     }
+
+  /**
+   * Returns the indices for non-zero elements of the vector
+   *
+   * @param vector the input vector
+   * @return the set of indices
+   */
+  def getActiveIndices(vector: Vector[Double]): Set[Int] = vector match {
+    case vector: DenseVector[Double] => vector
+        .valuesIterator
+        .zipWithIndex
+        .filter(x => !MathUtils.isAlmostZero(x._1))
+        .map(_._2)
+        .toSet
+
+    case _ => vector.activeKeysIterator.toSet
+  }
+
 }

--- a/photon-lib/src/test/scala/com/linkedin/photon/ml/util/VectorUtilsTest.scala
+++ b/photon-lib/src/test/scala/com/linkedin/photon/ml/util/VectorUtilsTest.scala
@@ -165,6 +165,20 @@ class VectorUtilsTest {
     }
   }
 
+  @DataProvider
+  def activeIndicesProvider() = Array(
+    Array(DenseVector(1.0, 2.0, 3.0, 4.0, 5.0, 6.0), Set(0, 1, 2, 3, 4, 5)),
+    Array(DenseVector(0.0, 1.0, 0.0, 2.0, 3.0, 0.0), Set(1, 3, 4)),
+    Array(DenseVector(1e-18, 1.0, 0.0, 2.0, 3.0, 0.0), Set(1, 3, 4)),
+    Array(new SparseVector(Array(1, 3, 4), Array(1.0, 2.0, 3.0), 3), Set(1, 3, 4))
+  )
+
+  @Test(dataProvider = "activeIndicesProvider")
+  def testGetActiveIndices(vector: Vector[Double], expected: Set[Int]): Unit = {
+    val result = VectorUtils.getActiveIndices(vector)
+    assertEquals(result, expected)
+  }
+
   /**
    * Asserts that the breeze and spark vectors are equal.
    *


### PR DESCRIPTION
Previously we were scanning only the active data to determine the nonzero indices of a RE dataset. This can produce nondeterministic results when we recompute and resample the active data, because the dimensionality of the feature vectors can change and get out of sync with the model.

The fix is to scan both active and passive data to determine the feature projection.