### PR TITLE
Minor: Test changes

### DIFF
--- a/photon-api/build.gradle
+++ b/photon-api/build.gradle
@@ -28,3 +28,16 @@ dependencies {
   testRuntime("org.scalanlp:breeze$scalaSuffix:0.11.2")
   testRuntime("org.scalanlp:breeze-macros$scalaSuffix:0.11.2")
 }
+
+task testsJar(type: Jar, dependsOn: testClasses) {
+  classifier = 'test'
+  from sourceSets.test.output
+}
+
+configurations {
+  testOutput.extendsFrom(testCompile)
+}
+
+artifacts {
+  testOutput testsJar
+}

--- a/photon-api/build.gradle
+++ b/photon-api/build.gradle
@@ -22,6 +22,7 @@ dependencies {
   compile('com.linkedin.paldb:paldb:1.1.0')
 
   testCompile(project(":photon-test-utils$scalaSuffix"))
+  testCompile(project(path: ":photon-lib$scalaSuffix", configuration: 'testOutput'))
   testCompile("org.mockito:mockito-core:1.+")
 
   testRuntime("org.scalanlp:breeze$scalaSuffix:0.11.2")

--- a/photon-api/src/integTest/scala/com/linkedin/photon/ml/model/GameModelIntegTest.scala
+++ b/photon-api/src/integTest/scala/com/linkedin/photon/ml/model/GameModelIntegTest.scala
@@ -191,14 +191,15 @@ class GameModelIntegTest extends SparkTestUtils {
     val numFeaturesPerModel = Map(("fixedFeatures", 10), ("RE1Features", 10), ("RE2Features", 10))
 
     // Fixed effect model
-    val glm = new LogisticRegressionModel(Coefficients(numFeaturesPerModel("fixedFeatures"))(1,2,5)(11,21,51))
+    val glm = new LogisticRegressionModel(
+      CoefficientsTest.sparseCoefficients(numFeaturesPerModel("fixedFeatures"))(1,2,5)(11,21,51))
     val FEModel = new FixedEffectModel(sc.broadcast(glm), "fixedFeatures")
 
     // Random effect 1 has 2 items
     val numFeaturesRE1 = numFeaturesPerModel("RE1Features")
-    val RE1Item1 = Coefficients(numFeaturesRE1)(1,5,7)(111,511,911)
+    val RE1Item1 = CoefficientsTest.sparseCoefficients(numFeaturesRE1)(1,5,7)(111,511,911)
     val glmRE11: GeneralizedLinearModel = new LogisticRegressionModel(RE1Item1)
-    val RE1Item2 = Coefficients(numFeaturesRE1)(1,2)(112,512)
+    val RE1Item2 = CoefficientsTest.sparseCoefficients(numFeaturesRE1)(1,2)(112,512)
     val glmRE12: GeneralizedLinearModel = new LogisticRegressionModel(RE1Item2)
 
     val glmRE1RDD = sc.parallelize(List(("RE1Item1", glmRE11), ("RE1Item2", glmRE12)))
@@ -206,11 +207,11 @@ class GameModelIntegTest extends SparkTestUtils {
 
     // Random effect 2 has 3 items (of a different kind)
     val numFeaturesRE2 = numFeaturesPerModel("RE2Features")
-    val RE2Item1 = Coefficients(numFeaturesRE2)(3,4,6)(321,421,621)
+    val RE2Item1 = CoefficientsTest.sparseCoefficients(numFeaturesRE2)(3,4,6)(321,421,621)
     val glmRE21: GeneralizedLinearModel = new LogisticRegressionModel(RE2Item1)
-    val RE2Item2 = Coefficients(numFeaturesRE2)(4,5)(322,422)
+    val RE2Item2 = CoefficientsTest.sparseCoefficients(numFeaturesRE2)(4,5)(322,422)
     val glmRE22: GeneralizedLinearModel = new LogisticRegressionModel(RE2Item2)
-    val RE2Item3 = Coefficients(numFeaturesRE2)(2,7,8)(323,423,523)
+    val RE2Item3 = CoefficientsTest.sparseCoefficients(numFeaturesRE2)(2,7,8)(323,423,523)
     val glmRE23: GeneralizedLinearModel = new LogisticRegressionModel(RE2Item3)
 
     val glmRE2RDD = sc.parallelize(List(("RE2Item1", glmRE21), ("RE2Item2", glmRE22), ("RE2Item3", glmRE23)))
@@ -229,14 +230,15 @@ class GameModelIntegTest extends SparkTestUtils {
     val numFeaturesPerModel = Map(("fixedFeatures", 10), ("RE1Features", 10), ("RE2Features", 10))
 
     // Fixed effect model
-    val glm = new LogisticRegressionModel(Coefficients(numFeaturesPerModel("fixedFeatures"))(1,2,5)(11,21,51))
+    val glm = new LogisticRegressionModel(
+      CoefficientsTest.sparseCoefficients(numFeaturesPerModel("fixedFeatures"))(1,2,5)(11,21,51))
     val FEModel = new FixedEffectModel(sc.broadcast(glm), "fixedFeatures")
 
     // Random effect 1 has 2 items
     val numFeaturesRE1 = numFeaturesPerModel("RE1Features")
-    val RE1Item1 = Coefficients(numFeaturesRE1)(1,5,7)(111,511,911)
+    val RE1Item1 = CoefficientsTest.sparseCoefficients(numFeaturesRE1)(1,5,7)(111,511,911)
     val glmRE11: GeneralizedLinearModel = new LogisticRegressionModel(RE1Item1)
-    val RE1Item2 = Coefficients(numFeaturesRE1)(1,2)(112,512)
+    val RE1Item2 = CoefficientsTest.sparseCoefficients(numFeaturesRE1)(1,2)(112,512)
     val glmRE12: GeneralizedLinearModel = new LogisticRegressionModel(RE1Item2)
 
     val glmRE1RDD = sc.parallelize(List(("RE1Item1", glmRE11), ("RE1Item2", glmRE12)))
@@ -244,11 +246,11 @@ class GameModelIntegTest extends SparkTestUtils {
 
     // Random effect 2 has 3 items (of a different kind)
     val numFeaturesRE2 = numFeaturesPerModel("RE2Features")
-    val RE2Item1 = Coefficients(numFeaturesRE2)(3,4,6)(321,421,621)
+    val RE2Item1 = CoefficientsTest.sparseCoefficients(numFeaturesRE2)(3,4,6)(321,421,621)
     val glmRE21: GeneralizedLinearModel = new PoissonRegressionModel(RE2Item1)
-    val RE2Item2 = Coefficients(numFeaturesRE2)(4,5)(322,422)
+    val RE2Item2 = CoefficientsTest.sparseCoefficients(numFeaturesRE2)(4,5)(322,422)
     val glmRE22: GeneralizedLinearModel = new PoissonRegressionModel(RE2Item2)
-    val RE2Item3 = Coefficients(numFeaturesRE2)(2,7,8)(323,423,523)
+    val RE2Item3 = CoefficientsTest.sparseCoefficients(numFeaturesRE2)(2,7,8)(323,423,523)
     val glmRE23: GeneralizedLinearModel = new PoissonRegressionModel(RE2Item3)
 
     val glmRE2RDD = sc.parallelize(List(("RE2Item1", glmRE21), ("RE2Item2", glmRE22), ("RE2Item3", glmRE23)))

--- a/photon-api/src/integTest/scala/com/linkedin/photon/ml/model/RandomEffectModelIntegTest.scala
+++ b/photon-api/src/integTest/scala/com/linkedin/photon/ml/model/RandomEffectModelIntegTest.scala
@@ -85,9 +85,9 @@ class RandomEffectModelIntegTest extends SparkTestUtils {
     val numFeatures = 10
 
     // Random effect with 2 items of the same type.
-    val randomEffectItem1 = Coefficients(numFeatures)(1,5,7)(111,511,911)
+    val randomEffectItem1 = CoefficientsTest.sparseCoefficients(numFeatures)(1,5,7)(111,511,911)
     val glm1: GeneralizedLinearModel = new LogisticRegressionModel(randomEffectItem1)
-    val randomEffectItem2 = Coefficients(numFeatures)(1,2)(112,512)
+    val randomEffectItem2 = CoefficientsTest.sparseCoefficients(numFeatures)(1,2)(112,512)
     val glm2: GeneralizedLinearModel = new LogisticRegressionModel(randomEffectItem2)
     val randomEffectRDD = sc.parallelize(List(("RandomEffectItem1", glm1), ("RandomEffectItem2", glm2)))
 
@@ -104,9 +104,9 @@ class RandomEffectModelIntegTest extends SparkTestUtils {
     val numFeatures = 10
 
     // Random effect with 2 items of differing types.
-    val randomEffectItem1 = Coefficients(numFeatures)(1,5,7)(111,511,911)
+    val randomEffectItem1 = CoefficientsTest.sparseCoefficients(numFeatures)(1,5,7)(111,511,911)
     val glm1: GeneralizedLinearModel = new LogisticRegressionModel(randomEffectItem1)
-    val randomEffectItem2 = Coefficients(numFeatures)(1,2)(112,512)
+    val randomEffectItem2 = CoefficientsTest.sparseCoefficients(numFeatures)(1,2)(112,512)
     val glm2: GeneralizedLinearModel = new PoissonRegressionModel(randomEffectItem2)
     val randomEffectRDD = sc.parallelize(List(("RandomEffectItem1", glm1), ("RandomEffectItem2", glm2)))
 

--- a/photon-api/src/test/scala/com/linkedin/photon/ml/util/GameTestUtils.scala
+++ b/photon-api/src/test/scala/com/linkedin/photon/ml/util/GameTestUtils.scala
@@ -34,8 +34,6 @@ import com.linkedin.photon.ml.supervised.classification.LogisticRegressionModel
 import com.linkedin.photon.ml.supervised.model.GeneralizedLinearModel
 import com.linkedin.photon.ml.test.{SparkTestUtils, TestTemplateWithTmpDir}
 
-// TODO: No good way to import test sources between modules - sticking these test utils in main code.
-
 /**
  * A set of utility functions for GAME unit and integration tests.
  */

--- a/photon-client/build.gradle
+++ b/photon-client/build.gradle
@@ -26,6 +26,7 @@ dependencies {
   compile("com.github.scopt:scopt$scalaSuffix:3.5.0")
 
   testCompile(project(":photon-test-utils$scalaSuffix"))
+  testCompile(project(path: ":photon-lib$scalaSuffix", configuration: 'testOutput'))
   testCompile('com.linkedin.paldb:paldb:1.1.0')
   testCompile("org.mockito:mockito-core:1.+")
 

--- a/photon-client/build.gradle
+++ b/photon-client/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 
   testCompile(project(":photon-test-utils$scalaSuffix"))
   testCompile(project(path: ":photon-lib$scalaSuffix", configuration: 'testOutput'))
+  testCompile(project(path: ":photon-api$scalaSuffix", configuration: 'testOutput'))
   testCompile('com.linkedin.paldb:paldb:1.1.0')
   testCompile("org.mockito:mockito-core:1.+")
 

--- a/photon-client/src/integTest/scala/com/linkedin/photon/ml/data/avro/ModelProcessingUtilsIntegTest.scala
+++ b/photon-client/src/integTest/scala/com/linkedin/photon/ml/data/avro/ModelProcessingUtilsIntegTest.scala
@@ -91,17 +91,17 @@ class ModelProcessingUtilsIntegTest extends SparkTestUtils with TestTemplateWith
         .map(identity) // .map(identity) needed because of: https://issues.scala-lang.org/browse/SI-7005
 
     // Fixed effect model
-    val glm = new LogisticRegressionModel(Coefficients(numFeatures("fixed"))(1,2,5)(11,21,51))
+    val glm = new LogisticRegressionModel(CoefficientsTest.sparseCoefficients(numFeatures("fixed"))(1,2,5)(11,21,51))
     val fixedEffectModel = new FixedEffectModel(sc.broadcast(glm), "fixed")
 
-    val glmRE11 = LogisticRegressionModel(Coefficients(numFeatures("RE1"))(1, 5, 7)(111, 511, 911))
-    val glmRE12 = LogisticRegressionModel(Coefficients(numFeatures("RE1"))(1, 2)(112, 512))
+    val glmRE11 = LogisticRegressionModel(CoefficientsTest.sparseCoefficients(numFeatures("RE1"))(1, 5, 7)(111, 511, 911))
+    val glmRE12 = LogisticRegressionModel(CoefficientsTest.sparseCoefficients(numFeatures("RE1"))(1, 2)(112, 512))
     val glmRE1RDD = sc.parallelize(List(("RE1Item1", glmRE11), ("RE1Item2", glmRE12)))
     val RE1Model = new RandomEffectModel(glmRE1RDD, "randomEffectModel1", "RE1")
 
-    val glmRE21 = LogisticRegressionModel(Coefficients(numFeatures("RE2"))(3, 4, 6)(321, 421, 621))
-    val glmRE22 = LogisticRegressionModel(Coefficients(numFeatures("RE2"))(4, 5)(322, 422))
-    val glmRE23 = LogisticRegressionModel(Coefficients(numFeatures("RE2"))(2, 7, 8)(323, 423, 523))
+    val glmRE21 = LogisticRegressionModel(CoefficientsTest.sparseCoefficients(numFeatures("RE2"))(3, 4, 6)(321, 421, 621))
+    val glmRE22 = LogisticRegressionModel(CoefficientsTest.sparseCoefficients(numFeatures("RE2"))(4, 5)(322, 422))
+    val glmRE23 = LogisticRegressionModel(CoefficientsTest.sparseCoefficients(numFeatures("RE2"))(2, 7, 8)(323, 423, 523))
     val glmRE2RDD = sc.parallelize(List(("RE2Item1", glmRE21), ("RE2Item2", glmRE22), ("RE2Item3", glmRE23)))
     val RE2Model = new RandomEffectModel(glmRE2RDD, "randomEffectModel2", "RE2")
 

--- a/photon-lib/build.gradle
+++ b/photon-lib/build.gradle
@@ -36,3 +36,16 @@ dependencies {
 
   testRuntime("org.scalanlp:breeze$scalaSuffix:0.11.2")
 }
+
+task testsJar(type: Jar, dependsOn: testClasses) {
+  classifier = 'test'
+  from sourceSets.test.output
+}
+
+configurations {
+  testOutput.extendsFrom(testCompile)
+}
+
+artifacts {
+  testOutput testsJar
+}

--- a/photon-lib/src/main/scala/com/linkedin/photon/ml/model/Coefficients.scala
+++ b/photon-lib/src/main/scala/com/linkedin/photon/ml/model/Coefficients.scala
@@ -128,6 +128,7 @@ case class Coefficients(means: Vector[Double], variancesOption: Option[Vector[Do
 }
 
 protected[ml] object Coefficients {
+
   /**
    * Create a zero coefficient vector.
    *
@@ -136,33 +137,5 @@ protected[ml] object Coefficients {
    */
   def initializeZeroCoefficients(dimension: Int): Coefficients = {
     Coefficients(Vector.zeros[Double](dimension), variancesOption = None)
-  }
-
-  /**
-   * Constructor for an instance backed by a Breeze DenseVector.
-   *
-   * @param values The coefficients values
-   * @return An instance of Coefficients
-   */
-  def apply(values: Double*): Coefficients =
-    Coefficients(new DenseVector[Double](Array[Double](values: _*)))
-
-  /**
-   * Constructor for an instance backed by a Breeze SparseVector.
-   *
-   * @note The non-zeros must be sorted in order of increasing indices!!!
-   * @param length The Coefficients dimension ( (1,0,0,4) has dimension 4)
-   * @param indices The indices of the non-zeros
-   * @param nnz The non-zero values
-   * @return An instance of Coefficients
-   */
-  def apply(length: Int)(indices: Int*)(nnz: Double*): Coefficients = {
-
-    require(0 < length)
-    require(indices.length == nnz.length)
-    require(indices.sorted == indices)
-    // TODO: check for duplicates?
-
-    Coefficients(new SparseVector[Double](Array[Int](indices: _*), Array[Double](nnz: _*), length))
   }
 }

--- a/photon-lib/src/test/scala/com/linkedin/photon/ml/model/CoefficientsTest.scala
+++ b/photon-lib/src/test/scala/com/linkedin/photon/ml/model/CoefficientsTest.scala
@@ -43,11 +43,21 @@ class CoefficientsTest {
   @Test
   def testEquals(): Unit = {
 
-    assertFalse(Coefficients(1,0,3,0) == Coefficients(1,0,2,0))
-    assertTrue(Coefficients(1,0,3,0) == Coefficients(1,0,3,0))
-    assertFalse(Coefficients(4)(0,2)(1,3) == Coefficients(5)(0,2)(1,3))
-    assertTrue(Coefficients(4)(0,2)(1,3) == Coefficients(4)(0,2)(1,3))
-    assertFalse(Coefficients(1,0,3,0) == Coefficients(4)(0,2)(1,3))
+    val denseCoefficients1 = denseCoefficients(1,0,2,0)
+    val denseCoefficients2 = denseCoefficients(1,0,3,0)
+    val sparseCoefficients1 = sparseCoefficients(4)(0,2)(1,3)
+    val sparseCoefficients2 = sparseCoefficients(4)(0,2)(1,2)
+
+    assertFalse(denseCoefficients1 == denseCoefficients2)
+    assertTrue(denseCoefficients1 == denseCoefficients1)
+    assertTrue(denseCoefficients2 == denseCoefficients2)
+
+    assertFalse(sparseCoefficients1 == sparseCoefficients2)
+    assertTrue(sparseCoefficients1 == sparseCoefficients1)
+    assertTrue(sparseCoefficients2 == sparseCoefficients2)
+
+    assertFalse(denseCoefficients1 == sparseCoefficients1)
+    assertFalse(sparseCoefficients2 == denseCoefficients2)
   }
 
   @Test
@@ -65,7 +75,7 @@ object CoefficientsTest {
    * @param values
    * @return
    */
-  private def dense(values: Double*) = new DenseVector[Double](Array[Double](values: _*))
+  def dense(values: Double*) = new DenseVector[Double](Array[Double](values: _*))
 
   /**
    *
@@ -74,6 +84,22 @@ object CoefficientsTest {
    * @param nnz
    * @return
    */
-  private def sparse(length: Int)(indices: Int*)(nnz: Double*) =
+  def sparse(length: Int)(indices: Int*)(nnz: Double*) =
     new SparseVector[Double](Array[Int](indices: _*), Array[Double](nnz: _*), length)
+
+  /**
+   *
+   * @param values
+   * @return
+   */
+  def denseCoefficients(values: Double*) = Coefficients(dense(values: _*))
+
+  /**
+   *
+   * @param length
+   * @param indices
+   * @param nnz
+   * @return
+   */
+  def sparseCoefficients(length: Int)(indices: Int*)(nnz: Double*) = Coefficients(sparse(length)(indices: _*)(nnz: _*))
 }


### PR DESCRIPTION
- Generate test source jars
- Mirror `client` > `api` > `lib` dependency for test source jars
- Remove some `apply` methods from `Coefficients` companion object that were only used by tests
- Replace above methods with calls to identical methods in the `CoefficientsTest` unit test class