### PR TITLE
Add String to acceptable types for AvroDataWriter

### DIFF
--- a/photon-client/src/integTest/scala/com/linkedin/photon/ml/data/avro/AvroDataWriterIntegTest.scala
+++ b/photon-client/src/integTest/scala/com/linkedin/photon/ml/data/avro/AvroDataWriterIntegTest.scala
@@ -22,7 +22,7 @@ import com.linkedin.photon.ml.io.FeatureShardConfiguration
 import com.linkedin.photon.ml.test.{SparkTestUtils, TestTemplateWithTmpDir}
 
 /**
- * Integeration test for AvroDataWriter
+ * Integration tests for [[AvroDataWriter]].
  */
 class AvroDataWriterIntegTest extends SparkTestUtils with TestTemplateWithTmpDir {
 

--- a/photon-client/src/main/scala/com/linkedin/photon/ml/data/avro/AvroDataWriter.scala
+++ b/photon-client/src/main/scala/com/linkedin/photon/ml/data/avro/AvroDataWriter.scala
@@ -112,10 +112,18 @@ object AvroDataWriter {
   protected[data] def getValueAsDouble(row: Row, fieldName: String): Double = {
 
     row.getAs[Any](fieldName) match {
-      case null => DEFAULTS
-        .getOrElse(fieldName, throw new IllegalArgumentException(s"Unsupported null for fieldName $fieldName"))
-      case n: Number => n.doubleValue()
-      case b: Boolean => if (b) 1.0D else 0.0D
+      case null =>
+        DEFAULTS.getOrElse(fieldName, throw new IllegalArgumentException(s"Unsupported null for fieldName $fieldName"))
+
+      case n: Number =>
+        n.doubleValue
+
+      case s: String =>
+        s.toDouble
+
+      case b: Boolean =>
+        if (b) 1.0D else 0.0D
+
       case _ =>
         throw new IllegalArgumentException(s"Unsupported data type")
     }

--- a/photon-client/src/test/scala/com/linkedin/photon/ml/data/avro/AvroDataWriterTest.scala
+++ b/photon-client/src/test/scala/com/linkedin/photon/ml/data/avro/AvroDataWriterTest.scala
@@ -26,22 +26,25 @@ import org.testng.annotations.{DataProvider, Test}
 import com.linkedin.photon.ml.Constants.DELIMITER
 import com.linkedin.photon.ml.index.{DefaultIndexMap, IndexMap}
 
+/**
+ * Unit tests for [[AvroDataWriter]].
+ */
 class AvroDataWriterTest {
 
   @DataProvider
   def rowsProvider(): Array[Array[GenericRowWithSchema]] = {
 
     val vector = Vectors.sparse(3, Array(0, 2), Array(0.0, 1.0))
-    val arrays = Array(
+    val arrays = Array[Array[Any]](
       Array(1, 0, 1, vector),
       Array(true, false, true, vector),
       Array(1.0f, 0.0f, 1.0f, vector),
       Array(1L, 0L, 1L, vector),
-      Array(1.0D, 0.0D, 1.0D, vector)
-    )
-    val types = Array(IntegerType, BooleanType, FloatType, LongType, DoubleType)
+      Array(1.0D, 0.0D, 1.0D, vector),
+      Array("1", "0.0", "1E0", vector))
+    val types = Array(IntegerType, BooleanType, FloatType, LongType, DoubleType, StringType)
 
-    // build a row with null fields for offset and weight
+    // Build a row with null fields for offset and weight
     val nullArray = Array(1.0D, null, null, vector)
     val nullSchema = new StructType(
       Array(
@@ -51,15 +54,20 @@ class AvroDataWriterTest {
         StructField("features", new VectorUDT)))
     val nullRow = new GenericRowWithSchema(nullArray, nullSchema)
 
-    arrays.zip(types).map { case (a, t) =>
-      val schema = new StructType(
-        Array(
-          StructField("response", t),
-          StructField("offset", t),
-          StructField("weight", t),
-          StructField("features", new VectorUDT)))
-      Array(new GenericRowWithSchema(a, schema))
-    } :+ Array(nullRow)
+    val rows = arrays
+      .zip(types)
+      .map { case (a, t) =>
+        val schema = new StructType(
+          Array(
+            StructField("response", t),
+            StructField("offset", t),
+            StructField("weight", t),
+            StructField("features", new VectorUDT)))
+
+        Array(new GenericRowWithSchema(a, schema))
+      }
+
+    rows :+ Array(nullRow)
   }
 
   @Test(dataProvider = "rowsProvider")


### PR DESCRIPTION
This makes it compatible with `AvroDataReader` again - currently the `AvroDataReader` will accept a label/offset/weight column that has a value stored as a `String`, but the `AvroDataWriter` will throw an error when writing out the resulting `DataFrame`.