### PR TITLE
Add new threshold parameter for training random effects

### DIFF
--- a/photon-api/src/integTest/scala/com/linkedin/photon/ml/data/RandomEffectDataSetIntegTest.scala
+++ b/photon-api/src/integTest/scala/com/linkedin/photon/ml/data/RandomEffectDataSetIntegTest.scala
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2017 LinkedIn Corp. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linkedin.photon.ml.data
+
+import breeze.linalg.{DenseVector, Vector}
+import org.testng.Assert._
+import org.testng.annotations.{DataProvider, Test}
+
+import com.linkedin.photon.ml.Types.{FeatureShardId, REId, UniqueSampleId}
+import com.linkedin.photon.ml.test.SparkTestUtils
+import com.linkedin.photon.ml.util.LongHashPartitioner
+
+/**
+ * Integration tests for [[RandomEffectDataSet]].
+ */
+class RandomEffectDataSetIntegTest extends SparkTestUtils {
+
+  import RandomEffectDataSetIntegTest._
+
+  @DataProvider
+  def rawDataProvider(): Array[Array[Any]] = {
+
+    val dummyResponse: Double = 1.0
+    val dummyOffset: Option[Double] = None
+    val dummyWeight: Option[Double] = None
+    val dummyFeatureVector: Vector[Double] = DenseVector(1, 2, 3)
+    val dummyFeatures: Map[FeatureShardId, Vector[Double]] = Map(FEATURE_SHARD_NAME -> dummyFeatureVector)
+
+    val reId1: REId = "1"
+    val reId2: REId = "2"
+    val reId3: REId = "3"
+    // Counts: 1 * reId1, 2 * reId2, 3 * reId3
+    val dataIds: Seq[REId] = Seq(reId1, reId2, reId2, reId3, reId3, reId3)
+
+    val data: Seq[(UniqueSampleId, GameDatum)] = dataIds
+      .zipWithIndex
+      .map { case (reId, uid) =>
+        val datum = new GameDatum(
+          dummyResponse,
+          dummyOffset,
+          dummyWeight,
+          dummyFeatures,
+          Map(RANDOM_EFFECT_TYPE -> reId))
+
+        (uid.toLong, datum)
+      }
+    val partitionMap: Map[REId, Int] = Map(reId1 -> NUM_PARTITIONS, reId2 -> NUM_PARTITIONS, reId3 -> NUM_PARTITIONS)
+
+    Array(
+      Array(data, partitionMap, 1, 3L),
+      Array(data, partitionMap, 2, 2L),
+      Array(data, partitionMap, 3, 1L))
+  }
+
+  /**
+   * Test that the random effects with less data than the active data lower bound will be dropped.
+   *
+   * @param data Raw training data
+   * @param partitionMap Raw map to build [[RandomEffectDataSetPartitioner]]
+   * @param activeDataLowerBound Threshold for active data
+   * @param expectedUniqueRandomEffects Expected number of random effects which have data exceeding the threshold
+   */
+  @Test(dataProvider = "rawDataProvider")
+  def testActiveDataLowerBound(
+      data: Seq[(UniqueSampleId, GameDatum)],
+      partitionMap: Map[REId, Int],
+      activeDataLowerBound: Int,
+      expectedUniqueRandomEffects: Long): Unit = sparkTest("testActiveDataLowerBound") {
+
+    val rdd = sc.parallelize(data, NUM_PARTITIONS).partitionBy(new LongHashPartitioner(NUM_PARTITIONS))
+    val randomEffectDataConfig = RandomEffectDataConfiguration(
+      RANDOM_EFFECT_TYPE,
+      FEATURE_SHARD_NAME,
+      NUM_PARTITIONS,
+      Some(activeDataLowerBound))
+    val partitioner = new RandomEffectDataSetPartitioner(sc.broadcast(partitionMap))
+
+    val randomEffectDataSet = RandomEffectDataSet(rdd, randomEffectDataConfig, partitioner)
+    val numUniqueRandomEffects = randomEffectDataSet.activeData.keys.count()
+
+    assertEquals(numUniqueRandomEffects, expectedUniqueRandomEffects)
+  }
+}
+
+object RandomEffectDataSetIntegTest {
+
+  private val NUM_PARTITIONS = 1
+  private val FEATURE_SHARD_NAME = "shard"
+  private val RANDOM_EFFECT_TYPE = "reId"
+}

--- a/photon-api/src/integTest/scala/com/linkedin/photon/ml/estimators/GameEstimatorIntegTest.scala
+++ b/photon-api/src/integTest/scala/com/linkedin/photon/ml/estimators/GameEstimatorIntegTest.scala
@@ -421,9 +421,9 @@ object GameEstimatorIntegTest {
    */
   private val coordinateDataConfigurations = Map(
     "global" -> FixedEffectDataConfiguration("shard1", 2),
-    "per-user" -> RandomEffectDataConfiguration("userId", "shard2", 2, None, None, None, IndexMapProjection),
-    "per-song" -> RandomEffectDataConfiguration("songId", "shard3", 2, None, None, None, IndexMapProjection),
-    "per-artist" -> RandomEffectDataConfiguration("artistId", "shard3", 2, None, None, None, RandomProjection(2)))
+    "per-user" -> RandomEffectDataConfiguration("userId", "shard2", 2),
+    "per-song" -> RandomEffectDataConfiguration("songId", "shard3", 2),
+    "per-artist" -> RandomEffectDataConfiguration("artistId", "shard3", 2, projectorType = RandomProjection(2)))
   private val idTagSet = Set("userId", "songId", "artistId")
 
   /**

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/data/CoordinateDataConfiguration.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/data/CoordinateDataConfiguration.scala
@@ -45,6 +45,8 @@ case class FixedEffectDataConfiguration(
  * @param randomEffectType The corresponding random effect type of the data set
  * @param featureShardId Key of the feature shard used to generate the data set
  * @param minNumPartitions Minimum number of data partitions
+ * @param numActiveDataPointsLowerBound The lower bound on the number of samples required to train a random effect model
+ *                                      for an entity. If this bound is not met, the data is discarded.
  * @param numActiveDataPointsUpperBound The upper bound on the number of samples to keep (via reservoir sampling) as
  *                                      "active" for each individual-id level local data set. The remaining samples that
  *                                      meet the numPassiveDataPointsToKeepLowerBound as discussed below will be kept as
@@ -67,6 +69,7 @@ case class RandomEffectDataConfiguration(
     randomEffectType: REType,
     featureShardId: FeatureShardId,
     minNumPartitions: Int = 1,
+    numActiveDataPointsLowerBound: Option[Int] = None,
     numActiveDataPointsUpperBound: Option[Int] = None,
     numPassiveDataPointsLowerBound: Option[Int] = None,
     numFeaturesToSamplesRatioUpperBound: Option[Double] = None,
@@ -74,12 +77,18 @@ case class RandomEffectDataConfiguration(
   extends CoordinateDataConfiguration {
 
   require(
+    numActiveDataPointsLowerBound.forall(_ > 0),
+    s"Active data lower bound must be greater than 0: ${numActiveDataPointsLowerBound.get}")
+  require(
     numActiveDataPointsUpperBound.forall(_ > 0),
-    s"Active data upper bound must be greater than 0: $numActiveDataPointsUpperBound")
+    s"Active data upper bound must be greater than 0: ${numActiveDataPointsUpperBound.get}")
+  require(
+    numActiveDataPointsLowerBound.forall(_ <= numActiveDataPointsUpperBound.getOrElse(Int.MaxValue)),
+    s"Active data lower bound must be less than active data upper bound (${numActiveDataPointsUpperBound.get})")
   require(
     numPassiveDataPointsLowerBound.forall(_ > 0),
-    s"Passive data lower bound must be greater than 0: $numPassiveDataPointsLowerBound")
+    s"Passive data lower bound must be greater than 0: ${numPassiveDataPointsLowerBound.get}")
   require(
     numFeaturesToSamplesRatioUpperBound.forall(_ > 0),
-    s"Features to samples ratio must be greater than 0: $numFeaturesToSamplesRatioUpperBound")
+    s"Features to samples ratio must be greater than 0: ${numFeaturesToSamplesRatioUpperBound.get}")
 }

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/data/RandomEffectDataSet.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/data/RandomEffectDataSet.scala
@@ -239,14 +239,19 @@ object RandomEffectDataSet {
   protected[ml] def apply(
       gameDataSet: RDD[(UniqueSampleId, GameDatum)],
       randomEffectDataConfiguration: RandomEffectDataConfiguration,
-      randomEffectPartitioner: Partitioner): RandomEffectDataSet = {
+      randomEffectPartitioner: Partitioner,
+      existingModelKeysRddOpt: Option[RDD[REId]]): RandomEffectDataSet = {
 
     val randomEffectType = randomEffectDataConfiguration.randomEffectType
     val featureShardId = randomEffectDataConfiguration.featureShardId
 
     val gameDataPartitioner = gameDataSet.partitioner.get
 
-    val rawActiveData = generateActiveData(gameDataSet, randomEffectDataConfiguration, randomEffectPartitioner)
+    val rawActiveData = generateActiveData(
+      gameDataSet,
+      randomEffectDataConfiguration,
+      randomEffectPartitioner,
+      existingModelKeysRddOpt)
     val activeData = featureSelectionOnActiveData(rawActiveData, randomEffectDataConfiguration)
       .setName("Active data")
       .persist(StorageLevel.INFREQUENT_REUSE_RDD_STORAGE_LEVEL)
@@ -289,7 +294,8 @@ object RandomEffectDataSet {
   private def generateActiveData(
       gameDataSet: RDD[(UniqueSampleId, GameDatum)],
       randomEffectDataConfiguration: RandomEffectDataConfiguration,
-      randomEffectPartitioner: Partitioner): RDD[(REId, LocalDataSet)] = {
+      randomEffectPartitioner: Partitioner,
+      existingModelKeysRddOpt: Option[RDD[REId]]): RDD[(REId, LocalDataSet)] = {
 
     val randomEffectType = randomEffectDataConfiguration.randomEffectType
     val featureShardId = randomEffectDataConfiguration.featureShardId
@@ -314,8 +320,22 @@ object RandomEffectDataSet {
     randomEffectDataConfiguration
       .numActiveDataPointsLowerBound
       .map { activeDataLowerBound =>
-        groupedRandomEffectDataSet.filter { case (_, data) =>
-          data.size >= activeDataLowerBound
+        existingModelKeysRddOpt match {
+          case Some(existingModelKeysRdd) =>
+            groupedRandomEffectDataSet
+              .zipPartitions(existingModelKeysRdd, preservesPartitioning = true) { (dataIt, existingKeysIt) =>
+
+              val lookupTable = existingKeysIt.toSet
+
+              dataIt.filter { case (key, data) =>
+                (data.size >= activeDataLowerBound) || !lookupTable.contains(key)
+              }
+            }
+
+          case None =>
+            groupedRandomEffectDataSet.filter { case (_, data) =>
+              data.size >= activeDataLowerBound
+            }
         }
       }
       .getOrElse(groupedRandomEffectDataSet)
@@ -379,8 +399,11 @@ object RandomEffectDataSet {
           val comparableKey = (byteswap64(randomEffectType.hashCode) ^ byteswap64(uniqueId)).hashCode()
           ComparableLabeledPointWithId(comparableKey, uniqueId, labeledPoint)
         }
-        .combineByKey[MinHeapWithFixedCapacity[ComparableLabeledPointWithId]](createCombiner, mergeValue,
-           mergeCombiners, partitioner)
+        .combineByKey[MinHeapWithFixedCapacity[ComparableLabeledPointWithId]](
+          createCombiner,
+          mergeValue,
+          mergeCombiners,
+          partitioner)
         .mapValues { minHeapWithFixedCapacity =>
           val cumCount = minHeapWithFixedCapacity.cumCount
           val data = minHeapWithFixedCapacity.getData

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/data/RandomEffectDataSet.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/data/RandomEffectDataSet.scala
@@ -311,7 +311,15 @@ object RandomEffectDataSet {
       }
       .getOrElse(keyedRandomEffectDataSet.groupByKey(randomEffectPartitioner))
 
-    groupedRandomEffectDataSet.mapValues(iterable => LocalDataSet(iterable.toArray, isSortedByFirstIndex = false))
+    randomEffectDataConfiguration
+      .numActiveDataPointsLowerBound
+      .map { activeDataLowerBound =>
+        groupedRandomEffectDataSet.filter { case (_, data) =>
+          data.size >= activeDataLowerBound
+        }
+      }
+      .getOrElse(groupedRandomEffectDataSet)
+      .mapValues(data => LocalDataSet(data.toArray, isSortedByFirstIndex = false))
   }
 
   /**

--- a/photon-api/src/test/scala/com/linkedin/photon/ml/data/CoordinateDataConfigurationTest.scala
+++ b/photon-api/src/test/scala/com/linkedin/photon/ml/data/CoordinateDataConfigurationTest.scala
@@ -26,15 +26,18 @@ class CoordinateDataConfigurationTest {
 
   @DataProvider
   def invalidInput(): Array[Array[Any]] = Array(
-    Array(-1, 1, 1, 1D),
-    Array(1, -1, 1, 1D),
-    Array(1, 1, -1, 1D),
-    Array(1, 1, 1, -1D))
+    Array(-1, 1, 1, 1, 1D),
+    Array(1, -1, 1, 1, 1D),
+    Array(1, 1, -1, 1, 1D),
+    Array(1, 1, 1, -1, 1D),
+    Array(1, 1, 1, 1, -1D),
+    Array(1, 2, 1, 1, 1D))
 
   /**
    * Test that invalid input will be rejected.
    *
    * @param minPartitions The minimum number of data partitions
+   * @param activeLowerBound The lower bound on number of active data samples
    * @param activeUpperBound The upper bound on number of active data samples
    * @param passiveLowerBound The lower bound on number of passive data samples
    * @param featuresToSamplesRatio The upper bound on the ratio between data samples and features
@@ -42,6 +45,7 @@ class CoordinateDataConfigurationTest {
   @Test(dataProvider = "invalidInput", expectedExceptions = Array(classOf[IllegalArgumentException]))
   def testSetupWithInvalidInput(
       minPartitions: Int,
+      activeLowerBound: Int,
       activeUpperBound: Int,
       passiveLowerBound: Int,
       featuresToSamplesRatio: Double): Unit = {
@@ -54,6 +58,44 @@ class CoordinateDataConfigurationTest {
       mockREType,
       mockFeatureShardId,
       minPartitions,
+      Some(activeLowerBound),
+      Some(activeUpperBound),
+      Some(passiveLowerBound),
+      Some(featuresToSamplesRatio),
+      mockProjector)
+  }
+
+  @DataProvider
+  def validInput(): Array[Array[Any]] = Array(
+    Array(1, 1, 1, 1, 1D),
+    Array(1, 2, 3, 4, 5D))
+
+  /**
+   * Test that valid input will not be rejected.
+   *
+   * @param minPartitions The minimum number of data partitions
+   * @param activeLowerBound The lower bound on number of active data samples
+   * @param activeUpperBound The upper bound on number of active data samples
+   * @param passiveLowerBound The lower bound on number of passive data samples
+   * @param featuresToSamplesRatio The upper bound on the ratio between data samples and features
+   */
+  @Test(dataProvider = "validInput")
+  def testSetupWithValidInput(
+      minPartitions: Int,
+      activeLowerBound: Int,
+      activeUpperBound: Int,
+      passiveLowerBound: Int,
+      featuresToSamplesRatio: Double): Unit = {
+
+    val mockREType = "reType"
+    val mockFeatureShardId = "featureShardId"
+    val mockProjector = mock(classOf[ProjectorType])
+
+    RandomEffectDataConfiguration(
+      mockREType,
+      mockFeatureShardId,
+      minPartitions,
+      Some(activeLowerBound),
       Some(activeUpperBound),
       Some(passiveLowerBound),
       Some(featuresToSamplesRatio),

--- a/photon-client/src/integTest/scala/com/linkedin/photon/ml/cli/game/training/GameTrainingDriverIntegTest.scala
+++ b/photon-client/src/integTest/scala/com/linkedin/photon/ml/cli/game/training/GameTrainingDriverIntegTest.scala
@@ -748,7 +748,7 @@ object GameTrainingDriverIntegTest {
     .zip(randomEffectFeatureShardIds)
     .zip(randomEffectProjectors)
     .map { case ((reType, reShardId), reProjector) =>
-      RandomEffectDataConfiguration(reType, reShardId, randomEffectMinPartitions, None, None, None, reProjector)
+      RandomEffectDataConfiguration(reType, reShardId, randomEffectMinPartitions, projectorType = reProjector)
     }
   private val randomEffectOptimizerConfig = OptimizerConfig(
     OptimizerType.TRON,

--- a/photon-client/src/main/scala/com/linkedin/photon/ml/io/scopt/ScoptParserHelpers.scala
+++ b/photon-client/src/main/scala/com/linkedin/photon/ml/io/scopt/ScoptParserHelpers.scala
@@ -59,7 +59,8 @@ object ScoptParserHelpers extends Logging {
   val COORDINATE_DATA_CONFIG_RANDOM_EFFECT_TYPE = "random.effect.type"
   val COORDINATE_DATA_CONFIG_FEATURE_SHARD = "feature.shard"
   val COORDINATE_DATA_CONFIG_MIN_PARTITIONS = "min.partitions"
-  val COORDINATE_DATA_CONFIG_ACTIVE_DATA_BOUND = "active.data.bound"
+  val COORDINATE_DATA_CONFIG_ACTIVE_DATA_LOWER_BOUND = "active.data.lower.bound"
+  val COORDINATE_DATA_CONFIG_ACTIVE_DATA_UPPER_BOUND = "active.data.upper.bound"
   val COORDINATE_DATA_CONFIG_PASSIVE_DATA_BOUND = "passive.data.bound"
   val COORDINATE_DATA_CONFIG_FEATURES_TO_SAMPLES_RATIO = "features.to.samples.ratio"
 
@@ -91,13 +92,15 @@ object ScoptParserHelpers extends Logging {
   val COORDINATE_CONFIG_FIXED_EFFECT_OPTIONAL_ARGS = Map(
     (COORDINATE_OPT_CONFIG_DOWN_SAMPLING_RATE, "<value>"))
   val COORDINATE_CONFIG_RANDOM_EFFECT_OPTIONAL_ARGS = Map(
-    (COORDINATE_DATA_CONFIG_ACTIVE_DATA_BOUND, "<value>"),
+    (COORDINATE_DATA_CONFIG_ACTIVE_DATA_LOWER_BOUND, "<value>"),
+    (COORDINATE_DATA_CONFIG_ACTIVE_DATA_UPPER_BOUND, "<value>"),
     (COORDINATE_DATA_CONFIG_PASSIVE_DATA_BOUND, "<value>"),
     (COORDINATE_DATA_CONFIG_FEATURES_TO_SAMPLES_RATIO, "<value>"))
 
   val COORDINATE_CONFIG_FIXED_ONLY_ARGS = Seq(COORDINATE_OPT_CONFIG_DOWN_SAMPLING_RATE)
   val COORDINATE_CONFIG_RANDOM_ONLY_ARGS = Seq(
-    COORDINATE_DATA_CONFIG_ACTIVE_DATA_BOUND,
+    COORDINATE_DATA_CONFIG_ACTIVE_DATA_LOWER_BOUND,
+    COORDINATE_DATA_CONFIG_ACTIVE_DATA_UPPER_BOUND,
     COORDINATE_DATA_CONFIG_PASSIVE_DATA_BOUND,
     COORDINATE_DATA_CONFIG_FEATURES_TO_SAMPLES_RATIO)
 
@@ -233,7 +236,8 @@ object ScoptParserHelpers extends Logging {
           reType,
           featureShard,
           minPartitions,
-          input.get(COORDINATE_DATA_CONFIG_ACTIVE_DATA_BOUND).map(_.toInt),
+          input.get(COORDINATE_DATA_CONFIG_ACTIVE_DATA_LOWER_BOUND).map(_.toInt),
+          input.get(COORDINATE_DATA_CONFIG_ACTIVE_DATA_UPPER_BOUND).map(_.toInt),
           input.get(COORDINATE_DATA_CONFIG_PASSIVE_DATA_BOUND).map(_.toInt),
           input.get(COORDINATE_DATA_CONFIG_FEATURES_TO_SAMPLES_RATIO).map(_.toDouble),
           IndexMapProjection)
@@ -243,7 +247,7 @@ object ScoptParserHelpers extends Logging {
           regularizationWeightRange = regularizationWeightRange,
           elasticNetParamRange = elasticNetParamRange)
 
-        //
+        // Log warnings for fixed effect coordinate settings found in random effect coordinate
         COORDINATE_CONFIG_FIXED_ONLY_ARGS.foreach { config =>
           input.get(config).foreach { _ =>
             logger.warn(s"Found and ignored $config for random effect coordinate '$coordinateName'")
@@ -260,7 +264,7 @@ object ScoptParserHelpers extends Logging {
           regularizationWeightRange = regularizationWeightRange,
           elasticNetParamRange = elasticNetParamRange)
 
-        //
+        // Log warnings for random effect coordinate settings found in fixed effect coordinate
         COORDINATE_CONFIG_RANDOM_ONLY_ARGS.foreach { config =>
           input.get(config).foreach { _ =>
             logger.warn(s"Found and ignored $config for fixed effect coordinate '$coordinateName'")
@@ -435,8 +439,11 @@ object ScoptParserHelpers extends Logging {
           argsMap += (COORDINATE_DATA_CONFIG_RANDOM_EFFECT_TYPE -> reDataConfig.randomEffectType)
           argsMap += (COORDINATE_DATA_CONFIG_RANDOM_EFFECT_TYPE -> reDataConfig.randomEffectType)
 
+          reDataConfig.numActiveDataPointsLowerBound.foreach { bound =>
+            argsMap += (COORDINATE_DATA_CONFIG_ACTIVE_DATA_LOWER_BOUND -> bound.toString)
+          }
           reDataConfig.numActiveDataPointsUpperBound.foreach { bound =>
-            argsMap += (COORDINATE_DATA_CONFIG_ACTIVE_DATA_BOUND -> bound.toString)
+            argsMap += (COORDINATE_DATA_CONFIG_ACTIVE_DATA_UPPER_BOUND -> bound.toString)
           }
           reDataConfig.numPassiveDataPointsLowerBound.foreach { bound =>
             argsMap += (COORDINATE_DATA_CONFIG_PASSIVE_DATA_BOUND -> bound.toString)

--- a/photon-client/src/main/scala/com/linkedin/photon/ml/io/scopt/game/ScoptGameTrainingParametersParser.scala
+++ b/photon-client/src/main/scala/com/linkedin/photon/ml/io/scopt/game/ScoptGameTrainingParametersParser.scala
@@ -148,9 +148,14 @@ object ScoptGameTrainingParametersParser extends ScoptGameParametersParser {
       // Compute Variance
       ScoptParameter[Boolean, Boolean](
         GameTrainingDriver.computeVariance),
+
       // Model Sparsity Threshold
       ScoptParameter[Double, Double](
-        GameTrainingDriver.modelSparsityThreshold))
+        GameTrainingDriver.modelSparsityThreshold),
+
+      // Ignore Threshold for New Models
+      ScoptParameter[Boolean, Boolean](
+        GameTrainingDriver.ignoreThresholdForNewModels))
 
   /**
    * Parse command line arguments for GAME training into a [[ParamMap]].

--- a/photon-client/src/test/scala/com/linkedin/photon/ml/io/scopt/ScoptParserHelpersTest.scala
+++ b/photon-client/src/test/scala/com/linkedin/photon/ml/io/scopt/ScoptParserHelpersTest.scala
@@ -117,14 +117,16 @@ class ScoptParserHelpersTest {
     val regWeights2Str =
       Seq("1", "10", "100", "100", "10").mkString(ScoptParserHelpers.SECONDARY_LIST_DELIMITER.toString)
     val regWeights2 = Set(1, 10, 100)
+    val activeDataLowerBound1 = None
+    val activeDataLowerBound2 = Some(5)
     val activeDataUpperBound1 = None
-    val activeDataUpperBound2 = Some(5)
+    val activeDataUpperBound2 = Some(6)
     val passiveDataLowerBound1 = None
-    val passiveDataLowerBound2 = Some(6)
+    val passiveDataLowerBound2 = Some(7)
     val featuresSamplesRatio1 = None
-    val featuresSamplesRatio2 = Some(7)
+    val featuresSamplesRatio2 = Some(8)
     val downSamplingRate1 = 1.0
-    val downSamplingRate2 = 0.7
+    val downSamplingRate2 = 0.9
 
     val inputMap1 = Map[String, String](
       ScoptParserHelpers.COORDINATE_CONFIG_NAME -> coordinateId,
@@ -142,7 +144,8 @@ class ScoptParserHelpersTest {
       ScoptParserHelpers.COORDINATE_DATA_CONFIG_RANDOM_EFFECT_TYPE -> reType)
     val inputMap4 = inputMap1 ++ Map[String, String](
       ScoptParserHelpers.COORDINATE_DATA_CONFIG_RANDOM_EFFECT_TYPE -> reType,
-      ScoptParserHelpers.COORDINATE_DATA_CONFIG_ACTIVE_DATA_BOUND -> activeDataUpperBound2.get.toString,
+      ScoptParserHelpers.COORDINATE_DATA_CONFIG_ACTIVE_DATA_LOWER_BOUND -> activeDataLowerBound2.get.toString,
+      ScoptParserHelpers.COORDINATE_DATA_CONFIG_ACTIVE_DATA_UPPER_BOUND -> activeDataUpperBound2.get.toString,
       ScoptParserHelpers.COORDINATE_DATA_CONFIG_PASSIVE_DATA_BOUND -> passiveDataLowerBound2.get.toString,
       ScoptParserHelpers.COORDINATE_DATA_CONFIG_FEATURES_TO_SAMPLES_RATIO -> featuresSamplesRatio2.get.toString,
       ScoptParserHelpers.COORDINATE_OPT_CONFIG_REGULARIZATION -> regularizationType.toString,
@@ -182,6 +185,7 @@ class ScoptParserHelpersTest {
         assertEquals(reConfig.dataConfiguration.randomEffectType, reType)
         assertEquals(reConfig.dataConfiguration.featureShardId, featureShard)
         assertEquals(reConfig.dataConfiguration.minNumPartitions, minPartitions)
+        assertEquals(reConfig.dataConfiguration.numActiveDataPointsLowerBound, activeDataLowerBound1)
         assertEquals(reConfig.dataConfiguration.numActiveDataPointsUpperBound, activeDataUpperBound1)
         assertEquals(reConfig.dataConfiguration.numPassiveDataPointsLowerBound, passiveDataLowerBound1)
         assertEquals(reConfig.dataConfiguration.numFeaturesToSamplesRatioUpperBound, featuresSamplesRatio1)
@@ -198,6 +202,7 @@ class ScoptParserHelpersTest {
     val coordinateConfig4 = ScoptParserHelpers.parseCoordinateConfiguration(inputMap4)(coordinateId)
     coordinateConfig4 match {
       case reConfig: RandomEffectCoordinateConfiguration =>
+        assertEquals(reConfig.dataConfiguration.numActiveDataPointsLowerBound, activeDataLowerBound2)
         assertEquals(reConfig.dataConfiguration.numActiveDataPointsUpperBound, activeDataUpperBound2)
         assertEquals(reConfig.dataConfiguration.numPassiveDataPointsLowerBound, passiveDataLowerBound2)
         assertEquals(reConfig.dataConfiguration.numFeaturesToSamplesRatioUpperBound, featuresSamplesRatio2)
@@ -430,12 +435,13 @@ class ScoptParserHelpersTest {
     val maxIterations = 3
     val optimizerConfig = OptimizerConfig(optimizer, maxIterations, tolerance)
     val reType = "type"
-    val activeDataBound = 4
-    val passiveDataBound = 5
-    val featuresSamplesRatio = 6.0
+    val activeDataLowerBound = 4
+    val activeDataUpperBound = 5
+    val passiveDataBound = 6
+    val featuresSamplesRatio = 7.0
     val regularizationType = RegularizationType.ELASTIC_NET
-    val regularizationAlpha = 0.7
-    val regularizationWeights = SortedSet[Double](8.8, 9.9).asInstanceOf[Set[Double]]
+    val regularizationAlpha = 0.8
+    val regularizationWeights = SortedSet[Double](9.9, 10.1).asInstanceOf[Set[Double]]
 
     val feDataConfig = FixedEffectDataConfiguration(featureShardId, minPartitions)
 
@@ -457,6 +463,7 @@ class ScoptParserHelpersTest {
       None,
       None,
       None,
+      None,
       IdentityProjection)
     val optConfig3 = RandomEffectOptimizationConfiguration(optimizerConfig)
     val coordinateConfig3 = RandomEffectCoordinateConfiguration(dataConfig3, optConfig3)
@@ -466,7 +473,8 @@ class ScoptParserHelpersTest {
       reType,
       featureShardId,
       minPartitions,
-      Some(activeDataBound),
+      Some(activeDataLowerBound),
+      Some(activeDataUpperBound),
       Some(passiveDataBound),
       Some(featuresSamplesRatio),
       IdentityProjection)
@@ -509,7 +517,8 @@ class ScoptParserHelpersTest {
     val expected4 = (((ScoptParserHelpers.COORDINATE_CONFIG_NAME -> coordinateId4) +: baseArgs) ++
       Seq[(String, String)](
         ScoptParserHelpers.COORDINATE_DATA_CONFIG_RANDOM_EFFECT_TYPE -> reType,
-        ScoptParserHelpers.COORDINATE_DATA_CONFIG_ACTIVE_DATA_BOUND -> activeDataBound.toString,
+        ScoptParserHelpers.COORDINATE_DATA_CONFIG_ACTIVE_DATA_LOWER_BOUND -> activeDataLowerBound.toString,
+        ScoptParserHelpers.COORDINATE_DATA_CONFIG_ACTIVE_DATA_UPPER_BOUND -> activeDataUpperBound.toString,
         ScoptParserHelpers.COORDINATE_DATA_CONFIG_PASSIVE_DATA_BOUND -> passiveDataBound.toString,
         ScoptParserHelpers.COORDINATE_DATA_CONFIG_FEATURES_TO_SAMPLES_RATIO -> featuresSamplesRatio.toString,
         ScoptParserHelpers.COORDINATE_OPT_CONFIG_REGULARIZATION -> regularizationType.toString,

--- a/photon-client/src/test/scala/com/linkedin/photon/ml/io/scopt/game/ScoptGameTrainingParametersParserTest.scala
+++ b/photon-client/src/test/scala/com/linkedin/photon/ml/io/scopt/game/ScoptGameTrainingParametersParserTest.scala
@@ -99,6 +99,7 @@ class ScoptGameTrainingParametersParserTest {
     val randomEffectCoordinateId = "randomCoordinate"
     val randomEffectType = "myType"
     val randomEffectPartitions = 10
+    val randomEffectActiveLowerBound = Some(11)
     val randomEffectActiveUpperBound = Some(11)
     val randomEffectPassiveLowerBound = Some(12)
     val randomEffectFeatureRatio = Some(13.0)
@@ -106,6 +107,7 @@ class ScoptGameTrainingParametersParserTest {
       randomEffectType,
       featureShard2,
       randomEffectPartitions,
+      randomEffectActiveLowerBound,
       randomEffectActiveUpperBound,
       randomEffectPassiveLowerBound,
       randomEffectFeatureRatio,
@@ -221,6 +223,7 @@ class ScoptGameTrainingParametersParserTest {
     assertEquals(finalRandomDataCoordinateConfig.randomEffectType, randomEffectType)
     assertEquals(finalRandomDataCoordinateConfig.featureShardId, featureShard2)
     assertEquals(finalRandomDataCoordinateConfig.minNumPartitions, randomEffectPartitions)
+    assertEquals(finalRandomDataCoordinateConfig.numActiveDataPointsLowerBound, randomEffectActiveLowerBound)
     assertEquals(finalRandomDataCoordinateConfig.numActiveDataPointsUpperBound, randomEffectActiveUpperBound)
     assertEquals(finalRandomDataCoordinateConfig.numPassiveDataPointsLowerBound, randomEffectPassiveLowerBound)
     assertEquals(finalRandomDataCoordinateConfig.numFeaturesToSamplesRatioUpperBound, randomEffectFeatureRatio)

--- a/photon-client/src/test/scala/com/linkedin/photon/ml/io/scopt/game/ScoptGameTrainingParametersParserTest.scala
+++ b/photon-client/src/test/scala/com/linkedin/photon/ml/io/scopt/game/ScoptGameTrainingParametersParserTest.scala
@@ -66,6 +66,7 @@ class ScoptGameTrainingParametersParserTest {
     val hyperparameterTuningMode = HyperparameterTuningMode.BAYESIAN
     val hyperparameterTuningIter = 6
     val computeVariance = true
+    val ignoreThreshold = true
 
     val featureShard1 = "featureShard1"
     val featureBags1 = Set("bag1", "bag2")
@@ -170,6 +171,7 @@ class ScoptGameTrainingParametersParserTest {
       .put(GameTrainingDriver.hyperParameterTuning, hyperparameterTuningMode)
       .put(GameTrainingDriver.hyperParameterTuningIter, hyperparameterTuningIter)
       .put(GameTrainingDriver.computeVariance, computeVariance)
+      .put(GameTrainingDriver.ignoreThresholdForNewModels, ignoreThreshold)
 
     val finalParamMap = ScoptGameTrainingParametersParser.parseFromCommandLine(
       ScoptGameTrainingParametersParser.printForCommandLine(initialParamMap).flatMap(_.split(" ")).toArray)


### PR DESCRIPTION
- Add a lower bound for active data; any entity which does not have more data samples than the threshold will not have a random effect model trained
- Added option to ignore the threshold during warm-start when training models for random effect IDs that do not have an existing model
- Added/modified unit tests for new parameter
- Added integration test for new functionality in RandomEffectDataSet