### PR TITLE
Minor replacement of SparkContext with SparkSession

### DIFF
--- a/photon-api/src/integTest/scala/com/linkedin/photon/ml/SparkSessionConfigurationTest.scala
+++ b/photon-api/src/integTest/scala/com/linkedin/photon/ml/SparkSessionConfigurationTest.scala
@@ -22,29 +22,27 @@ import org.testng.annotations.Test
 import com.linkedin.photon.ml.test.SparkTestUtils
 
 /**
- * Integration tests for [[SparkContextConfiguration]].
+ * This class tests the SparkContextConfiguration object.
  */
-class SparkContextConfigurationIntegTest extends SparkTestUtils {
+class SparkSessionConfigurationTest extends SparkTestUtils {
 
-  import SparkContextConfiguration._
+  import SparkSessionConfiguration._
 
-  /**
-   * Synchronize across different potential SparkContext creators.
-   */
+  // Synchronize across different potential SparkContext creators
   @Test
   def testAsYarnClient(): Unit = sparkTestSelfServeContext("testAsYarnClient") {
-    val sc1 = asYarnClient(new SparkConf().setMaster("local[1]"), "foo", useKryo = true)
-    assertEquals(sc1.getConf.get(CONF_SPARK_APP_NAME), "foo")
-    assertEquals(sc1.getConf.get(CONF_SPARK_SERIALIZER), classOf[KryoSerializer].getName)
-    assertEquals(sc1.getConf.get(CONF_SPARK_KRYO_CLASSES_TO_REGISTER),
+    val session1 = asYarnClient(new SparkConf().setMaster("local[1]"), "foo", useKryo = true)
+    assertEquals(session1.sparkContext.getConf.get(CONF_SPARK_APP_NAME), "foo")
+    assertEquals(session1.sparkContext.getConf.get(CONF_SPARK_SERIALIZER), classOf[KryoSerializer].getName)
+    assertEquals(session1.sparkContext.getConf.get(CONF_SPARK_KRYO_CLASSES_TO_REGISTER),
       KRYO_CLASSES_TO_REGISTER.map(c => c.getName).mkString(",")
     )
-    sc1.stop()
+    session1.stop()
 
-    val sc2 = asYarnClient(new SparkConf().setMaster("local[1]"), "bar", useKryo = false)
-    assertEquals(sc2.getConf.get(CONF_SPARK_APP_NAME), "bar")
-    assertFalse(sc2.getConf.contains(CONF_SPARK_SERIALIZER))
-    assertFalse(sc2.getConf.contains(CONF_SPARK_KRYO_CLASSES_TO_REGISTER))
-    sc2.stop()
+    val session2 = asYarnClient(new SparkConf().setMaster("local[1]"), "bar", useKryo = false)
+    assertEquals(session2.sparkContext.getConf.get(CONF_SPARK_APP_NAME), "bar")
+    assertFalse(session2.sparkContext.getConf.contains(CONF_SPARK_SERIALIZER))
+    assertFalse(session2.sparkContext.getConf.contains(CONF_SPARK_KRYO_CLASSES_TO_REGISTER))
+    session2.stop()
   }
 }

--- a/photon-api/src/integTest/scala/com/linkedin/photon/ml/function/DistributedObjectiveFunctionIntegTest.scala
+++ b/photon-api/src/integTest/scala/com/linkedin/photon/ml/function/DistributedObjectiveFunctionIntegTest.scala
@@ -17,8 +17,6 @@ package com.linkedin.photon.ml.function
 import java.util.Random
 
 import breeze.linalg.{DenseVector, SparseVector, Vector}
-import org.apache.log4j.{LogManager, Logger}
-import org.apache.spark.SparkContext
 import org.mockito.Mockito._
 import org.testng.Assert.{assertEquals, assertTrue}
 import org.testng.annotations.{DataProvider, Test}
@@ -41,7 +39,10 @@ class DistributedObjectiveFunctionIntegTest extends SparkTestUtils {
 
   import DistributedObjectiveFunctionIntegTest._
 
-  private val twiceDiffTasks = Array(TaskType.LOGISTIC_REGRESSION, TaskType.LINEAR_REGRESSION, TaskType.POISSON_REGRESSION)
+  private val twiceDiffTasks = Array(
+    TaskType.LOGISTIC_REGRESSION,
+    TaskType.LINEAR_REGRESSION,
+    TaskType.POISSON_REGRESSION)
   private val diffTasks = twiceDiffTasks ++ Array(TaskType.SMOOTHED_HINGE_LOSS_LINEAR_SVM)
   private val binaryClassificationDataSetGenerationFuncs = Array(
     generateBenignDataSetBinaryClassification _,
@@ -70,10 +71,11 @@ class DistributedObjectiveFunctionIntegTest extends SparkTestUtils {
     .flatMap {
       case TaskType.LOGISTIC_REGRESSION =>
         treeAggregateDepths.flatMap { treeAggDepth =>
-          def lossFuncBuilder = (sc: SparkContext) =>
-            DistributedGLMLossFunction(sc, NO_REG_CONFIGURATION_MOCK, treeAggDepth)(LogisticLossFunction)
-          def lossFuncWithL2Builder = (sc: SparkContext) =>
-            DistributedGLMLossFunction(sc, L2_REG_CONFIGURATION_MOCK, treeAggDepth)(LogisticLossFunction)
+          def lossFuncBuilder =
+            () => DistributedGLMLossFunction(NO_REG_CONFIGURATION_MOCK, treeAggDepth)(LogisticLossFunction)
+
+          def lossFuncWithL2Builder =
+            () => DistributedGLMLossFunction(L2_REG_CONFIGURATION_MOCK, treeAggDepth)(LogisticLossFunction)
 
           binaryClassificationDataSetGenerationFuncs.flatMap { dataGenFunc =>
             Seq[(Object, Object)]((lossFuncBuilder, dataGenFunc), (lossFuncWithL2Builder, dataGenFunc))
@@ -82,10 +84,11 @@ class DistributedObjectiveFunctionIntegTest extends SparkTestUtils {
 
       case TaskType.LINEAR_REGRESSION =>
         treeAggregateDepths.flatMap { treeAggDepth =>
-          def lossFuncBuilder = (sc: SparkContext) =>
-            DistributedGLMLossFunction(sc, NO_REG_CONFIGURATION_MOCK, treeAggDepth)(SquaredLossFunction)
-          def lossFuncWithL2Builder = (sc: SparkContext) =>
-            DistributedGLMLossFunction(sc, L2_REG_CONFIGURATION_MOCK, treeAggDepth)(SquaredLossFunction)
+          def lossFuncBuilder =
+            () => DistributedGLMLossFunction(NO_REG_CONFIGURATION_MOCK, treeAggDepth)(SquaredLossFunction)
+
+          def lossFuncWithL2Builder =
+            () => DistributedGLMLossFunction(L2_REG_CONFIGURATION_MOCK, treeAggDepth)(SquaredLossFunction)
 
           linearRegressionDataSetGenerationFuncs.flatMap { dataGenFunc =>
             Seq[(Object, Object)]((lossFuncBuilder, dataGenFunc), (lossFuncWithL2Builder, dataGenFunc))
@@ -94,10 +97,11 @@ class DistributedObjectiveFunctionIntegTest extends SparkTestUtils {
 
       case TaskType.POISSON_REGRESSION =>
         treeAggregateDepths.flatMap { treeAggDepth =>
-          def lossFuncBuilder = (sc: SparkContext) =>
-            DistributedGLMLossFunction(sc, NO_REG_CONFIGURATION_MOCK, treeAggDepth)(PoissonLossFunction)
-          def lossFuncWithL2Builder = (sc: SparkContext) =>
-            DistributedGLMLossFunction(sc, L2_REG_CONFIGURATION_MOCK, treeAggDepth)(PoissonLossFunction)
+          def lossFuncBuilder =
+            () => DistributedGLMLossFunction(NO_REG_CONFIGURATION_MOCK, treeAggDepth)(PoissonLossFunction)
+
+          def lossFuncWithL2Builder =
+            () => DistributedGLMLossFunction(L2_REG_CONFIGURATION_MOCK, treeAggDepth)(PoissonLossFunction)
 
           poissonRegressionDataSetGenerationFuncs.flatMap { dataGenFunc =>
             Seq[(Object, Object)]((lossFuncBuilder, dataGenFunc), (lossFuncWithL2Builder, dataGenFunc))
@@ -106,8 +110,11 @@ class DistributedObjectiveFunctionIntegTest extends SparkTestUtils {
 
       case TaskType.SMOOTHED_HINGE_LOSS_LINEAR_SVM =>
         treeAggregateDepths.flatMap { treeAggDepth =>
-          def lossFuncBuilder = (sc: SparkContext) => DistributedSmoothedHingeLossFunction(sc, NO_REG_CONFIGURATION_MOCK, treeAggDepth)
-          def lossFuncWithL2Builder = (sc: SparkContext) => DistributedSmoothedHingeLossFunction(sc, L2_REG_CONFIGURATION_MOCK, treeAggDepth)
+          def lossFuncBuilder =
+            () => DistributedSmoothedHingeLossFunction(NO_REG_CONFIGURATION_MOCK, treeAggDepth)
+
+          def lossFuncWithL2Builder =
+            () => DistributedSmoothedHingeLossFunction(L2_REG_CONFIGURATION_MOCK, treeAggDepth)
 
           binaryClassificationDataSetGenerationFuncs.flatMap { dataGenFunc =>
             Seq[(Object, Object)]((lossFuncBuilder, dataGenFunc), (lossFuncWithL2Builder, dataGenFunc))
@@ -129,10 +136,11 @@ class DistributedObjectiveFunctionIntegTest extends SparkTestUtils {
     .flatMap {
       case TaskType.LOGISTIC_REGRESSION =>
         treeAggregateDepths.flatMap { treeAggDepth =>
-          def lossFuncBuilder = (sc: SparkContext) =>
-            DistributedGLMLossFunction(sc, NO_REG_CONFIGURATION_MOCK, treeAggDepth)(LogisticLossFunction)
-          def lossFuncWithL2Builder = (sc: SparkContext) =>
-            DistributedGLMLossFunction(sc, L2_REG_CONFIGURATION_MOCK, treeAggDepth)(LogisticLossFunction)
+          def lossFuncBuilder =
+            () => DistributedGLMLossFunction(NO_REG_CONFIGURATION_MOCK, treeAggDepth)(LogisticLossFunction)
+
+          def lossFuncWithL2Builder =
+            () => DistributedGLMLossFunction(L2_REG_CONFIGURATION_MOCK, treeAggDepth)(LogisticLossFunction)
 
           binaryClassificationDataSetGenerationFuncs.flatMap { dataGenFunc =>
             Seq((lossFuncBuilder, dataGenFunc), (lossFuncWithL2Builder, dataGenFunc))
@@ -141,10 +149,11 @@ class DistributedObjectiveFunctionIntegTest extends SparkTestUtils {
 
       case TaskType.LINEAR_REGRESSION =>
         treeAggregateDepths.flatMap { treeAggDepth =>
-          def lossFuncBuilder = (sc: SparkContext) =>
-            DistributedGLMLossFunction(sc, NO_REG_CONFIGURATION_MOCK, treeAggDepth)(SquaredLossFunction)
-          def lossFuncWithL2Builder = (sc: SparkContext) =>
-            DistributedGLMLossFunction(sc, L2_REG_CONFIGURATION_MOCK, treeAggDepth)(SquaredLossFunction)
+          def lossFuncBuilder =
+            () => DistributedGLMLossFunction(NO_REG_CONFIGURATION_MOCK, treeAggDepth)(SquaredLossFunction)
+
+          def lossFuncWithL2Builder =
+            () => DistributedGLMLossFunction(L2_REG_CONFIGURATION_MOCK, treeAggDepth)(SquaredLossFunction)
 
           linearRegressionDataSetGenerationFuncs.flatMap { dataGenFunc =>
             Seq((lossFuncBuilder, dataGenFunc), (lossFuncWithL2Builder, dataGenFunc))
@@ -153,10 +162,11 @@ class DistributedObjectiveFunctionIntegTest extends SparkTestUtils {
 
       case TaskType.POISSON_REGRESSION =>
         treeAggregateDepths.flatMap { treeAggDepth =>
-          def lossFuncBuilder = (sc: SparkContext) =>
-            DistributedGLMLossFunction(sc, NO_REG_CONFIGURATION_MOCK, treeAggDepth)(PoissonLossFunction)
-          def lossFuncWithL2Builder = (sc: SparkContext) =>
-            DistributedGLMLossFunction(sc, L2_REG_CONFIGURATION_MOCK, treeAggDepth)(PoissonLossFunction)
+          def lossFuncBuilder =
+            () => DistributedGLMLossFunction(NO_REG_CONFIGURATION_MOCK, treeAggDepth)(PoissonLossFunction)
+
+          def lossFuncWithL2Builder =
+            () => DistributedGLMLossFunction(L2_REG_CONFIGURATION_MOCK, treeAggDepth)(PoissonLossFunction)
 
           poissonRegressionDataSetGenerationFuncs.flatMap { dataGenFunc =>
             Seq((lossFuncBuilder, dataGenFunc), (lossFuncWithL2Builder, dataGenFunc))
@@ -194,6 +204,7 @@ class DistributedObjectiveFunctionIntegTest extends SparkTestUtils {
    * @return A Seq of [[LabeledPoint]]
    */
   def generateWeightedBenignDataSetBinaryClassification: Seq[LabeledPoint] = {
+
     val r = new Random(WEIGHT_RANDOM_SEED)
 
     drawBalancedSampleFromNumericallyBenignDenseFeaturesForBinaryClassifierLocal(
@@ -218,10 +229,10 @@ class DistributedObjectiveFunctionIntegTest extends SparkTestUtils {
       DATA_RANDOM_SEED,
       TRAINING_SAMPLES,
       PROBLEM_DIMENSION)
-      .map({ obj =>
+      .map { obj =>
         assertEquals(obj._2.length, PROBLEM_DIMENSION, "Samples should have expected lengths")
         new LabeledPoint(label = obj._1, features = obj._2)
-      })
+      }
       .toList
 
   /**
@@ -230,17 +241,18 @@ class DistributedObjectiveFunctionIntegTest extends SparkTestUtils {
    * @return A Seq of [[LabeledPoint]]
    */
   def generateWeightedOutlierDataSetBinaryClassification: Seq[LabeledPoint] = {
+
     val r = new Random(WEIGHT_RANDOM_SEED)
 
     drawBalancedSampleFromOutlierDenseFeaturesForBinaryClassifierLocal(
       DATA_RANDOM_SEED,
       TRAINING_SAMPLES,
       PROBLEM_DIMENSION)
-      .map({ obj =>
+      .map { obj =>
         assertEquals(obj._2.length, PROBLEM_DIMENSION, "Samples should have expected lengths")
         val weight = r.nextDouble() * WEIGHT_RANDOM_MAX
         new LabeledPoint(label = obj._1, features = obj._2, weight = weight)
-      })
+      }
       .toList
   }
 
@@ -258,10 +270,10 @@ class DistributedObjectiveFunctionIntegTest extends SparkTestUtils {
       DATA_RANDOM_SEED,
       TRAINING_SAMPLES,
       PROBLEM_DIMENSION)
-      .map({ obj =>
+      .map { obj =>
         assertEquals(obj._2.length, PROBLEM_DIMENSION, "Samples should have expected lengths")
         new LabeledPoint(label = obj._1, features = obj._2)
-      })
+      }
       .toList
 
   /**
@@ -270,17 +282,18 @@ class DistributedObjectiveFunctionIntegTest extends SparkTestUtils {
    * @return A Seq of [[LabeledPoint]]
    */
   def generateWeightedBenignDataSetLinearRegression: Seq[LabeledPoint] = {
+
     val r = new Random(WEIGHT_RANDOM_SEED)
 
     drawSampleFromNumericallyBenignDenseFeaturesForLinearRegressionLocal(
       DATA_RANDOM_SEED,
       TRAINING_SAMPLES,
       PROBLEM_DIMENSION)
-      .map({ obj =>
+      .map { obj =>
         assertEquals(obj._2.length, PROBLEM_DIMENSION, "Samples should have expected lengths")
         val weight = r.nextDouble() * WEIGHT_RANDOM_MAX
         new LabeledPoint(label = obj._1, features = obj._2, weight = weight)
-      })
+      }
       .toList
   }
 
@@ -294,10 +307,10 @@ class DistributedObjectiveFunctionIntegTest extends SparkTestUtils {
       DATA_RANDOM_SEED,
       TRAINING_SAMPLES,
       PROBLEM_DIMENSION)
-      .map({ obj =>
+      .map { obj =>
         assertEquals(obj._2.length, PROBLEM_DIMENSION, "Samples should have expected lengths")
         new LabeledPoint(label = obj._1, features = obj._2)
-      })
+      }
       .toList
 
   /**
@@ -306,17 +319,18 @@ class DistributedObjectiveFunctionIntegTest extends SparkTestUtils {
    * @return A Seq of [[LabeledPoint]]
    */
   def generateWeightedOutlierDataSetLinearRegression: Seq[LabeledPoint] = {
+
     val r = new Random(WEIGHT_RANDOM_SEED)
 
     drawSampleFromOutlierDenseFeaturesForLinearRegressionLocal(
       DATA_RANDOM_SEED,
       TRAINING_SAMPLES,
       PROBLEM_DIMENSION)
-      .map({ obj =>
+      .map { obj =>
         assertEquals(obj._2.length, PROBLEM_DIMENSION, "Samples should have expected lengths")
         val weight = r.nextDouble() * WEIGHT_RANDOM_MAX
         new LabeledPoint(label = obj._1, features = obj._2, weight = weight)
-      })
+      }
       .toList
   }
 
@@ -334,10 +348,10 @@ class DistributedObjectiveFunctionIntegTest extends SparkTestUtils {
       DATA_RANDOM_SEED,
       TRAINING_SAMPLES,
       PROBLEM_DIMENSION)
-      .map({ obj =>
+      .map { obj =>
         assertEquals(obj._2.length, PROBLEM_DIMENSION, "Samples should have expected lengths")
         new LabeledPoint(label = obj._1, features = obj._2)
-      })
+      }
       .toList
 
   /**
@@ -346,17 +360,18 @@ class DistributedObjectiveFunctionIntegTest extends SparkTestUtils {
    * @return A Seq of [[LabeledPoint]]
    */
   def generateWeightedBenignDataSetPoissonRegression: Seq[LabeledPoint] = {
+
     val r = new Random(WEIGHT_RANDOM_SEED)
 
     drawSampleFromNumericallyBenignDenseFeaturesForPoissonRegressionLocal(
       DATA_RANDOM_SEED,
       TRAINING_SAMPLES,
       PROBLEM_DIMENSION)
-      .map({ obj =>
+      .map { obj =>
         assertEquals(obj._2.length, PROBLEM_DIMENSION, "Samples should have expected lengths")
         val weight = r.nextDouble() * WEIGHT_RANDOM_MAX
         new LabeledPoint(label = obj._1, features = obj._2, weight = weight)
-      })
+      }
       .toList
   }
 
@@ -370,10 +385,10 @@ class DistributedObjectiveFunctionIntegTest extends SparkTestUtils {
       DATA_RANDOM_SEED,
       TRAINING_SAMPLES,
       PROBLEM_DIMENSION)
-      .map({ obj =>
+      .map { obj =>
         assertEquals(obj._2.length, PROBLEM_DIMENSION, "Samples should have expected lengths")
         new LabeledPoint(label = obj._1, features = obj._2)
-      })
+      }
       .toList
 
   /**
@@ -382,17 +397,18 @@ class DistributedObjectiveFunctionIntegTest extends SparkTestUtils {
    * @return A Seq of [[LabeledPoint]]
    */
   def generateWeightedOutlierDataSetPoissonRegression: Seq[LabeledPoint] = {
+
     val r = new Random(WEIGHT_RANDOM_SEED)
 
     drawSampleFromOutlierDenseFeaturesForPoissonRegressionLocal(
       DATA_RANDOM_SEED,
       TRAINING_SAMPLES,
       PROBLEM_DIMENSION)
-      .map({ obj =>
+      .map { obj =>
         assertEquals(obj._2.length, PROBLEM_DIMENSION, "Samples should have expected lengths")
         val weight = r.nextDouble() * WEIGHT_RANDOM_MAX
         new LabeledPoint(label = obj._1, features = obj._2, weight = weight)
-      })
+      }
       .toList
   }
 
@@ -408,12 +424,12 @@ class DistributedObjectiveFunctionIntegTest extends SparkTestUtils {
    * @param tolerance The relative & absolute error tolerance
    */
   def checkDerivativeError(
-    prefix: String,
-    descriptor: String,
-    deltaBefore: Double,
-    deltaAfter: Double,
-    expected: Double,
-    tolerance: Double): Unit = {
+      prefix: String,
+      descriptor: String,
+      deltaBefore: Double,
+      deltaAfter: Double,
+      expected: Double,
+      tolerance: Double): Unit = {
 
     assertTrue(java.lang.Double.isFinite(deltaBefore), s"Value before step [$deltaBefore] should be finite")
     assertTrue(java.lang.Double.isFinite(deltaAfter), s"Value after step [$deltaAfter] should be finite")
@@ -433,11 +449,11 @@ class DistributedObjectiveFunctionIntegTest extends SparkTestUtils {
     assert(
       relativeError < tolerance || absoluteError < tolerance,
       s"""$prefix
-          |Computed and numerical differentiation estimates should be close.
-          |NUMERICAL ESTIMATE: $numericDerivative ($descriptor)
-          |COMPUTED: $expected
-          |ABSOLUTE ERROR: $absoluteError
-          |RELATIVE ERROR: $relativeError""".stripMargin)
+        |Computed and numerical differentiation estimates should be close.
+        |NUMERICAL ESTIMATE: $numericDerivative ($descriptor)
+        |COMPUTED: $expected
+        |ABSOLUTE ERROR: $absoluteError
+        |RELATIVE ERROR: $relativeError""".stripMargin)
   }
 
   /**
@@ -452,10 +468,10 @@ class DistributedObjectiveFunctionIntegTest extends SparkTestUtils {
    */
   @Test(dataProvider = "getDifferentiableFunctions", groups = Array[String]("ObjectiveFunctionTests", "testCore"))
   def checkGradientConsistentWithObjectiveSpark(
-    objectiveBuilder: (SparkContext) => DistributedObjectiveFunction with DiffFunction,
-    dataGenerationFunction: () => List[LabeledPoint]): Unit = sparkTest("checkGradientConsistentWithObjectiveSpark") {
+      objectiveBuilder: () => DistributedObjectiveFunction with DiffFunction,
+      dataGenerationFunction: () => List[LabeledPoint]): Unit = sparkTest("checkGradientConsistentWithObjectiveSpark") {
 
-    val objective = objectiveBuilder(sc)
+    val objective = objectiveBuilder()
     val trainingData = sc.parallelize(dataGenerationFunction()).repartition(NUM_PARTITIONS)
     val normalizationContextBroadcast = PhotonBroadcast(sc.broadcast(NORMALIZATION))
     val r = new Random(PARAMETER_RANDOM_SEED)
@@ -510,10 +526,10 @@ class DistributedObjectiveFunctionIntegTest extends SparkTestUtils {
    */
   @Test(dataProvider = "getTwiceDifferentiableFunctions", groups = Array[String]("ObjectiveFunctionTests", "testCore"))
   def checkHessianConsistentWithObjectiveSpark(
-    objectiveBuilder: (SparkContext) => DistributedObjectiveFunction with TwiceDiffFunction,
-    dataGenerationFunction: () => List[LabeledPoint]): Unit = sparkTest("checkHessianConsistentWithObjectiveSpark") {
+      objectiveBuilder: () => DistributedObjectiveFunction with TwiceDiffFunction,
+      dataGenerationFunction: () => List[LabeledPoint]): Unit = sparkTest("checkHessianConsistentWithObjectiveSpark") {
 
-    val objective = objectiveBuilder(sc)
+    val objective = objectiveBuilder()
     val trainingData = sc.parallelize(dataGenerationFunction()).repartition(NUM_PARTITIONS)
     val normalizationContextBroadcast = PhotonBroadcast(sc.broadcast(NORMALIZATION))
     val r = new Random(PARAMETER_RANDOM_SEED)
@@ -560,7 +576,8 @@ class DistributedObjectiveFunctionIntegTest extends SparkTestUtils {
 
           checkDerivativeError(
             "Checking Hessian",
-            s"f=[$objective / ${objective.getClass.getName}], iter=[$iter], basis=[$basis], idx=[$idx], Hessian=[$hessianVector]",
+            s"f=[$objective / ${objective.getClass.getName}], iter=[$iter], basis=[$basis], idx=[$idx], " +
+              s"Hessian=[$hessianVector]",
             gradBefore(basis),
             gradAfter(basis),
             hessianVector(idx),
@@ -578,6 +595,7 @@ class DistributedObjectiveFunctionIntegTest extends SparkTestUtils {
 }
 
 object DistributedObjectiveFunctionIntegTest {
+
   private val SPARK_CONSISTENCY_CHECK_SAMPLES = 5
   private val NUM_PARTITIONS = 4
   private val PROBLEM_DIMENSION = 5

--- a/photon-api/src/integTest/scala/com/linkedin/photon/ml/normalization/NormalizationContextIntegTest.scala
+++ b/photon-api/src/integTest/scala/com/linkedin/photon/ml/normalization/NormalizationContextIntegTest.scala
@@ -220,13 +220,13 @@ class NormalizationContextIntegTest extends SparkTestUtils with GameTestUtils {
     val configuration = FixedEffectOptimizationConfiguration(generateOptimizerConfig())
     val objectiveFunction = taskType match {
       case TaskType.LOGISTIC_REGRESSION =>
-        DistributedGLMLossFunction(sc, configuration, treeAggregateDepth = 1)(LogisticLossFunction)
+        DistributedGLMLossFunction(configuration, treeAggregateDepth = 1)(LogisticLossFunction)
 
       case TaskType.LINEAR_REGRESSION =>
-        DistributedGLMLossFunction(sc, configuration, treeAggregateDepth = 1)(SquaredLossFunction)
+        DistributedGLMLossFunction(configuration, treeAggregateDepth = 1)(SquaredLossFunction)
 
       case TaskType.POISSON_REGRESSION =>
-        DistributedGLMLossFunction(sc, configuration, treeAggregateDepth = 1)(PoissonLossFunction)
+        DistributedGLMLossFunction(configuration, treeAggregateDepth = 1)(PoissonLossFunction)
     }
     val optimizerNorm = optimizerType match {
       case OptimizerType.LBFGS =>

--- a/photon-api/src/integTest/scala/com/linkedin/photon/ml/optimization/DistributedOptimizationProblemIntegTest.scala
+++ b/photon-api/src/integTest/scala/com/linkedin/photon/ml/optimization/DistributedOptimizationProblemIntegTest.scala
@@ -294,7 +294,7 @@ class DistributedOptimizationProblemIntegTest extends SparkTestUtils {
       doReturn(regContext).when(optConfig).regularizationContext
       doReturn(RegularizationType.NONE).when(regContext).regularizationType
 
-      val objective = DistributedGLMLossFunction(sc, optConfig, treeAggregateDepth = 1)(lossFunction)
+      val objective = DistributedGLMLossFunction(optConfig, treeAggregateDepth = 1)(lossFunction)
 
       val optimizationProblem = new DistributedOptimizationProblem(
         optimizer,
@@ -348,7 +348,7 @@ class DistributedOptimizationProblemIntegTest extends SparkTestUtils {
       doReturn(RegularizationType.L2).when(regContext).regularizationType
       doReturn(regularizationWeight).when(regContext).getL2RegularizationWeight(regularizationWeight)
 
-      val objective = DistributedGLMLossFunction(sc, optConfig, treeAggregateDepth = 1)(lossFunction)
+      val objective = DistributedGLMLossFunction(optConfig, treeAggregateDepth = 1)(lossFunction)
 
       val optimizationProblem = new DistributedOptimizationProblem(
         optimizer,
@@ -491,6 +491,6 @@ object DistributedOptimizationProblemIntegTest {
 
   // No way to pass Mixin class type to Mockito, need to define a concrete class
   private class L2LossFunction(sc: SparkContext)
-    extends DistributedSmoothedHingeLossFunction(sc, treeAggregateDepth = 1)
+    extends DistributedSmoothedHingeLossFunction(treeAggregateDepth = 1)
     with L2RegularizationDiff
 }

--- a/photon-api/src/integTest/scala/com/linkedin/photon/ml/supervised/BaseGLMIntegTest.scala
+++ b/photon-api/src/integTest/scala/com/linkedin/photon/ml/supervised/BaseGLMIntegTest.scala
@@ -118,7 +118,7 @@ class BaseGLMIntegTest extends SparkTestUtils {
         (sc: SparkContext, normalizationContext: BroadcastWrapper[NormalizationContext]) =>
           DistributedOptimizationProblem(
             lbfgsConfig,
-            DistributedGLMLossFunction(sc, lbfgsConfig, treeAggregateDepth = 1)(SquaredLossFunction) ,
+            DistributedGLMLossFunction(lbfgsConfig, treeAggregateDepth = 1)(SquaredLossFunction) ,
             None,
             LinearRegressionModel.apply,
             normalizationContext,
@@ -134,7 +134,7 @@ class BaseGLMIntegTest extends SparkTestUtils {
         (sc: SparkContext, normalizationContext: BroadcastWrapper[NormalizationContext]) =>
           DistributedOptimizationProblem(
             lbfgsConfig,
-            DistributedGLMLossFunction(sc, lbfgsConfig, treeAggregateDepth = 1)(PoissonLossFunction) ,
+            DistributedGLMLossFunction(lbfgsConfig, treeAggregateDepth = 1)(PoissonLossFunction) ,
             None,
             PoissonRegressionModel.apply,
             normalizationContext,
@@ -152,7 +152,7 @@ class BaseGLMIntegTest extends SparkTestUtils {
         (sc: SparkContext, normalizationContext: BroadcastWrapper[NormalizationContext]) =>
           DistributedOptimizationProblem(
             lbfgsConfig,
-            DistributedGLMLossFunction(sc, lbfgsConfig, treeAggregateDepth = 1)(LogisticLossFunction),
+            DistributedGLMLossFunction(lbfgsConfig, treeAggregateDepth = 1)(LogisticLossFunction),
             None,
             LogisticRegressionModel.apply,
             normalizationContext,

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/ModelTraining.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/ModelTraining.scala
@@ -128,7 +128,6 @@ object ModelTraining extends Logging {
       case TaskType.LOGISTIC_REGRESSION =>
         val constructor = LogisticRegressionModel.apply _
         val objective = DistributedGLMLossFunction(
-          trainingData.sparkContext,
           optimizationConfig,
           treeAggregateDepth)(
           LogisticLossFunction)
@@ -138,7 +137,6 @@ object ModelTraining extends Logging {
       case TaskType.LINEAR_REGRESSION =>
         val constructor = LinearRegressionModel.apply _
         val objective = DistributedGLMLossFunction(
-          trainingData.sparkContext,
           optimizationConfig,
           treeAggregateDepth)(
           SquaredLossFunction)
@@ -148,7 +146,6 @@ object ModelTraining extends Logging {
       case TaskType.POISSON_REGRESSION =>
         val constructor = PoissonRegressionModel.apply _
         val objective = DistributedGLMLossFunction(
-          trainingData.sparkContext,
           optimizationConfig,
           treeAggregateDepth)(
           PoissonLossFunction)
@@ -158,7 +155,6 @@ object ModelTraining extends Logging {
       case TaskType.SMOOTHED_HINGE_LOSS_LINEAR_SVM =>
         val constructor = SmoothedHingeLossLinearSVMModel.apply _
         val objective = DistributedSmoothedHingeLossFunction(
-          trainingData.sparkContext,
           optimizationConfig,
           treeAggregateDepth)
 

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/estimators/GameEstimator.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/estimators/GameEstimator.scala
@@ -766,7 +766,6 @@ class GameEstimator(val sc: SparkContext, implicit val logger: Logger) extends P
       treeAggregateDepth: Int): DistributedObjectiveFunction = {
 
     val distLossFunction: DistributedLossFunctionConstructor = DistributedGLMLossFunction(
-      sc,
       configuration,
       treeAggregateDepth)
 
@@ -775,7 +774,7 @@ class GameEstimator(val sc: SparkContext, implicit val logger: Logger) extends P
       case TaskType.LINEAR_REGRESSION => distLossFunction(SquaredLossFunction)
       case TaskType.POISSON_REGRESSION => distLossFunction(PoissonLossFunction)
       case TaskType.SMOOTHED_HINGE_LOSS_LINEAR_SVM =>
-        DistributedSmoothedHingeLossFunction(sc, configuration, treeAggregateDepth)
+        DistributedSmoothedHingeLossFunction(configuration, treeAggregateDepth)
     }
   }
 }

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/function/DistributedObjectiveFunction.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/function/DistributedObjectiveFunction.scala
@@ -18,6 +18,7 @@ import breeze.linalg.Vector
 import org.apache.spark.SparkContext
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.SparkSession
 
 import com.linkedin.photon.ml.data.LabeledPoint
 
@@ -25,18 +26,19 @@ import com.linkedin.photon.ml.data.LabeledPoint
  * The base objective function used by DistributedOptimizationProblems. This function works with an RDD of data
  * distributed across the cluster.
  *
- * @param sc The Spark context
  * @param treeAggregateDepth The depth used by treeAggregate. Depth 1 indicates normal linear aggregate. Using
  *                           depth > 1 can reduce memory consumption in the Driver and may also speed up the
  *                           aggregation. It is experimental currently because treeAggregate is unstable in Spark
  *                           versions 1.4 and 1.5.
  */
-abstract class DistributedObjectiveFunction(sc: SparkContext, treeAggregateDepth: Int) extends ObjectiveFunction {
+abstract class DistributedObjectiveFunction(treeAggregateDepth: Int) extends ObjectiveFunction {
 
   type Data = RDD[LabeledPoint]
   type Coefficients = Broadcast[Vector[Double]]
 
   require(treeAggregateDepth > 0, s"Tree aggregate depth must be greater than 0: $treeAggregateDepth")
+
+  private lazy val sc: SparkContext = SparkSession.builder().getOrCreate().sparkContext
 
   /**
    * Compute the size of the domain for the given input data (i.e. the number of features, including the intercept if

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/util/GameTestUtils.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/util/GameTestUtils.scala
@@ -20,7 +20,7 @@ import org.apache.spark.mllib.linalg.Vectors
 import org.apache.spark.{HashPartitioner, SparkConf}
 import org.testng.annotations.DataProvider
 
-import com.linkedin.photon.ml.SparkContextConfiguration
+import com.linkedin.photon.ml.SparkSessionConfiguration
 import com.linkedin.photon.ml.algorithm.{FixedEffectCoordinate, RandomEffectCoordinateInProjectedSpace}
 import com.linkedin.photon.ml.data._
 import com.linkedin.photon.ml.function.glm.{DistributedGLMLossFunction, LogisticLossFunction, SingleNodeGLMLossFunction}
@@ -146,7 +146,7 @@ trait GameTestUtils extends TestTemplateWithTmpDir {
 
     DistributedOptimizationProblem(
       configuration,
-      DistributedGLMLossFunction(sc, configuration, 1)(LogisticLossFunction) ,
+      DistributedGLMLossFunction(configuration, 1)(LogisticLossFunction) ,
       None,
       LogisticRegressionModel.apply,
       PhotonBroadcast(sc.broadcast(NoNormalization())),
@@ -309,8 +309,9 @@ trait GameTestUtils extends TestTemplateWithTmpDir {
    */
   def sparkTest(name: String, useKryo: Boolean)(body: => Unit) {
     SparkTestUtils.SPARK_LOCAL_CONFIG.synchronized {
-      sc = SparkContextConfiguration.asYarnClient(
-        new SparkConf().setMaster(SparkTestUtils.SPARK_LOCAL_CONFIG), name, useKryo)
+      sc = SparkSessionConfiguration
+        .asYarnClient(new SparkConf().setMaster(SparkTestUtils.SPARK_LOCAL_CONFIG), name, useKryo)
+        .sparkContext
 
       try {
         body

--- a/photon-api/src/test/scala/com/linkedin/photon/ml/function/DistributedObjectiveFunctionTest.scala
+++ b/photon-api/src/test/scala/com/linkedin/photon/ml/function/DistributedObjectiveFunctionTest.scala
@@ -14,8 +14,6 @@
  */
 package com.linkedin.photon.ml.function
 
-import org.apache.spark.SparkContext
-import org.mockito.Mockito._
 import org.testng.annotations.{DataProvider, Test}
 
 import com.linkedin.photon.ml.normalization.NormalizationContext
@@ -26,7 +24,7 @@ import com.linkedin.photon.ml.util.BroadcastWrapper
  */
 class DistributedObjectiveFunctionTest {
 
-  import DistributedObjectiveFunctionIntegTest.MockDistributedObjectiveFunction
+  import DistributedObjectiveFunctionTest._
 
   @DataProvider
   def invalidInput(): Array[Array[Any]] = Array(Array(-1), Array(0))
@@ -37,18 +35,14 @@ class DistributedObjectiveFunctionTest {
    * @param treeAggregateDepth An invalid tree aggregate depth
    */
   @Test(dataProvider = "invalidInput", expectedExceptions = Array(classOf[IllegalArgumentException]))
-  def testSetupWithInvalidInput(treeAggregateDepth: Int): Unit = {
-
-    val mockSparkContext = mock(classOf[SparkContext])
-
-    new MockDistributedObjectiveFunction(mockSparkContext, treeAggregateDepth)
-  }
+  def testSetupWithInvalidInput(treeAggregateDepth: Int): Unit =
+    new MockDistributedObjectiveFunction(treeAggregateDepth)
 }
 
-object DistributedObjectiveFunctionIntegTest {
+object DistributedObjectiveFunctionTest {
 
-  class MockDistributedObjectiveFunction(sc: SparkContext, treeAggregateDepth: Int)
-    extends DistributedObjectiveFunction(sc, treeAggregateDepth) {
+  class MockDistributedObjectiveFunction(treeAggregateDepth: Int)
+    extends DistributedObjectiveFunction(treeAggregateDepth) {
 
     override protected[ml] def value(
         input: Data,

--- a/photon-client/src/integTest/scala/com/linkedin/photon/ml/cli/game/training/GameTrainingDriverIntegTest.scala
+++ b/photon-client/src/integTest/scala/com/linkedin/photon/ml/cli/game/training/GameTrainingDriverIntegTest.scala
@@ -570,7 +570,7 @@ class GameTrainingDriverIntegTest extends SparkTestUtils with GameTestUtils with
 
     val indexMapLoadersOpt = GameTrainingDriver.prepareFeatureMaps()
     val featureShardConfigs = GameTrainingDriver.getOrDefault(GameTrainingDriver.featureShardConfigurations)
-    val (testData, indexMapLoaders) = new AvroDataReader(sc).readMerged(
+    val (testData, indexMapLoaders) = new AvroDataReader().readMerged(
       Seq(testPath.toString),
       indexMapLoadersOpt,
       featureShardConfigs,
@@ -622,7 +622,7 @@ class GameTrainingDriverIntegTest extends SparkTestUtils with GameTestUtils with
 
     val indexMapLoadersOpt = GameTrainingDriver.prepareFeatureMaps()
     val featureShardConfigs = GameTrainingDriver.getOrDefault(GameTrainingDriver.featureShardConfigurations)
-    val (testData, indexMapLoaders) = new AvroDataReader(sc).readMerged(
+    val (testData, indexMapLoaders) = new AvroDataReader().readMerged(
       Seq(testPath.toString),
       indexMapLoadersOpt,
       featureShardConfigs,

--- a/photon-client/src/integTest/scala/com/linkedin/photon/ml/data/avro/AvroDataReaderIntegTest.scala
+++ b/photon-client/src/integTest/scala/com/linkedin/photon/ml/data/avro/AvroDataReaderIntegTest.scala
@@ -40,8 +40,7 @@ class AvroDataReaderIntegTest extends SparkTestUtils {
    */
   @Test
   def testRead(): Unit = sparkTest("testRead") {
-
-    val dr = new AvroDataReader(sc)
+    val dr = new AvroDataReader()
     val (df, _) = dr.readMerged(inputPath.toString, featureShardConfigurationsMap, numPartitions)
 
     verifyDataFrame(df, expectedRows = 34810)
@@ -62,7 +61,7 @@ class AvroDataReaderIntegTest extends SparkTestUtils {
       (shardId, indexMapLoader)
     }
 
-    val dr = new AvroDataReader(sc)
+    val dr = new AvroDataReader()
     val df = dr.readMerged(inputPath.toString, indexMapLoaders, featureShardConfigurationsMap, numPartitions)
 
     verifyDataFrame(df, expectedRows = 34810)
@@ -73,7 +72,7 @@ class AvroDataReaderIntegTest extends SparkTestUtils {
    */
   @Test
   def testReadMultipleFiles(): Unit = sparkTest("testReadMultipleFiles") {
-    val dr = new AvroDataReader(sc)
+    val dr = new AvroDataReader()
     val (df, _) = dr.readMerged(
       Seq(inputPath, inputPath2).map(_.toString),
       featureShardConfigurationsMap,
@@ -113,7 +112,7 @@ class AvroDataReaderIntegTest extends SparkTestUtils {
    */
   @Test(expectedExceptions = Array(classOf[SparkException]))
   def testReadDuplicateFeatures(): Unit = sparkTest("testReadDuplicateFeatures") {
-    val dr = new AvroDataReader(sc)
+    val dr = new AvroDataReader()
     val (df, _) = dr.read(duplicateFeaturesPath.toString, numPartitions)
 
     // Force evaluation
@@ -125,7 +124,7 @@ class AvroDataReaderIntegTest extends SparkTestUtils {
    */
   @Test(expectedExceptions = Array(classOf[IllegalArgumentException]))
   def testReadInvalidPaths(): Unit = sparkTest("testReadInvalidPaths") {
-    val dr = new AvroDataReader(sc)
+    val dr = new AvroDataReader()
     dr.read(Seq.empty[String], numPartitions)
   }
 
@@ -134,7 +133,7 @@ class AvroDataReaderIntegTest extends SparkTestUtils {
    */
   @Test(expectedExceptions = Array(classOf[IllegalArgumentException]))
   def testReadInvalidPartitions(): Unit = sparkTest("testReadInvalidPartitions") {
-    val dr = new AvroDataReader(sc)
+    val dr = new AvroDataReader()
     dr.read(inputPath.toString, -1)
   }
 
@@ -144,7 +143,7 @@ class AvroDataReaderIntegTest extends SparkTestUtils {
   @Test(expectedExceptions = Array(classOf[IllegalArgumentException]))
   def testInvalidInputPath(): Unit = sparkTest("testInvalidInputPath") {
     val emptyInputPath = getClass.getClassLoader.getResource("GameIntegTest/empty-input").getPath
-    val dr = new AvroDataReader(sc)
+    val dr = new AvroDataReader()
     dr.read(emptyInputPath, numPartitions)
   }
 }

--- a/photon-client/src/main/scala/com/linkedin/photon/ml/Driver.scala
+++ b/photon-client/src/main/scala/com/linkedin/photon/ml/Driver.scala
@@ -686,7 +686,7 @@ object Driver {
     // Parse the parameters from command line, should always be the 1st line in main
     val params = PhotonMLCmdLineParser.parseFromCommandLine(args)
     // Configure the Spark application and initialize SparkContext, which is the entry point of a Spark application
-    val sc = SparkContextConfiguration.asYarnClient(new SparkConf(), params.jobName, params.kryo)
+    val sc = SparkSessionConfiguration.asYarnClient(new SparkConf(), params.jobName, params.kryo).sparkContext
     // A temporary solution to save log into HDFS.
     val logPath = new Path(params.outputDir, "log-message.txt")
     val logger = new PhotonLogger(logPath, sc)

--- a/photon-client/src/main/scala/com/linkedin/photon/ml/cli/game/scoring/GameScoringDriver.scala
+++ b/photon-client/src/main/scala/com/linkedin/photon/ml/cli/game/scoring/GameScoringDriver.scala
@@ -19,7 +19,7 @@ import org.apache.spark.SparkContext
 import org.apache.spark.ml.param.{Param, ParamMap, Params}
 import org.apache.spark.sql.DataFrame
 
-import com.linkedin.photon.ml.{DataValidationType, SparkContextConfiguration, TaskType}
+import com.linkedin.photon.ml.{DataValidationType, SparkSessionConfiguration, TaskType}
 import com.linkedin.photon.ml.Types.FeatureShardId
 import com.linkedin.photon.ml.cli.game.GameDriver
 import com.linkedin.photon.ml.constants.StorageLevel
@@ -214,12 +214,11 @@ object GameScoringDriver extends GameDriver {
 
     logger.debug(s"Input records paths:\n${recordsPaths.mkString("\n")}")
 
-    new AvroDataReader(sc)
-      .readMerged(
-        recordsPaths.map(_.toString),
-        featureShardIdToIndexMapLoaderMapOpt,
-        getRequiredParam(featureShardConfigurations),
-        parallelism)
+    new AvroDataReader().readMerged(
+      recordsPaths.map(_.toString),
+      featureShardIdToIndexMapLoaderMapOpt,
+      getRequiredParam(featureShardConfigurations),
+      parallelism)
   }
 
   /**
@@ -266,7 +265,7 @@ object GameScoringDriver extends GameDriver {
     val params: ParamMap = ScoptGameScoringParametersParser.parseFromCommandLine(args)
     params.toSeq.foreach(set)
 
-    sc = SparkContextConfiguration.asYarnClient(getOrDefault(applicationName), useKryo = true)
+    sc = SparkSessionConfiguration.asYarnClient(getOrDefault(applicationName), useKryo = true).sparkContext
     logger = new PhotonLogger(getRequiredParam(rootOutputDirectory), sc)
     logger.setLogLevel(getOrDefault(logLevel))
 

--- a/photon-client/src/main/scala/com/linkedin/photon/ml/cli/game/training/GameTrainingDriver.scala
+++ b/photon-client/src/main/scala/com/linkedin/photon/ml/cli/game/training/GameTrainingDriver.scala
@@ -495,12 +495,11 @@ object GameTrainingDriver extends GameDriver {
 
     // The 'map(identity)' call is required due to a long-standing Scala bug SI-7005: the result of a 'mapValues' call
     // is not serializable.
-    new AvroDataReader(sc)
-      .readMerged(
-        trainingRecordsPath.map(_.toString),
-        featureIndexMapLoadersOpt,
-        getRequiredParam(featureShardConfigurations),
-        numPartitions)
+    new AvroDataReader().readMerged(
+      trainingRecordsPath.map(_.toString),
+      featureIndexMapLoadersOpt,
+      getRequiredParam(featureShardConfigurations),
+      numPartitions)
   }
 
   /**
@@ -519,12 +518,11 @@ object GameTrainingDriver extends GameDriver {
 
       // The 'map(identity)' call is required due to a long-standing Scala bug SI-7005: the result of a 'mapValues' call
       // is not serializable.
-      new AvroDataReader(sc)
-        .readMerged(
-          validationRecordsPath.map(_.toString),
-          featureIndexMapLoaders,
-          getRequiredParam(featureShardConfigurations),
-          getOrDefault(minValidationPartitions))
+      new AvroDataReader().readMerged(
+        validationRecordsPath.map(_.toString),
+        featureIndexMapLoaders,
+        getRequiredParam(featureShardConfigurations),
+        getOrDefault(minValidationPartitions))
     }
 
   /**
@@ -813,7 +811,7 @@ object GameTrainingDriver extends GameDriver {
     val params: ParamMap = ScoptGameTrainingParametersParser.parseFromCommandLine(args)
     params.toSeq.foreach(set)
 
-    sc = SparkContextConfiguration.asYarnClient(getOrDefault(applicationName), useKryo = true)
+    sc = SparkSessionConfiguration.asYarnClient(getOrDefault(applicationName), useKryo = true).sparkContext
     logger = new PhotonLogger(new Path(getRequiredParam(rootOutputDirectory), LOGS), sc)
     logger.setLogLevel(getOrDefault(logLevel))
 

--- a/photon-client/src/main/scala/com/linkedin/photon/ml/data/avro/NameAndTermFeatureBagsDriver.scala
+++ b/photon-client/src/main/scala/com/linkedin/photon/ml/data/avro/NameAndTermFeatureBagsDriver.scala
@@ -20,7 +20,7 @@ import org.apache.spark.SparkContext
 import org.apache.spark.ml.param.{Param, ParamMap, Params}
 import org.apache.spark.ml.util.Identifiable
 
-import com.linkedin.photon.ml.SparkContextConfiguration
+import com.linkedin.photon.ml.SparkSessionConfiguration
 import com.linkedin.photon.ml.io.scopt.avro.ScoptNameAndTermFeatureBagsParametersParser
 import com.linkedin.photon.ml.util._
 
@@ -204,7 +204,7 @@ object NameAndTermFeatureBagsDriver extends Params with Logging {
     params.toSeq.foreach(set)
 
     implicit val log = logger
-    sc = SparkContextConfiguration.asYarnClient(getOrDefault(applicationName), useKryo = true)
+    sc = SparkSessionConfiguration.asYarnClient(getOrDefault(applicationName), useKryo = true).sparkContext
 
     try {
 

--- a/photon-client/src/main/scala/com/linkedin/photon/ml/index/FeatureIndexingDriver.scala
+++ b/photon-client/src/main/scala/com/linkedin/photon/ml/index/FeatureIndexingDriver.scala
@@ -31,7 +31,7 @@ import com.linkedin.photon.ml.data.avro._
 import com.linkedin.photon.ml.io.FeatureShardConfiguration
 import com.linkedin.photon.ml.io.scopt.index.ScoptFeatureIndexingParametersParser
 import com.linkedin.photon.ml.util._
-import com.linkedin.photon.ml.{Constants, SparkContextConfiguration}
+import com.linkedin.photon.ml.{Constants, SparkSessionConfiguration}
 
 /**
  * A driver to build feature index maps as an independent Spark job. Recommended when the feature space is large,
@@ -305,7 +305,7 @@ object FeatureIndexingDriver extends Params with Logging {
     params.toSeq.foreach(set)
 
     implicit val log = logger
-    sc = SparkContextConfiguration.asYarnClient(getOrDefault(applicationName), useKryo = true)
+    sc = SparkSessionConfiguration.asYarnClient(getOrDefault(applicationName), useKryo = true).sparkContext
 
     try {
 

--- a/photon-lib/src/integTest/scala/com/linkedin/photon/ml/stat/BasicStatisticalSummaryIntegTest.scala
+++ b/photon-lib/src/integTest/scala/com/linkedin/photon/ml/stat/BasicStatisticalSummaryIntegTest.scala
@@ -64,8 +64,7 @@ class BasicStatisticalSummaryIntegTest extends SparkTestUtils {
       val featureShardId = "features"
 
       val trainingData: DataFrame = sparkSession
-        .createDataFrame(
-          labeledPoints.map { point: LabeledPoint => (point.label, VectorUtils.breezeToMllib(point.features).asML) })
+        .createDataFrame(labeledPoints.map(point => (point.label, VectorUtils.breezeToMllib(point.features).asML)))
         .toDF("response", featureShardId)
 
       // Calling rdd explicitly here to avoid a typed encoder lookup in Spark 2.1


### PR DESCRIPTION
- Replace SQLContext with SparkSession
- Replace SparkContextConfiguration with SparkSessionConfiguration
- Remove a few cases where SparkContext explictly passed around