### PR TITLE
Add amplitude and noise to the hyperparamater tuning model

### DIFF
--- a/photon-lib/src/main/scala/com/linkedin/photon/ml/hyperparameter/SliceSampler.scala
+++ b/photon-lib/src/main/scala/com/linkedin/photon/ml/hyperparameter/SliceSampler.scala
@@ -17,8 +17,9 @@ package com.linkedin.photon.ml.hyperparameter
 import scala.annotation.tailrec
 import scala.util.Random
 
-import breeze.linalg.DenseVector
+import breeze.linalg.{DenseVector, norm}
 import breeze.numerics.log
+import breeze.stats.distributions.Gaussian
 
 /**
  * This class implements the slice sampling algorithm. Slice sampling is an Markov chain Monte Carlo algorithm for
@@ -43,17 +44,14 @@ import breeze.numerics.log
  *   4) Sample uniformly from the slice to obtain the new point x'.
  *   5) Back to step 1 with the new point.
  *
- * @param logp the log-transformed function from which to sample. Note that this need not sum to 1, and need only be
- *   proportional to the target PDF.
- * @param range the range of values within which to sample
  * @param stepSize the size to expand a slice while taking one step in a single direction from the
  *   starting point
+ * @param maxStepsOut the maximum number of steps in either direction while expanding a slice
  * @param seed the random seed
  */
 class SliceSampler(
-    logp: (DenseVector[Double]) => Double,
-    range: (Double, Double) = (log(1e-5), log(1e5)),
     stepSize: Double = 1.0,
+    maxStepsOut: Int = 1000,
     seed: Long = System.currentTimeMillis) {
 
   val random = new Random(seed)
@@ -62,12 +60,29 @@ class SliceSampler(
    * Draws a new point from the target distribution
    *
    * @param x the original point
+   * @param logp the log-transformed function from which to sample. Note that this need not sum to 1, and need only be
+   *   proportional to the target PDF.
    * @return the new point
    */
-  def draw(x: DenseVector[Double]): DenseVector[Double] = {
+  def draw(x: DenseVector[Double], logp: (DenseVector[Double]) => Double): DenseVector[Double] = {
+    val sampledVector = DenseVector(Gaussian(0, 1).sample(x.length):_*)
+    val direction = sampledVector / norm(sampledVector)
+
+    draw(x, logp, direction)
+  }
+
+  /**
+   * Draws a new point from the target distribution, sampling from each dimension one-by-one
+   *
+   * @param x the original point
+   * @param logp the log-transformed function from which to sample. Note that this need not sum to 1, and need only be
+   *   proportional to the target PDF.
+   * @return the new point
+   */
+  def drawDimensionWise(x: DenseVector[Double], logp: (DenseVector[Double]) => Double): DenseVector[Double] = {
     val directions = random.shuffle((0 until x.length).toList)
     directions.foldLeft(x) { (currX, i) =>
-      draw(currX, getDirection(i, x.length))
+      draw(currX, logp, getDirection(i, x.length))
     }
   }
 
@@ -75,19 +90,20 @@ class SliceSampler(
    * Draws a new point from the target distribution along the given direction
    *
    * @param x the original point
+   * @param logp the log-transformed function from which to sample. Note that this need not sum to 1, and need only be
+   *   proportional to the target PDF.
    * @param direction the direction along which to draw a new point
    * @return the new point
    */
   protected def draw(
       x: DenseVector[Double],
+      logp: (DenseVector[Double]) => Double,
       direction: DenseVector[Double]): DenseVector[Double] = {
 
-    require(checkDirection(direction), "Direction must be a standard unit basis vector.")
-
     val y = log(random.nextDouble()) + logp(x)
-    val slice = stepOut(x, y, direction)
+    val slice = stepOut(x, y, logp, direction)
 
-    draw(x, y, direction, slice)
+    draw(x, y, logp, direction, slice)
   }
 
   /**
@@ -96,6 +112,8 @@ class SliceSampler(
    *
    * @param x the original point
    * @param y the value of the function slice
+   * @param logp the log-transformed function from which to sample. Note that this need not sum to 1, and need only be
+   *   proportional to the target PDF.
    * @param direction the direction along which to draw a new point
    * @param slice the slice bounds
    * @return the new point
@@ -104,6 +122,7 @@ class SliceSampler(
   protected final def draw(
       x: DenseVector[Double],
       y: Double,
+      logp: (DenseVector[Double]) => Double,
       direction: DenseVector[Double],
       slice: (DenseVector[Double], DenseVector[Double])): DenseVector[Double] = {
 
@@ -117,17 +136,8 @@ class SliceSampler(
 
     } else {
       // Otherwise, reject the sample and shrink the slice
-      val newSlice = try {
-        shrink(slice, x, newX, direction)
-
-      } catch {
-        // If shrinking the slice fails, it means that our step-out procedure failed to distinguish between regions of
-        // the PDF that fall above or below the slice, and our slice shrank to zero. In this case, the best we can do is
-        // reset to the entire range and start over with rejection sampling and shrinking.
-        case _: Exception => (range._1 * direction, range._2 * direction)
-      }
-
-      draw(x, y, direction, newSlice)
+      val newSlice = shrink(slice, x, newX, direction)
+      draw(x, y, logp, direction, newSlice)
     }
   }
 
@@ -142,41 +152,35 @@ class SliceSampler(
     DenseVector.tabulate(dim) { j => if (i == j) 1.0 else 0.0 }
 
   /**
-   * Verifies that the direction vector is a standard unit basis vector
-   *
-   * @param direction the direction vector to check
-   * @return true if valid
-   */
-  protected def checkDirection(direction: DenseVector[Double]): Boolean = {
-    val arr = direction.toArray
-    arr.count(_ == 1.0) == 1 &&
-      arr.count(_ == 0.0) == direction.length - 1
-  }
-
-  /**
    * Performs the step out procedure. Start at the given x position, and expand outwards along the
    * given direction until the slice extends beyond where the PDF lies above the y value.
    *
    * @param x the starting point
    * @param y the value at which the function will be sliced
+   * @param logp the log-transformed function from which to sample. Note that this need not sum to 1, and need only be
+   *   proportional to the target PDF.
    * @param direction the direction along which to slice
    * @return the slice lower and upper bounds
    */
   protected def stepOut(
       x: DenseVector[Double],
       y: Double,
+      logp: (DenseVector[Double]) => Double,
       direction: DenseVector[Double]): (DenseVector[Double], DenseVector[Double]) = {
 
     var lower = x - direction * random.nextDouble() * stepSize
     var upper = lower + direction * stepSize
-    val (lowerBound, upperBound) = range
+    var lowerStepsOut = 0
+    var upperStepsOut = 0
 
-    while ((logp(lower) > y) && (lower.t * direction > lowerBound)) {
+    while ((logp(lower) > y) && lowerStepsOut < maxStepsOut) {
       lower -= direction * stepSize
+      lowerStepsOut += 1
     }
 
-    while ((logp(upper) > y) && upper.t * direction < upperBound) {
+    while ((logp(upper) > y) && upperStepsOut < maxStepsOut) {
       upper += direction * stepSize
+      upperStepsOut += 1
     }
 
     (lower, upper)

--- a/photon-lib/src/main/scala/com/linkedin/photon/ml/hyperparameter/estimators/kernels/Kernel.scala
+++ b/photon-lib/src/main/scala/com/linkedin/photon/ml/hyperparameter/estimators/kernels/Kernel.scala
@@ -60,11 +60,22 @@ trait Kernel {
   def getParams: DenseVector[Double]
 
   /**
-   * Returns the kernel parameter bounds
+   * Builds a kernel with initial settings, based on the observations
    *
-   * @return the kernel parameter bounds
+   * @param x the observed features
+   * @param y the observed labels
+   * @return the initial kernel
    */
-  def getParamBounds: (Double, Double)
+  def getInitialKernel(x: DenseMatrix[Double], y: DenseVector[Double]): Kernel
+
+  /**
+   * Computes the log likelihood of the kernel parameters
+   *
+   * @param x the observed features
+   * @param y the observed labels
+   * @return the log likelihood
+   */
+  def logLikelihood(x: DenseMatrix[Double], y: DenseVector[Double]): Double
 
   /**
    * If only one parameter value has been specified, builds a new vector with the single value repeated to fill all

--- a/photon-lib/src/main/scala/com/linkedin/photon/ml/hyperparameter/estimators/kernels/Matern52.scala
+++ b/photon-lib/src/main/scala/com/linkedin/photon/ml/hyperparameter/estimators/kernels/Matern52.scala
@@ -16,6 +16,7 @@ package com.linkedin.photon.ml.hyperparameter.estimators.kernels
 
 import breeze.linalg.{DenseMatrix, DenseVector}
 import breeze.numerics.{exp, sqrt}
+import breeze.stats.stddev
 
 /**
  * Implements the Matérn 5/2 covariance kernel.
@@ -34,15 +35,17 @@ import breeze.numerics.{exp, sqrt}
  * @see "Practical Bayesian Optimization of Machine Learning Algorithms" (PBO),
  *   https://papers.nips.cc/paper/4522-practical-bayesian-optimization-of-machine-learning-algorithms.pdf
  *
+ * @param amplitude the covariance amplitude
+ * @param noise the observation noise
  * @param lengthScale the length scale of the kernel. This controls the complexity of the kernel, or the degree to which
  *   it can vary within a given region of the function's domain. Higher values allow less variation, and lower values
  *   allow more.
- * @param lengthScaleBounds the bounds within which the length scale must fall
  */
 class Matern52(
-    lengthScale: DenseVector[Double] = DenseVector(1.0),
-    lengthScaleBounds: (Double, Double) = (1e-5, 1e5))
-  extends StationaryKernel(lengthScale, lengthScaleBounds) {
+    amplitude: Double = 1.0,
+    noise: Double = 1e-4,
+    lengthScale: DenseVector[Double] = DenseVector(1.0))
+  extends StationaryKernel(amplitude, noise, lengthScale) {
 
   /**
    * Computes the Matern 5/2 kernel function from the pairwise distances between points.
@@ -62,6 +65,18 @@ class Matern52(
    * @return the new kernel function
    */
   override def withParams(theta: DenseVector[Double]): Kernel = new Matern52(
-    lengthScale = exp(theta),
-    lengthScaleBounds = lengthScaleBounds)
+    amplitude = theta(0),
+    noise = theta(1),
+    lengthScale = theta.slice(2, theta.length))
+
+  /**
+   * Builds a kernel with initial settings, based on the observations
+   *
+   * @param x the observed features
+   * @param y the observed labels
+   * @return the initial kernel
+   */
+  override def getInitialKernel(x: DenseMatrix[Double], y: DenseVector[Double]): Kernel =
+    new Matern52(amplitude = stddev(y))
+
 }

--- a/photon-lib/src/main/scala/com/linkedin/photon/ml/hyperparameter/search/GaussianProcessSearch.scala
+++ b/photon-lib/src/main/scala/com/linkedin/photon/ml/hyperparameter/search/GaussianProcessSearch.scala
@@ -51,6 +51,7 @@ import com.linkedin.photon.ml.util.DoubleRange
  * @param discreteParams specifies the indices of parameters that should be treated as discrete values
  * @param candidatePoolSize the number of candidate points to draw at each iteration. Larger numbers give more precise
  *   results, but also incur higher computational cost.
+ * @param noisyTarget whether to include observation noise in the evaluation function model
  * @param seed the random seed value
  */
 class GaussianProcessSearch[T](
@@ -59,6 +60,7 @@ class GaussianProcessSearch[T](
     evaluator: Evaluator,
     discreteParams: Seq[Int] = Seq(),
     candidatePoolSize: Int = 250,
+    noisyTarget: Boolean = false,
     seed: Long = System.currentTimeMillis)
   extends RandomSearch[T](ranges, evaluationFunction, discreteParams, seed){
 
@@ -96,6 +98,7 @@ class GaussianProcessSearch[T](
         val estimator = new GaussianProcessEstimator(
           kernel = kernel,
           normalizeLabels = true,
+          noisyTarget = noisyTarget,
           predictionTransformation = Some(transformation),
           seed = seed)
 

--- a/photon-lib/src/test/scala/com/linkedin/photon/ml/hyperparameter/SliceSamplerTest.scala
+++ b/photon-lib/src/test/scala/com/linkedin/photon/ml/hyperparameter/SliceSamplerTest.scala
@@ -53,18 +53,18 @@ class SliceSamplerTest {
       testDistribution: RealDistribution): Unit = {
 
     def logp(x: DenseVector[Double]) = log(sourceDistribution.pdf(x(0)))
-    val sampler = new SliceSampler(logp, seed = seed)
+    val sampler = new SliceSampler(seed = seed)
 
     // Sampler burn-in
     val init = (0 until numBurnInSamples)
       .foldLeft(DenseVector(0.0)) { (currX, _) =>
-        sampler.draw(currX)
+        sampler.draw(currX, logp)
       }
 
     // Draw the real samples
     val (_, samples) = (0 until numSamples)
       .foldLeft((init, List.empty[Double])) { case ((currX, ls), _) =>
-        val x = sampler.draw(currX)
+        val x = sampler.draw(currX, logp)
         (x, ls :+ x(0))
       }
 

--- a/photon-lib/src/test/scala/com/linkedin/photon/ml/hyperparameter/estimators/GaussianProcessEstimatorTest.scala
+++ b/photon-lib/src/test/scala/com/linkedin/photon/ml/hyperparameter/estimators/GaussianProcessEstimatorTest.scala
@@ -31,55 +31,8 @@ import com.linkedin.photon.ml.hyperparameter.estimators.kernels.RBF
 class GaussianProcessEstimatorTest {
 
   private val seed = 0
-  private val estimator = new GaussianProcessEstimator(kernel = new RBF, seed = seed)
+  private val estimator = new GaussianProcessEstimator(kernel = new RBF(noise = 0.0), seed = seed)
   private val tol = 1e-7
-
-  /**
-   * Test data and results generated from reference implementation in scikit-learn
-   */
-  @DataProvider
-  def logLikelihoodProvider() =
-    Array(
-      Array(
-        DenseMatrix((1.0, 2.0), (3.0, 4.0)),
-        DenseVector(1.0, 0.0),
-        DenseVector(0.0),
-        -2.3378770946057106),
-      Array(
-        DenseMatrix((0.01388442, -0.45110147, -1.19551816,  0.67570627),
-          (0.03187212,  0.26128739,  0.09664432,  0.51288568),
-          (-0.1892356 , -0.37331575, -0.63040424, -0.91800163),
-          (-0.41915027, -0.63310943, -0.33619354, -1.54669407)),
-        DenseVector(1.97492722, -0.14301486, -0.17681195, -0.25272319),
-        DenseVector(0.0),
-        -5.6170735015658586),
-      Array(
-        DenseMatrix((-0.80210875,  1.01741171,  0.14846267,  1.15931876),
-          (1.40446672, -0.06407389, -0.06608613, -0.55499189),
-          (0.65113077, -0.53180815, -0.51595562,  0.08615354),
-          (0.33328126,  0.89654475,  0.99865134, -0.34262719)),
-        DenseVector(0.01540465,  0.93196629, -0.83929026,  0.39678908),
-        DenseVector(-1.0),
-        -4.5455256227943401),
-      Array(
-        DenseMatrix((0.32817291, -0.62739075, -0.15141223),
-          (-0.33697839, -0.49970007, -0.30290632),
-          (-0.49786383, 0.34232845, 0.11775675),
-          (-0.86069848, -0.60832783, 0.13357631)),
-        DenseVector(0.16192959, 0.86015525, -0.14415703, -0.46888909),
-        DenseVector(0.0),
-        -6.0655926036008498))
-
-  @Test(dataProvider = "logLikelihoodProvider")
-  def testLogLikelihood(
-      x: DenseMatrix[Double],
-      y: DenseVector[Double],
-      theta: DenseVector[Double],
-      expectedLikelihood: Double): Unit = {
-
-    val likelihood = estimator.logLikelihood(x, y, theta)
-    assertEquals(likelihood, expectedLikelihood, tol)
-  }
 
   @Test
   def testFit(): Unit = {
@@ -95,6 +48,6 @@ class GaussianProcessEstimatorTest {
     val (means, vars) = model.predict(x.toDenseMatrix.t)
 
     val mse = mean(pow(y - means, 2))
-    assertTrue(mse < 1.66)
+    assertTrue(mse < 1.922)
   }
 }

--- a/photon-lib/src/test/scala/com/linkedin/photon/ml/hyperparameter/estimators/GaussianProcessModelTest.scala
+++ b/photon-lib/src/test/scala/com/linkedin/photon/ml/hyperparameter/estimators/GaussianProcessModelTest.scala
@@ -27,7 +27,7 @@ import com.linkedin.photon.ml.test.Assertions.assertIterableEqualsWithTolerance
  */
 class GaussianProcessModelTest {
   private val tol = 1e-7
-  private val kernel = new RBF(lengthScale = DenseVector(1.0))
+  private val kernel = new RBF(noise = 0.0, lengthScale = DenseVector(1.0))
 
   /**
    * Test data and results generated from reference implementation in scikit-learn

--- a/photon-lib/src/test/scala/com/linkedin/photon/ml/hyperparameter/estimators/kernels/Matern52Test.scala
+++ b/photon-lib/src/test/scala/com/linkedin/photon/ml/hyperparameter/estimators/kernels/Matern52Test.scala
@@ -26,7 +26,7 @@ import com.linkedin.photon.ml.test.Assertions.assertIterableEqualsWithTolerance
 class Matern52Test {
 
   private val tol = 1e-7
-  private val kernel = new Matern52
+  private val kernel = new Matern52(noise = 0.0)
 
   /**
    * Test data and results generated from reference implementation in scikit-learn

--- a/photon-lib/src/test/scala/com/linkedin/photon/ml/hyperparameter/estimators/kernels/RBFTest.scala
+++ b/photon-lib/src/test/scala/com/linkedin/photon/ml/hyperparameter/estimators/kernels/RBFTest.scala
@@ -26,7 +26,7 @@ import com.linkedin.photon.ml.test.Assertions.assertIterableEqualsWithTolerance
 class RBFTest {
 
   private val tol = 1e-7
-  private val kernel = new RBF
+  private val kernel = new RBF(noise = 0.0)
 
   /**
    * Test data and results generated from reference implementation in scikit-learn

--- a/photon-lib/src/test/scala/com/linkedin/photon/ml/hyperparameter/estimators/kernels/StationaryKernelTest.scala
+++ b/photon-lib/src/test/scala/com/linkedin/photon/ml/hyperparameter/estimators/kernels/StationaryKernelTest.scala
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2018 LinkedIn Corp. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linkedin.photon.ml.hyperparameter.estimators.kernels
+
+import breeze.linalg.{DenseMatrix, DenseVector}
+import org.testng.Assert._
+import org.testng.annotations.{DataProvider, Test}
+
+import com.linkedin.photon.ml.test.Assertions.assertIterableEqualsWithTolerance
+
+/**
+ * Test cases for the StationaryKernel class
+ */
+class StationaryKernelTest {
+
+  private val tol = 1e-7
+  private val kernel = new RBF(noise = 0.0)
+
+  /**
+   * Test data and results generated from reference implementation in scikit-learn
+   */
+  @DataProvider
+  def logLikelihoodProvider() =
+    Array(
+      Array(
+        DenseMatrix((1.0, 2.0), (3.0, 4.0)),
+        DenseVector(1.0, 0.0),
+        DenseVector(1.0, 0.0, 1.0),
+        -2.3378770946057106),
+      Array(
+        DenseMatrix((0.01388442, -0.45110147, -1.19551816,  0.67570627),
+          (0.03187212,  0.26128739,  0.09664432,  0.51288568),
+          (-0.1892356 , -0.37331575, -0.63040424, -0.91800163),
+          (-0.41915027, -0.63310943, -0.33619354, -1.54669407)),
+        DenseVector(1.97492722, -0.14301486, -0.17681195, -0.25272319),
+        DenseVector(1.0, 0.0, 1.0),
+        -5.6170735015658586),
+      Array(
+        DenseMatrix((-0.80210875,  1.01741171,  0.14846267,  1.15931876),
+          (1.40446672, -0.06407389, -0.06608613, -0.55499189),
+          (0.65113077, -0.53180815, -0.51595562,  0.08615354),
+          (0.33328126,  0.89654475,  0.99865134, -0.34262719)),
+        DenseVector(0.01540465,  0.93196629, -0.83929026,  0.39678908),
+        DenseVector(1.0, 0.0, 0.36787944117144233),
+        -4.5455256227943401),
+      Array(
+        DenseMatrix((0.32817291, -0.62739075, -0.15141223),
+          (-0.33697839, -0.49970007, -0.30290632),
+          (-0.49786383, 0.34232845, 0.11775675),
+          (-0.86069848, -0.60832783, 0.13357631)),
+        DenseVector(0.16192959, 0.86015525, -0.14415703, -0.46888909),
+        DenseVector(1.0, 0.0, 1.0),
+        -6.0655926036008498))
+
+  @Test(dataProvider = "logLikelihoodProvider")
+  def testLogLikelihood(
+      x: DenseMatrix[Double],
+      y: DenseVector[Double],
+      theta: DenseVector[Double],
+      expectedLikelihood: Double): Unit = {
+
+    val likelihood = kernel.withParams(theta).logLikelihood(x, y)
+    assertEquals(likelihood, expectedLikelihood, tol)
+  }
+
+}


### PR DESCRIPTION
For simplicity, the initial implementation of the Bayesian hyperparameter tuning module assumed a noiseless target function, and a covariance amplitude of 1.0. This commit adds the capability to learn noisy target functions and covariance amplitude from the observations.

For background on the Bayesian hyperparamter tuning module, see:
[https://docs.google.com/document/d/158Kjt4mbZrXWYFpo-ZElZ7ZU5ug8ZU5FQmap4YIVeT0](https://docs.google.com/document/d/158Kjt4mbZrXWYFpo-ZElZ7ZU5ug8ZU5FQmap4YIVeT0)