### PR TITLE
Enable option to use warm-start training for GAME

### DIFF
--- a/photon-api/src/integTest/scala/com/linkedin/photon/ml/estimators/GameEstimatorIntegTest.scala
+++ b/photon-api/src/integTest/scala/com/linkedin/photon/ml/estimators/GameEstimatorIntegTest.scala
@@ -45,9 +45,9 @@ import com.linkedin.photon.ml.util._
 /**
  * Integration tests for [[GameEstimator]].
  */
-class GameEstimatorTest extends SparkTestUtils with GameTestUtils {
+class GameEstimatorIntegTest extends SparkTestUtils with GameTestUtils {
 
-  import GameEstimatorTest._
+  import GameEstimatorIntegTest._
 
   /**
    * A very simple test that fits a toy data set using only the [[GameEstimator]] (not the full Driver).
@@ -396,7 +396,7 @@ class GameEstimatorTest extends SparkTestUtils with GameTestUtils {
   def createLogger(testName: String = "GenericTest"): PhotonLogger = new PhotonLogger(s"$getTmpDir/$testName", sc)
 }
 
-object GameEstimatorTest {
+object GameEstimatorIntegTest {
 
   /**
    * The test data set here is a subset of the Yahoo! music data set available on the internet, in [[DataFrame]] form,
@@ -423,6 +423,8 @@ object GameEstimatorTest {
    */
   private class MockGameEstimator(sc: SparkContext, logger: Logger) extends GameEstimator(sc, logger) {
 
+    set(useWarmStart, false)
+
     override def prepareTrainingDataSetsAndEvaluator(
         data: DataFrame,
         featureShards: Set[FeatureShardId],
@@ -445,7 +447,8 @@ object GameEstimatorTest {
         configuration: GameEstimator.GameOptimizationConfiguration,
         trainingDataSets: Map[CoordinateId, D forSome { type D <: DataSet[D] }],
         trainingEvaluator: Evaluator,
-        validationDataAndEvaluators: Option[(RDD[(UniqueSampleId, GameDatum)], Seq[Evaluator])])
+        validationDataAndEvaluators: Option[(RDD[(UniqueSampleId, GameDatum)], Seq[Evaluator])],
+        prevGameModelOpt: Option[GameModel] = None)
       : (GameModel, Option[EvaluationResults]) =
 
       super.train(configuration, trainingDataSets, trainingEvaluator, validationDataAndEvaluators)

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/algorithm/FixedEffectCoordinate.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/algorithm/FixedEffectCoordinate.scala
@@ -17,6 +17,7 @@ package com.linkedin.photon.ml.algorithm
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
 
+import com.linkedin.photon.ml.Types.UniqueSampleId
 import com.linkedin.photon.ml.data._
 import com.linkedin.photon.ml.data.scoring.CoordinateDataScores
 import com.linkedin.photon.ml.function.DistributedObjectiveFunction
@@ -126,8 +127,6 @@ object FixedEffectCoordinate {
   /**
    * Update the model (i.e. run the coordinate optimizer).
    *
-   * TODO: Does this method need to be static?
-   *
    * @param input The training dataset
    * @param optimizationProblem The optimization problem
    * @param fixedEffectModel The current model, used as a starting point
@@ -135,11 +134,11 @@ object FixedEffectCoordinate {
    * @return A tuple of the optimized model and the updated optimization problem
    */
   private def updateModel[Function <: DistributedObjectiveFunction](
-      input: RDD[(Long, LabeledPoint)],
+      input: RDD[(UniqueSampleId, LabeledPoint)],
       optimizationProblem: DistributedOptimizationProblem[Function],
       fixedEffectModel: FixedEffectModel,
       sc: SparkContext): FixedEffectModel = {
-    // TODO: Allow normalization
+
     val model = fixedEffectModel.model
     val updatedModelBroadcast = sc.broadcast(optimizationProblem.runWithSampling(input, model))
     val updatedFixedEffectModel = fixedEffectModel.update(updatedModelBroadcast)

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/optimization/DistributedOptimizationProblem.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/optimization/DistributedOptimizationProblem.scala
@@ -18,6 +18,7 @@ import breeze.linalg.Vector
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.rdd.RDD
 
+import com.linkedin.photon.ml.Types.UniqueSampleId
 import com.linkedin.photon.ml.constants.{MathConst, StorageLevel}
 import com.linkedin.photon.ml.data.LabeledPoint
 import com.linkedin.photon.ml.function.{DistributedObjectiveFunction, L2Regularization, TwiceDiffFunction}
@@ -112,6 +113,7 @@ protected[ml] class DistributedOptimizationProblem[Objective <: DistributedObjec
    * @return The learned generalized linear models of each regularization weight and iteration.
    */
   override def run(input: RDD[LabeledPoint], initialModel: GeneralizedLinearModel): GeneralizedLinearModel = {
+
     val normalizationContext = optimizer.getNormalizationContext
     val (optimizedCoefficients, _) = optimizer.optimize(objectiveFunction, initialModel.coefficients.means)(input)
     val optimizedVariances = computeVariances(input, optimizedCoefficients)
@@ -140,7 +142,10 @@ protected[ml] class DistributedOptimizationProblem[Objective <: DistributedObjec
    * @param initialModel The initial model from which to begin optimization
    * @return The learned generalized linear models of each regularization weight and iteration.
    */
-  def runWithSampling(input: RDD[(Long, LabeledPoint)], initialModel: GeneralizedLinearModel): GeneralizedLinearModel = {
+  def runWithSampling(
+      input: RDD[(UniqueSampleId, LabeledPoint)],
+      initialModel: GeneralizedLinearModel): GeneralizedLinearModel = {
+
     val data = (samplerOption match {
         case Some(sampler) => sampler.downSample(input).values
         case None => input.values

--- a/photon-api/src/test/scala/com/linkedin/photon/ml/estimators/GameEstimatorTest.scala
+++ b/photon-api/src/test/scala/com/linkedin/photon/ml/estimators/GameEstimatorTest.scala
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2017 LinkedIn Corp. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linkedin.photon.ml.estimators
+
+import org.apache.spark.SparkContext
+import org.apache.spark.broadcast.Broadcast
+import org.apache.spark.ml.param.ParamMap
+import org.mockito.Mockito._
+import org.slf4j.Logger
+import org.testng.annotations.{DataProvider, Test}
+
+import com.linkedin.photon.ml.TaskType
+import com.linkedin.photon.ml.data.{CoordinateDataConfiguration, InputColumnsNames}
+import com.linkedin.photon.ml.evaluation.EvaluatorType.AUC
+import com.linkedin.photon.ml.normalization.NormalizationContext
+
+class GameEstimatorTest {
+
+  /**
+   * Test that a [[ParamMap]] with only required parameters set can be valid input.
+   */
+  @Test
+  def testMinValidParamMap(): Unit = {
+
+    val coordinateId = "id"
+    val featureShardId = "id"
+    val trainingTask = TaskType.LINEAR_REGRESSION
+
+    val mockSparkContext = mock(classOf[SparkContext])
+    val mockLogger = mock(classOf[Logger])
+    val mockDataConfig = mock(classOf[CoordinateDataConfiguration])
+
+    doReturn(featureShardId).when(mockDataConfig).featureShardId
+
+    val estimator = new GameEstimator(mockSparkContext, mockLogger)
+
+    estimator.set(estimator.trainingTask, trainingTask)
+    estimator.set(estimator.coordinateUpdateSequence, Seq(coordinateId))
+    estimator.set(estimator.coordinateDataConfigurations, Map((coordinateId, mockDataConfig)))
+
+    estimator.validateParams()
+  }
+
+  /**
+   * Test that a [[ParamMap]] with all parameters set can be valid input.
+   */
+  @Test
+  def testMaxValidParamMap(): Unit = {
+
+    val coordinateId = "id"
+    val featureShardId = "id"
+    val trainingTask = TaskType.LINEAR_REGRESSION
+    val coordinateDescentIter = 1
+    val computeVariance = true
+    val treeAggregateDepth = 2
+    val validationEvaluators = Seq(AUC)
+    val useWarmStart = false
+
+    val mockSparkContext = mock(classOf[SparkContext])
+    val mockLogger = mock(classOf[Logger])
+    val mockInputColumnNames = mock(classOf[InputColumnsNames])
+    val mockDataConfig = mock(classOf[CoordinateDataConfiguration])
+    val mockNormalizationBroadcast = mock(classOf[Broadcast[NormalizationContext]])
+
+    doReturn(featureShardId).when(mockDataConfig).featureShardId
+
+    val estimator = new GameEstimator(mockSparkContext, mockLogger)
+
+    estimator.set(estimator.trainingTask, trainingTask)
+    estimator.set(estimator.inputColumnNames, mockInputColumnNames)
+    estimator.set(estimator.coordinateUpdateSequence, Seq(coordinateId))
+    estimator.set(estimator.coordinateDataConfigurations, Map((coordinateId, mockDataConfig)))
+    estimator.set(estimator.coordinateDescentIterations, coordinateDescentIter)
+    estimator.set(estimator.coordinateNormalizationContexts, Map((coordinateId, mockNormalizationBroadcast)))
+    estimator.set(estimator.computeVariance, computeVariance)
+    estimator.set(estimator.treeAggregateDepth, treeAggregateDepth)
+    estimator.set(estimator.validationEvaluators, validationEvaluators)
+    estimator.set(estimator.useWarmStart, useWarmStart)
+
+    estimator.validateParams()
+  }
+
+  @DataProvider
+  def invalidParamMaps(): Array[Array[Any]] = {
+
+    val coordinateId1 = "id1"
+    val coordinateId2 = "id2"
+    val trainingTask = TaskType.LINEAR_REGRESSION
+
+    val badUpdateSeq1 = Seq(coordinateId1, coordinateId1, coordinateId1)
+    val badUpdateSeq2 = Seq(coordinateId1, coordinateId2)
+
+    val mockSparkContext = mock(classOf[SparkContext])
+    val mockLogger = mock(classOf[Logger])
+    val mockDataConfig1 = mock(classOf[CoordinateDataConfiguration])
+    val mockNormalizationBroadcast = mock(classOf[Broadcast[NormalizationContext]])
+
+    val estimator = new GameEstimator(mockSparkContext, mockLogger)
+
+    estimator.set(estimator.trainingTask, trainingTask)
+    estimator.set(estimator.coordinateUpdateSequence, Seq(coordinateId1))
+    estimator.set(estimator.coordinateDataConfigurations, Map((coordinateId1, mockDataConfig1)))
+
+    estimator.validateParams()
+
+    var result = Seq[Array[Any]]()
+    var badEstimator = estimator
+
+    // No training task
+    badEstimator = estimator.copy(ParamMap.empty)
+    badEstimator.clear(badEstimator.trainingTask)
+    result = result :+ Array[Any](badEstimator)
+
+    // No coordinate update sequence
+    badEstimator = estimator.copy(ParamMap.empty)
+    badEstimator.clear(badEstimator.coordinateUpdateSequence)
+    result = result :+ Array[Any](badEstimator)
+
+    // No data configurations
+    badEstimator = estimator.copy(ParamMap.empty)
+    badEstimator.clear(badEstimator.coordinateDataConfigurations)
+    result = result :+ Array[Any](badEstimator)
+
+    // Update sequence repeats defined coordinate ID
+    badEstimator = estimator.copy(ParamMap.empty)
+    badEstimator.set(badEstimator.coordinateUpdateSequence, badUpdateSeq1)
+    result = result :+ Array[Any](badEstimator)
+
+    // Update sequence has undefined coordinate ID
+    badEstimator = estimator.copy(ParamMap.empty)
+    badEstimator.set(badEstimator.coordinateUpdateSequence, badUpdateSeq2)
+    result = result :+ Array[Any](badEstimator)
+
+    // Normalization context undefined for coordinate ID in update sequence
+    badEstimator = estimator.copy(ParamMap.empty)
+    badEstimator.set(badEstimator.coordinateNormalizationContexts, Map((coordinateId2, mockNormalizationBroadcast)))
+    result = result :+ Array[Any](badEstimator)
+
+    result.toArray
+  }
+
+  /**
+   * Test that invalid parameters will be correctly rejected.
+   *
+   * @param estimator A [[GameEstimator]] with one or more flaws in its parameters
+   */
+  @Test(dataProvider = "invalidParamMaps", expectedExceptions = Array(classOf[IllegalArgumentException]))
+  def testValidateParams(estimator: GameEstimator): Unit = estimator.validateParams()
+
+  /**
+   * Test that default values are set for all parameters that require them.
+   */
+  @Test
+  def testDefaultParams(): Unit = {
+
+    val mockSparkContext = mock(classOf[SparkContext])
+    val mockLogger = mock(classOf[Logger])
+
+    val estimator = new GameEstimator(mockSparkContext, mockLogger)
+
+    estimator.getOrDefault(estimator.coordinateDescentIterations)
+    estimator.getOrDefault(estimator.inputColumnNames)
+    estimator.getOrDefault(estimator.computeVariance)
+    estimator.getOrDefault(estimator.treeAggregateDepth)
+    estimator.getOrDefault(estimator.useWarmStart)
+  }
+}

--- a/photon-client/src/main/scala/com/linkedin/photon/ml/cli/game/training/GameTrainingDriver.scala
+++ b/photon-client/src/main/scala/com/linkedin/photon/ml/cli/game/training/GameTrainingDriver.scala
@@ -150,6 +150,10 @@ object GameTrainingDriver extends GameDriver {
     "compute variance",
     "Whether to compute the coefficient variances.")
 
+  val useWarmStart: Param[Boolean] = ParamUtils.createParam[Boolean](
+    "use warm start",
+    "Whether to re-use trained GAME models as starting points.")
+
   //
   // Initialize object
   //
@@ -243,6 +247,7 @@ object GameTrainingDriver extends GameDriver {
     setDefault(hyperParameterTuning, HyperparameterTuningMode.NONE)
     setDefault(hyperParameterTuningRange, DoubleRange(1e-4, 1e4))
     setDefault(computeVariance, false)
+    setDefault(useWarmStart, true)
     setDefault(dataValidation, DataValidationType.VALIDATE_DISABLED)
     setDefault(logLevel, PhotonLogger.LogLevelInfo)
     setDefault(applicationName, DEFAULT_APPLICATION_NAME)
@@ -319,6 +324,7 @@ object GameTrainingDriver extends GameDriver {
         .setCoordinateUpdateSequence(getRequiredParam(coordinateUpdateSequence))
         .setCoordinateDescentIterations(getRequiredParam(coordinateDescentIterations))
         .setComputeVariance(getOrDefault(computeVariance))
+        .setWarmStart(getOrDefault(useWarmStart))
 
       get(inputColumnNames).foreach(estimator.setInputColumnNames)
       normalizationContexts.foreach(estimator.setCoordinateNormalizationContexts)

--- a/photon-client/src/main/scala/com/linkedin/photon/ml/io/scopt/game/ScoptGameTrainingParametersParser.scala
+++ b/photon-client/src/main/scala/com/linkedin/photon/ml/io/scopt/game/ScoptGameTrainingParametersParser.scala
@@ -141,7 +141,11 @@ object ScoptGameTrainingParametersParser extends ScoptGameParametersParser {
 
       // Compute Variance
       ScoptParameter[Boolean, Boolean](
-        GameTrainingDriver.computeVariance))
+        GameTrainingDriver.computeVariance),
+
+      // Use Warm Start
+      ScoptParameter[Boolean, Boolean](
+        GameTrainingDriver.useWarmStart))
 
   /**
    * Parse command line arguments for GAME training into a [[ParamMap]].

--- a/photon-client/src/test/scala/com/linkedin/photon/ml/io/scopt/game/ScoptGameTrainingParametersParserTest.scala
+++ b/photon-client/src/test/scala/com/linkedin/photon/ml/io/scopt/game/ScoptGameTrainingParametersParserTest.scala
@@ -67,6 +67,7 @@ class ScoptGameTrainingParametersParserTest {
     val hyperparameterTuningIter = 6
     val hyperparameterTuningRange = DoubleRange(0.1, 1000.1)
     val computeVariance = true
+    val useWarmStart = false
 
     val featureShard1 = "featureShard1"
     val featureBags1 = Set("bag1", "bag2")
@@ -162,6 +163,7 @@ class ScoptGameTrainingParametersParserTest {
       .put(GameTrainingDriver.hyperParameterTuningIter, hyperparameterTuningIter)
       .put(GameTrainingDriver.hyperParameterTuningRange, hyperparameterTuningRange)
       .put(GameTrainingDriver.computeVariance, computeVariance)
+      .put(GameTrainingDriver.useWarmStart, useWarmStart)
 
     val finalParamMap = ScoptGameTrainingParametersParser.parseFromCommandLine(
       ScoptGameTrainingParametersParser.printForCommandLine(initialParamMap).flatMap(_.split(" ")).toArray)

--- a/photon-lib/src/main/scala/com/linkedin/photon/ml/algorithm/CoordinateDescent.scala
+++ b/photon-lib/src/main/scala/com/linkedin/photon/ml/algorithm/CoordinateDescent.scala
@@ -42,8 +42,6 @@ class CoordinateDescent(
 
   import CoordinateDescent._
 
-  // TODO: Do we really need a separate run and optimize?
-
   /**
    * Run coordinate descent.
    *
@@ -78,7 +76,7 @@ class CoordinateDescent(
       .toMap
 
     val initialGameModel = new GameModel(initializedModelContainer)
-    optimize(descentIterations, initialGameModel)
+    run(descentIterations, initialGameModel)
   }
 
   /**
@@ -91,7 +89,7 @@ class CoordinateDescent(
    * @param gameModel The initial GAME model
    * @return The best GAME model (see above for exact meaning of "best")
    */
-  def optimize(descentIterations: Int, gameModel: GameModel): (GameModel, Option[EvaluationResults]) = {
+  def run(descentIterations: Int, gameModel: GameModel): (GameModel, Option[EvaluationResults]) = {
 
     //
     // Input verification

--- a/photon-lib/src/main/scala/com/linkedin/photon/ml/optimization/Optimizer.scala
+++ b/photon-lib/src/main/scala/com/linkedin/photon/ml/optimization/Optimizer.scala
@@ -170,8 +170,8 @@ abstract class Optimizer[-Function <: ObjectiveFunction](
    * @return Optimized model coefficients and corresponding objective function's value
    */
   protected[ml] def optimize
-    (objectiveFunction: Function, initialCoefficients: Vector[Double])
-    (data: objectiveFunction.Data): (Vector[Double], Double) = {
+      (objectiveFunction: Function, initialCoefficients: Vector[Double])
+      (data: objectiveFunction.Data): (Vector[Double], Double) = {
 
     val normalizedInitialCoefficients = normalizationContext.value.modelToTransformedSpace(initialCoefficients)
 
@@ -181,7 +181,7 @@ abstract class Optimizer[-Function <: ObjectiveFunction](
     // We set the absolute tolerances from the magnitudes of the first loss and gradient
     setAbsTolerances(calculateState(objectiveFunction, VectorUtils.zeroOfSameType(normalizedInitialCoefficients))(data))
 
-    // TODO for cold start, we call calculateState with the same arguments twice
+    // TODO: For cold start, we call calculateState with the same arguments twice
     val initialState = calculateState(objectiveFunction, normalizedInitialCoefficients)(data)
     init(objectiveFunction, initialState)(data)
     updateCurrentState(initialState)
@@ -240,8 +240,8 @@ abstract class Optimizer[-Function <: ObjectiveFunction](
    * @return The updated state of the optimizer
    */
   protected def runOneIteration
-    (objectiveFunction: Function, currState: OptimizerState)
-    (data: objectiveFunction.Data): OptimizerState
+      (objectiveFunction: Function, currState: OptimizerState)
+      (data: objectiveFunction.Data): OptimizerState
 }
 
 object Optimizer {

--- a/photon-lib/src/test/scala/com/linkedin/photon/ml/algorithm/CoordinateDescentTest.scala
+++ b/photon-lib/src/test/scala/com/linkedin/photon/ml/algorithm/CoordinateDescentTest.scala
@@ -56,7 +56,7 @@ class CoordinateDescentTest {
       validationDataAndEvaluatorsOption = None,
       logger)
 
-    coordinateDescent.optimize(iter, gameModel)
+    coordinateDescent.run(iter, gameModel)
   }
 
   @DataProvider
@@ -115,7 +115,7 @@ class CoordinateDescentTest {
       evaluator,
       validationDataAndEvaluatorsOption = None,
       logger)
-    coordinateDescent.optimize(numIterations, gameModel)
+    coordinateDescent.run(numIterations, gameModel)
 
     // Verify the calls to updateModel
     if (coordinates.length == 1) {
@@ -195,7 +195,7 @@ class CoordinateDescentTest {
     val validationDataAndEvaluators
       = if (validationEvaluators.isEmpty) None else Option(validationData, validationEvaluators)
     val coordinateDescent = new CoordinateDescent(coordinates, lossEvaluator, validationDataAndEvaluators, logger)
-    val (returnedModel, _) = coordinateDescent.optimize(iterationCount, gameModels.head)
+    val (returnedModel, _) = coordinateDescent.run(iterationCount, gameModels.head)
 
     assert(returnedModel.hashCode == gameModels(2).hashCode())
 


### PR DESCRIPTION
- Introduced configurable parameter to re-use trained GameModel objects as a starting point for training further GameModels
- Note: GAME already uses warm-start training during coordinate descent (the way the legacy Photon code does)
- Added unit test for GameEstimator
- Fixed bug in GameEstimator.copy