### PR TITLE
Add computation of the full Hessian matrix for computing variance

### DIFF
--- a/photon-api/src/main/scala/com/linkedin/photon/ml/function/glm/DistributedGLMLossFunction.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/function/glm/DistributedGLMLossFunction.scala
@@ -123,16 +123,17 @@ protected[ml] class DistributedGLMLossFunction private (
       treeAggregateDepth)
 
   /**
-   * Compute an approximation of the Hessian diagonal over the given data for the given model coefficients.
+   * Compute the Hessian matrix over the given data for the given model coefficients.
    *
    * @param input The given data over which to compute the diagonal of the Hessian matrix
    * @param coefficients The model coefficients used to compute the diagonal of the Hessian matrix
-   * @return The computed diagonal of the Hessian matrix
+   * @return The computed Hessian matrix
    */
-  override protected[ml] def hessianDiagonal(
+  override protected[ml] def hessianMatrix(
       input: RDD[LabeledPoint],
-      coefficients: Broadcast[Vector[Double]]) : Vector[Double] =
-    HessianDiagonalAggregator.calcHessianDiagonal(input, coefficients, singlePointLossFunction, treeAggregateDepth)
+      coefficients: Broadcast[Vector[Double]]): DenseMatrix[Double] =
+    HessianMatrixAggregator.calcHessianMatrix(input, coefficients, singlePointLossFunction, treeAggregateDepth)
+
 }
 
 object DistributedGLMLossFunction {

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/function/glm/SingleNodeGLMLossFunction.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/function/glm/SingleNodeGLMLossFunction.scala
@@ -113,16 +113,17 @@ protected[ml] class SingleNodeGLMLossFunction private (singlePointLossFunction: 
       normalizationContext)
 
   /**
-   * Compute an approximation of the Hessian diagonal over the given data for the given model coefficients.
+   * Compute the Hessian matrix over the given data for the given model coefficients.
    *
    * @param input The given data over which to compute the diagonal of the Hessian matrix
    * @param coefficients The model coefficients used to compute the diagonal of the Hessian matrix
-   * @return The computed diagonal of the Hessian matrix
+   * @return The computed Hessian matrix
    */
-  override protected[ml] def hessianDiagonal(
+  override protected[ml] def hessianMatrix(
       input: Iterable[LabeledPoint],
-      coefficients: Vector[Double]) : Vector[Double] =
-    HessianDiagonalAggregator.calcHessianDiagonal(input, coefficients, singlePointLossFunction)
+      coefficients: Vector[Double]): DenseMatrix[Double] =
+    HessianMatrixAggregator.calcHessianMatrix(input, coefficients, singlePointLossFunction)
+
 }
 
 object SingleNodeGLMLossFunction {

--- a/photon-lib/src/integTest/scala/com/linkedin/photon/ml/optimization/IntegTestObjective.scala
+++ b/photon-lib/src/integTest/scala/com/linkedin/photon/ml/optimization/IntegTestObjective.scala
@@ -14,7 +14,7 @@
  */
 package com.linkedin.photon.ml.optimization
 
-import breeze.linalg.{Vector, sum}
+import breeze.linalg.{DenseMatrix, Vector, sum}
 import org.apache.spark.SparkContext
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.rdd.RDD
@@ -121,15 +121,12 @@ class IntegTestObjective(sc: SparkContext, treeAggregateDepth: Int) extends Obje
 
   /**
    * Unused, only implemented as part of TwiceDiffFunction.
-   *
-   * @param input The given data over which to compute the diagonal of the Hessian matrix
-   * @param coefficients The model coefficients used to compute the diagonal of the Hessian matrix
-   * @return The computed diagonal of the Hessian matrix
    */
-  override protected[ml] def hessianDiagonal(
+  override protected[ml] def hessianMatrix(
       input: RDD[LabeledPoint],
-      coefficients: Broadcast[Vector[Double]]): Vector[Double] =
-    Coefficients.initializeZeroCoefficients(coefficients.value.size).means
+      coefficients: Broadcast[Vector[Double]]): DenseMatrix[Double] =
+    DenseMatrix.zeros[Double](coefficients.value.length, coefficients.value.length)
+
 }
 
 object IntegTestObjective {

--- a/photon-lib/src/main/scala/com/linkedin/photon/ml/function/L2Regularization.scala
+++ b/photon-lib/src/main/scala/com/linkedin/photon/ml/function/L2Regularization.scala
@@ -14,7 +14,7 @@
  */
 package com.linkedin.photon.ml.function
 
-import breeze.linalg.Vector
+import breeze.linalg.{DenseMatrix, Vector}
 import org.apache.spark.broadcast.Broadcast
 
 import com.linkedin.photon.ml.normalization.NormalizationContext
@@ -165,8 +165,10 @@ trait L2RegularizationTwiceDiff extends TwiceDiffFunction with L2RegularizationD
    * @param coefficients The model coefficients used to compute the diagonal of the Hessian matrix
    * @return The computed diagonal of the Hessian matrix
    */
-  abstract override protected[ml] def hessianDiagonal(input: Data, coefficients: Coefficients): Vector[Double] =
-    super.hessianDiagonal(input, coefficients) + l2RegHessianDiagonal
+  abstract override protected[ml] def hessianMatrix(input: Data, coefficients: Coefficients): DenseMatrix[Double] = {
+    val hessianMatrix = super.hessianMatrix(input, coefficients)
+    hessianMatrix + l2RegHessianDiagonal * DenseMatrix.eye[Double](hessianMatrix.rows)
+  }
 
   /**
    * Compute the Hessian vector of the L2 regularization term for the given Hessian multiplication vector.

--- a/photon-lib/src/main/scala/com/linkedin/photon/ml/function/TwiceDiffFunction.scala
+++ b/photon-lib/src/main/scala/com/linkedin/photon/ml/function/TwiceDiffFunction.scala
@@ -14,7 +14,7 @@
  */
 package com.linkedin.photon.ml.function
 
-import breeze.linalg.Vector
+import breeze.linalg.{DenseMatrix, Vector}
 
 import com.linkedin.photon.ml.normalization.NormalizationContext
 import com.linkedin.photon.ml.util.BroadcastWrapper
@@ -42,11 +42,12 @@ trait TwiceDiffFunction extends DiffFunction {
     normalizationContext: BroadcastWrapper[NormalizationContext]): Vector[Double]
 
   /**
-   * Compute the diagonal of Hessian matrix of the function over the given data for the given model coefficients.
+   * Compute the Hessian matrix over the given data for the given model coefficients.
    *
    * @param input The given data over which to compute the diagonal of the Hessian matrix
    * @param coefficients The model coefficients used to compute the diagonal of the Hessian matrix
-   * @return The computed diagonal of the Hessian matrix
+   * @return The computed Hessian matrix
    */
-  protected[ml] def hessianDiagonal(input: Data, coefficients: Coefficients): Vector[Double]
+  protected[ml] def hessianMatrix(input: Data, coefficients: Coefficients): DenseMatrix[Double]
+
 }

--- a/photon-lib/src/main/scala/com/linkedin/photon/ml/hyperparameter/estimators/GaussianProcessModel.scala
+++ b/photon-lib/src/main/scala/com/linkedin/photon/ml/hyperparameter/estimators/GaussianProcessModel.scala
@@ -16,8 +16,8 @@ package com.linkedin.photon.ml.hyperparameter.estimators
 
 import breeze.linalg.{DenseMatrix, DenseVector, cholesky, diag}
 
-import com.linkedin.photon.ml.hyperparameter.Linalg.{choleskySolve, vectorMean}
 import com.linkedin.photon.ml.hyperparameter.estimators.kernels._
+import com.linkedin.photon.ml.util.Linalg.{choleskySolve, vectorMean}
 
 /**
  * Gaussian Process regression model that predicts mean and variance of response for new observations

--- a/photon-lib/src/main/scala/com/linkedin/photon/ml/hyperparameter/estimators/kernels/StationaryKernel.scala
+++ b/photon-lib/src/main/scala/com/linkedin/photon/ml/hyperparameter/estimators/kernels/StationaryKernel.scala
@@ -18,7 +18,7 @@ import breeze.linalg._
 import breeze.numerics.constants.Pi
 import breeze.numerics.{log, pow, sqrt}
 
-import com.linkedin.photon.ml.hyperparameter.Linalg.choleskySolve
+import com.linkedin.photon.ml.util.Linalg.choleskySolve
 
 /**
  * Base trait for stationary covariance kernel functions

--- a/photon-lib/src/test/scala/com/linkedin/photon/ml/optimization/TestObjective.scala
+++ b/photon-lib/src/test/scala/com/linkedin/photon/ml/optimization/TestObjective.scala
@@ -14,7 +14,7 @@
  */
 package com.linkedin.photon.ml.optimization
 
-import breeze.linalg.{Vector, sum}
+import breeze.linalg.{DenseMatrix, Vector, sum}
 
 import com.linkedin.photon.ml.data.LabeledPoint
 import com.linkedin.photon.ml.function.{ObjectiveFunction, TwiceDiffFunction}
@@ -112,10 +112,11 @@ class TestObjective extends ObjectiveFunction with TwiceDiffFunction {
   /**
    * Unused, only implemented as part of TwiceDiffFunction.
    */
-  override protected[ml] def hessianDiagonal(
-    input: Iterable[LabeledPoint],
-    coefficients: Vector[Double]): Vector[Double] =
-    Coefficients.initializeZeroCoefficients(coefficients.length).means
+  override protected[ml] def hessianMatrix(
+      input: Iterable[LabeledPoint],
+      coefficients: Vector[Double]): DenseMatrix[Double] =
+    DenseMatrix.zeros[Double](coefficients.length, coefficients.length)
+
 }
 
 object TestObjective {


### PR DESCRIPTION
Here we mean variance in the sense of the posterior model distribution. We approximate the model variance by inverting the final Hessian matrix. This replaces the approximation that used just the Hessian diagonal, because it introduced too much error. See:

https://docs.google.com/document/d/1MAAeSIefs66q0tM2dXu-sNBtBlzUzVCVO7KmhOwCtmQ/edit?usp=sharing
