### PR TITLE
Fix bug which allowed one column to be read for multiple purposes

### DIFF
--- a/photon-api/src/main/scala/com/linkedin/photon/ml/data/GameConverters.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/data/GameConverters.scala
@@ -48,6 +48,13 @@ object GameConverters {
       isResponseRequired: Boolean,
       inputColumnsNames: InputColumnsNames = InputColumnsNames()): RDD[(UniqueSampleId, GameDatum)] = {
 
+    val colNamesSet = inputColumnsNames.getNames
+
+    // Cannot use response, offset, weight, or uid fields as fields for grouping random effects or queries
+    require(
+      idTagSet.intersect(colNamesSet).isEmpty,
+      s"Cannot use required columns (${colNamesSet.mkString(", ")}) for random effect/validation grouping.")
+
     val inputColumnsNamesBroadcast = data.sqlContext.sparkContext.broadcast(inputColumnsNames)
 
     data

--- a/photon-client/src/main/scala/com/linkedin/photon/ml/io/scopt/ScoptParserHelpers.scala
+++ b/photon-client/src/main/scala/com/linkedin/photon/ml/io/scopt/ScoptParserHelpers.scala
@@ -133,10 +133,14 @@ object ScoptParserHelpers extends Logging {
    * @param input A [[Map]] of (default column name -> new column name)
    * @return A new [[InputColumnsNames]] instance
    */
-  def parseInputColumnNames(input: Map[String, String]): InputColumnsNames =
-    input.foldLeft(InputColumnsNames()) { case (columns, (origColName, newColName)) =>
-      columns.updated(InputColumnsNames.withName(origColName), newColName)
+  def parseInputColumnNames(input: Map[String, String]): InputColumnsNames = {
+
+    val columnsMap = input.map {
+      case (origColName, newColName) => (InputColumnsNames.withName(origColName), newColName)
     }
+
+    InputColumnsNames(columnsMap)
+  }
 
   /**
    * Create a single [[FeatureShardConfiguration]] from a [[Map]] of (feature shard arg -> feature shard value), and

--- a/photon-client/src/test/scala/com/linkedin/photon/ml/cli/game/training/GameTrainingDriverTest.scala
+++ b/photon-client/src/test/scala/com/linkedin/photon/ml/cli/game/training/GameTrainingDriverTest.scala
@@ -21,10 +21,10 @@ import org.testng.Assert._
 import org.testng.annotations.{DataProvider, Test}
 
 import com.linkedin.photon.ml.{DataValidationType, HyperparameterTuningMode, TaskType}
-import com.linkedin.photon.ml.data.{CoordinateDataConfiguration, InputColumnsNames}
+import com.linkedin.photon.ml.data.{CoordinateDataConfiguration, InputColumnsNames, RandomEffectDataConfiguration}
 import com.linkedin.photon.ml.estimators.GameEstimator
 import com.linkedin.photon.ml.evaluation.{Evaluator, EvaluatorType}
-import com.linkedin.photon.ml.io.{CoordinateConfiguration, FeatureShardConfiguration, ModelOutputMode}
+import com.linkedin.photon.ml.io.{CoordinateConfiguration, FeatureShardConfiguration, ModelOutputMode, RandomEffectCoordinateConfiguration}
 import com.linkedin.photon.ml.io.ModelOutputMode.ModelOutputMode
 import com.linkedin.photon.ml.model.GameModel
 import com.linkedin.photon.ml.normalization.NormalizationType
@@ -138,12 +138,15 @@ class GameTrainingDriverTest {
     val mockCoordinateConfig = mock(classOf[CoordinateConfiguration])
     val mockBadDataConfig = mock(classOf[CoordinateDataConfiguration])
     val mockBadCoordinateConfig = mock(classOf[CoordinateConfiguration])
+    val mockRECoordinateConfig = mock(classOf[RandomEffectCoordinateConfiguration])
+    val mockREDataConfig = mock(classOf[RandomEffectDataConfiguration])
 
     val coordinateId1 = "id1"
     val coordinateId2 = "id2"
     val featureShardId = "id"
     val missingCoordinateId = "missing"
     val missingFeatureShardId = "missing"
+    val badREType = "uid"
     val updateSequence1 = Seq(coordinateId1, coordinateId2)
     val updateSequence2 = Seq(coordinateId1)
     val updateSequence3 = Seq(coordinateId2)
@@ -156,6 +159,9 @@ class GameTrainingDriverTest {
     doReturn(featureShardId).when(mockDataConfig).featureShardId
     doReturn(mockBadDataConfig).when(mockBadCoordinateConfig).dataConfiguration
     doReturn(missingFeatureShardId).when(mockBadDataConfig).featureShardId
+    doReturn(mockREDataConfig).when(mockRECoordinateConfig).dataConfiguration
+    doReturn(featureShardId).when(mockREDataConfig).featureShardId
+    doReturn(badREType).when(mockREDataConfig).randomEffectType
 
     val validParamMap = ParamMap
       .empty
@@ -227,6 +233,11 @@ class GameTrainingDriverTest {
         validParamMap
           .copy
           .put(GameTrainingDriver.coordinateConfigurations, Map((coordinateId1, mockBadCoordinateConfig)))),
+      // Random effect coordinate configuration with invalid random effect field
+      Array(
+        validParamMap
+          .copy
+          .put(GameTrainingDriver.coordinateConfigurations, Map((coordinateId1, mockRECoordinateConfig)))),
       // No intercepts for standardization
       Array(validParamMap.copy.put(GameTrainingDriver.normalization, NormalizationType.STANDARDIZATION)),
       // No iterations for hyperparameter tuning

--- a/photon-client/src/test/scala/com/linkedin/photon/ml/io/scopt/ScoptParserHelpersTest.scala
+++ b/photon-client/src/test/scala/com/linkedin/photon/ml/io/scopt/ScoptParserHelpersTest.scala
@@ -331,17 +331,13 @@ class ScoptParserHelpersTest {
   @Test
   def testInputColumnNamesToString(): Unit = {
 
-    val columnNamesMap = InputColumnsNames.all.zipWithIndex.toMap.mapValues(_.toString)
-    val inputColumnsNames = InputColumnsNames()
+    val columnNamesMap = InputColumnsNames.all.map(col => (col, s"___${col.toString}")).toMap
+    val inputColumnsNames = InputColumnsNames(columnNamesMap)
     val expected = columnNamesMap
       .map { case (column, name) =>
         s"$column${ScoptParserHelpers.KV_DELIMITER}$name"
       }
       .mkString(ScoptParserHelpers.LIST_DELIMITER)
-
-    columnNamesMap.foreach { case (column, name) =>
-      inputColumnsNames.updated(column, name)
-    }
 
     assertEquals(ScoptParserHelpers.inputColumnNamesToString(inputColumnsNames), expected)
   }

--- a/photon-client/src/test/scala/com/linkedin/photon/ml/io/scopt/game/ScoptGameScoringParametersParserTest.scala
+++ b/photon-client/src/test/scala/com/linkedin/photon/ml/io/scopt/game/ScoptGameScoringParametersParserTest.scala
@@ -41,8 +41,7 @@ class ScoptGameScoringParametersParserTest {
     val inputDateRange = DateRange.fromDateString("20170101-20181231")
     val offHeapIndexMapPath = new Path("/some/off/heap/path")
     val offHeapIndexMapPartitions = 1
-    val customColumnsNames = InputColumnsNames()
-    InputColumnsNames.all.foreach(colName => customColumnsNames.updated(colName, s"___$colName"))
+    val customColumnsNames = InputColumnsNames(InputColumnsNames.all.map(col => (col, s"___${col.toString}")).toMap)
     val evaluators = Seq(AUC, RMSE)
     val outputPath = new Path("/some/output/path")
     val overrideOutputDir = true

--- a/photon-client/src/test/scala/com/linkedin/photon/ml/io/scopt/game/ScoptGameTrainingParametersParserTest.scala
+++ b/photon-client/src/test/scala/com/linkedin/photon/ml/io/scopt/game/ScoptGameTrainingParametersParserTest.scala
@@ -45,8 +45,7 @@ class ScoptGameTrainingParametersParserTest {
     val inputDateRange = DateRange.fromDateString("20170101-20181231")
     val offHeapIndexMapPath = new Path("/some/off/heap/path")
     val offHeapIndexMapPartitions = 1
-    val customColumnsNames = InputColumnsNames()
-    InputColumnsNames.all.foreach(colName => customColumnsNames.updated(colName, s"___$colName"))
+    val customColumnsNames = InputColumnsNames(InputColumnsNames.all.map(col => (col, s"___${col.toString}")).toMap)
     val evaluators = Seq(AUC, RMSE)
     val outputPath = new Path("/some/output/path")
     val overrideOutputDir = true


### PR DESCRIPTION
- Multiple columns in `InputColumnNames` could have the same name
- Columns used for grouping of random effects could have the same names as columns in `InputColumnNames`