### PR TITLE
https://github.com/linkedin/photon-ml/issues/301- Issue with writing to S3 from Photon-ML

### DIFF
--- a/photon-client/src/main/scala/com/linkedin/photon/ml/data/avro/AvroUtils.scala
+++ b/photon-client/src/main/scala/com/linkedin/photon/ml/data/avro/AvroUtils.scala
@@ -169,8 +169,8 @@ object AvroUtils {
     schemaString: String,
     forceOverwrite: Boolean = false): Unit = {
 
-    val fs = FileSystem.get(sc.hadoopConfiguration)
     val outputPath = new Path(path)
+    val fs = outputPath.getFileSystem(sc.hadoopConfiguration)
     val outputStream = fs.create(outputPath, forceOverwrite)
     val schema = new Parser().parse(schemaString)
     val writer = new SpecificDatumWriter[T](schema)


### PR DESCRIPTION
We are trying to use Photon-ML with the training data, output directory and feature path stored in S3 instead of in HDFS. When using photon-ml with s3 I am getting the following error:

2017-09-12T18:54:02.273+0000 [ERROR] Failure while running the driver
java.lang.IllegalArgumentException: Wrong FS: s3://com.climate.qa1.analytics/dsw/data/staging/v2.1/blup/out/all/0/fixed-effect/fixed/coefficients/part-00000.avro, expected: hdfs://ip-172-16-130-18.ec2.internal:8020
at org.apache.hadoop.fs.FileSystem.checkPath(FileSystem.java:653)