### PR TITLE
Use zipWithUniqueId instead of zipWithIndex

### DIFF
--- a/photon-api/src/main/scala/com/linkedin/photon/ml/data/GameConverters.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/data/GameConverters.scala
@@ -52,7 +52,7 @@ object GameConverters {
 
     data
       .rdd
-      .zipWithIndex
+      .zipWithUniqueId
       .map { case (row, index) =>
         (index, getGameDatumFromRow(row, featureShards, idTagSet, isResponseRequired, inputColumnsNamesBroadcast))
       }

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/estimators/GameEstimator.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/estimators/GameEstimator.scala
@@ -478,9 +478,12 @@ class GameEstimator(val sc: SparkContext, implicit val logger: Logger) extends P
             .setName(s"Fixed Effect Data Set: $coordinateId")
             .persistRDD(StorageLevel.INFREQUENT_REUSE_RDD_STORAGE_LEVEL)
 
-          logger.debug(
-            s"Summary of fixed effect data set with coordinate ID '$coordinateId':\n" +
-              s"${fixedEffectDataSet.toSummaryString}")
+          if (logger.isDebugEnabled) {
+            // Eval this only in debug mode, because the call to "toSummaryString" can be very expensive
+            logger.debug(
+              s"Summary of fixed effect data set with coordinate ID '$coordinateId':\n" +
+                s"${fixedEffectDataSet.toSummaryString}")
+          }
 
           (coordinateId, fixedEffectDataSet)
 
@@ -522,9 +525,12 @@ class GameEstimator(val sc: SparkContext, implicit val logger: Logger) extends P
               randomEffectDataSetInProjectedSpace
           }
 
-          logger.debug(
-            s"Summary of random effect data set with coordinate ID $coordinateId:\n" +
-              s"${randomEffectDataSet.toSummaryString}\n")
+          if (logger.isDebugEnabled) {
+            // Eval this only in debug mode, because the call to "toSummaryString" can be very expensive
+            logger.debug(
+              s"Summary of random effect data set with coordinate ID $coordinateId:\n" +
+                s"${randomEffectDataSet.toSummaryString}\n")
+          }
 
           partitioner.unpersistBroadcast()
 


### PR DESCRIPTION
Generating unique ids is much less expensive since it doesn't trigger a job, and we don't need these ids to be sequential.

Also, guard the evaluation of expensive debugging information with a condition that checks whether we're actually in debug log level.