### PR TITLE
Decouple hyper-parameter autotuning from evaluator

### DIFF
--- a/photon-api/src/main/scala/com/linkedin/photon/ml/hyperparameter/tuner/AtlasTuner.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/hyperparameter/tuner/AtlasTuner.scala
@@ -34,7 +34,6 @@ class AtlasTuner[T] extends HyperparameterTuner[T] {
    * @param dimension Numbers of hyper-parameters to be tuned
    * @param mode Hyper-parameter tuning mode (random or Bayesian)
    * @param evaluationFunction Function that evaluates points in the space to real values
-   * @param evaluator the original evaluator
    * @param observations Observations made prior to searching, from this data set (not mean-centered)
    * @param priorObservations Observations made prior to searching, from past data sets (mean-centered)
    * @param discreteParams Map that specifies the indices of discrete parameters and their numbers of discrete values
@@ -45,14 +44,13 @@ class AtlasTuner[T] extends HyperparameterTuner[T] {
       dimension: Int,
       mode: HyperparameterTuningMode,
       evaluationFunction: EvaluationFunction[T],
-      evaluator: Evaluator,
       observations: Seq[(DenseVector[Double], Double)],
       priorObservations: Seq[(DenseVector[Double], Double)] = Seq(),
       discreteParams: Map[Int, Int] = Map()): Seq[T] = {
 
     val searcher = mode match {
       case HyperparameterTuningMode.BAYESIAN =>
-        new GaussianProcessSearch[T](dimension, evaluationFunction, evaluator)
+        new GaussianProcessSearch[T](dimension, evaluationFunction)
 
       case HyperparameterTuningMode.RANDOM =>
         new RandomSearch[T](dimension, evaluationFunction)

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/hyperparameter/tuner/DummyTuner.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/hyperparameter/tuner/DummyTuner.scala
@@ -32,7 +32,6 @@ class DummyTuner[T] extends HyperparameterTuner[T] {
    * @param dimension Numbers of hyper-parameters to be tuned
    * @param mode Hyper-parameter tuning mode (random or Bayesian)
    * @param evaluationFunction Function that evaluates points in the space to real values
-   * @param evaluator the original evaluator
    * @param observations Observations made prior to searching, from this data set (not mean-centered)
    * @param priorObservations Observations made prior to searching, from past data sets (mean-centered)
    * @param discreteParams Map that specifies the indices of discrete parameters and their numbers of discrete values
@@ -43,7 +42,6 @@ class DummyTuner[T] extends HyperparameterTuner[T] {
       dimension: Int,
       mode: HyperparameterTuningMode,
       evaluationFunction: EvaluationFunction[T],
-      evaluator: Evaluator,
       observations: Seq[(DenseVector[Double], Double)],
       priorObservations: Seq[(DenseVector[Double], Double)] = Seq(),
       discreteParams: Map[Int, Int] = Map()): Seq[T] = Seq()

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/hyperparameter/tuner/HyperparameterTuner.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/hyperparameter/tuner/HyperparameterTuner.scala
@@ -32,7 +32,6 @@ trait HyperparameterTuner[T] {
    * @param dimension Numbers of hyper-parameters to be tuned
    * @param mode Hyper-parameter tuning mode (random or Bayesian)
    * @param evaluationFunction Function that evaluates points in the space to real values
-   * @param evaluator the original evaluator
    * @param observations Observations made prior to searching, from this data set (not mean-centered)
    * @param priorObservations Observations made prior to searching, from past data sets (mean-centered)
    * @param discreteParams Map that specifies the indices of discrete parameters and their numbers of discrete values
@@ -43,7 +42,6 @@ trait HyperparameterTuner[T] {
       dimension: Int,
       mode: HyperparameterTuningMode,
       evaluationFunction: EvaluationFunction[T],
-      evaluator: Evaluator,
       observations: Seq[(DenseVector[Double], Double)],
       priorObservations: Seq[(DenseVector[Double], Double)] = Seq(),
       discreteParams: Map[Int, Int] = Map()): Seq[T]

--- a/photon-client/src/main/scala/com/linkedin/photon/ml/cli/game/training/GameTrainingDriver.scala
+++ b/photon-client/src/main/scala/com/linkedin/photon/ml/cli/game/training/GameTrainingDriver.scala
@@ -649,13 +649,21 @@ object GameTrainingDriver extends GameDriver {
         val iteration = getOrDefault(hyperParameterTuningIter)
         val dimension = baseConfig.toSeq.length
         val mode = getOrDefault(hyperParameterTuning)
-        val evaluationFunction = new GameEstimatorEvaluationFunction(estimator, baseConfig, trainingData, testData)
+
         val evaluator = evaluationResults.get.head._1
+        val isOptMax = evaluator.betterThan(1.0, 0.0)
+        val evaluationFunction = new GameEstimatorEvaluationFunction(
+          estimator,
+          baseConfig,
+          trainingData,
+          testData,
+          isOptMax)
+
         val observations = evaluationFunction.convertObservations(models)
 
         val hyperparameterTuner = HyperparameterTunerFactory[GameEstimator.GameResult](getOrDefault(hyperParameterTunerName))
 
-        hyperparameterTuner.search(iteration, dimension, mode, evaluationFunction, evaluator, observations)
+        hyperparameterTuner.search(iteration, dimension, mode, evaluationFunction, observations)
 
       case _ => Seq()
     }

--- a/photon-client/src/test/scala/com/linkedin/photon/ml/estimators/GameEstimatorEvaluationFunctionTest.scala
+++ b/photon-client/src/test/scala/com/linkedin/photon/ml/estimators/GameEstimatorEvaluationFunctionTest.scala
@@ -47,6 +47,7 @@ class GameEstimatorEvaluationFunctionTest {
   private val regWeights = Array.fill[Double](6) { random.nextDouble }
   private val regAlphas = Array.fill[Double](6) { random.nextDouble }
   private val tolerance = MathConst.EPSILON
+  private val isOptMax = true
 
   /**
    * Test that hyperparameter ranges are correctly constructed from a [[GameOptimizationConfiguration]].
@@ -63,7 +64,7 @@ class GameEstimatorEvaluationFunctionTest {
         regWeights(2),
         elasticNetParamRange = Some(DoubleRange(0.0, 0.5)))))
 
-    val evaluationFunction = new GameEstimatorEvaluationFunction(mockEstimator, configuration, mockData, mockData)
+    val evaluationFunction = new GameEstimatorEvaluationFunction(mockEstimator, configuration, mockData, mockData, isOptMax)
 
     assertEquals(evaluationFunction.ranges, Seq(
       DoubleRange(0.01, 100.0).transform(log),
@@ -84,7 +85,7 @@ class GameEstimatorEvaluationFunctionTest {
       ("c", RandomEffectOptimizationConfiguration(
         mockOptimizerConfig, ElasticNetRegularizationContext(regAlphas(0)), regWeights(2))))
 
-    val evaluationFunction = new GameEstimatorEvaluationFunction(mockEstimator, configuration, mockData, mockData)
+    val evaluationFunction = new GameEstimatorEvaluationFunction(mockEstimator, configuration, mockData, mockData, isOptMax)
     val hypers = DenseVector(log(regWeights(3)), log(regWeights(4)), log(regWeights(5)), regAlphas(1))
     val newConfiguration = evaluationFunction.vectorToConfiguration(hypers)
 
@@ -131,7 +132,7 @@ class GameEstimatorEvaluationFunctionTest {
   @Test(dataProvider = "invalidVectorProvider", expectedExceptions = Array(classOf[IllegalArgumentException]))
   def testInvalidVectorToConfiguration(config: GameOptimizationConfiguration, hypers: DenseVector[Double]): Unit = {
 
-    val evaluationFunction = new GameEstimatorEvaluationFunction(mockEstimator, config, mockData, mockData)
+    val evaluationFunction = new GameEstimatorEvaluationFunction(mockEstimator, config, mockData, mockData, isOptMax)
     evaluationFunction.vectorToConfiguration(hypers)
   }
 
@@ -165,7 +166,7 @@ class GameEstimatorEvaluationFunctionTest {
   @Test(dataProvider = "configurationProvider")
   def testConfigurationToVector(config: GameOptimizationConfiguration, expected: DenseVector[Double]): Unit = {
 
-    val evaluationFunction = new GameEstimatorEvaluationFunction(mockEstimator, config, mockData, mockData)
+    val evaluationFunction = new GameEstimatorEvaluationFunction(mockEstimator, config, mockData, mockData, isOptMax)
     val result = evaluationFunction.configurationToVector(config)
 
     assertEquals(result.length, expected.length)
@@ -211,7 +212,7 @@ class GameEstimatorEvaluationFunctionTest {
     baseConfig: GameOptimizationConfiguration,
     vectorConfig: GameOptimizationConfiguration): Unit = {
 
-    val evaluationFunction = new GameEstimatorEvaluationFunction(mockEstimator, baseConfig, mockData, mockData)
+    val evaluationFunction = new GameEstimatorEvaluationFunction(mockEstimator, baseConfig, mockData, mockData, isOptMax)
     evaluationFunction.configurationToVector(vectorConfig)
   }
 }

--- a/photon-lib/src/main/scala/com/linkedin/photon/ml/hyperparameter/criteria/ConfidenceBound.scala
+++ b/photon-lib/src/main/scala/com/linkedin/photon/ml/hyperparameter/criteria/ConfidenceBound.scala
@@ -17,30 +17,25 @@ package com.linkedin.photon.ml.hyperparameter.criteria
 import breeze.linalg.DenseVector
 import breeze.numerics.sqrt
 
-import com.linkedin.photon.ml.evaluation.Evaluator
 import com.linkedin.photon.ml.hyperparameter.estimators.PredictionTransformation
 
 /**
- * Confidence bound selection criterion. This transformation produces either an upper or lower confidence bound,
- * depending on how the evaluator compares values.
+ * Confidence bound selection criterion. This transformation produces a lower confidence bound.
  *
- * @param evaluator the evaluator
- * @param explorationFactor a factor that determines the tradeoff between exploration and exploitation during search:
+ * @param explorationFactor a factor that determines the trade-off between exploration and exploitation during search:
  *   higher values favor exploration.
  */
-class ConfidenceBound(
-    evaluator: Evaluator,
-    explorationFactor: Double = 2.0)
-  extends PredictionTransformation {
+class ConfidenceBound(explorationFactor: Double = 2.0) extends PredictionTransformation {
 
-  def isMaxOpt: Boolean = evaluator.betterThan(1.0, 0.0)
+  // Minimize CB to minimize the evaluation value.
+  def isMaxOpt: Boolean = false
 
   /**
    * Applies the confidence bound transformation to the model output
    *
    * @param predictiveMeans predictive mean output from the model
    * @param predictiveVariances predictive variance output from the model
-   * @return the confidence bounds
+   * @return the lower confidence bounds
    */
   def apply(
       predictiveMeans: DenseVector[Double],
@@ -48,14 +43,6 @@ class ConfidenceBound(
 
     // PBO Eq. 3
     val confidenceBounds = explorationFactor * sqrt(predictiveVariances)
-    val upper = predictiveMeans + confidenceBounds
-    val lower = predictiveMeans - confidenceBounds
-
-
-    if (evaluator.betterThan(upper(0), lower(0))) {
-      upper
-    } else {
-      lower
-    }
+    predictiveMeans - confidenceBounds
   }
 }

--- a/photon-lib/src/main/scala/com/linkedin/photon/ml/hyperparameter/criteria/ExpectedImprovement.scala
+++ b/photon-lib/src/main/scala/com/linkedin/photon/ml/hyperparameter/criteria/ExpectedImprovement.scala
@@ -18,7 +18,6 @@ import breeze.linalg.DenseVector
 import breeze.numerics.sqrt
 import breeze.stats.distributions.Gaussian
 
-import com.linkedin.photon.ml.evaluation.Evaluator
 import com.linkedin.photon.ml.hyperparameter.estimators.PredictionTransformation
 
 /**
@@ -28,11 +27,11 @@ import com.linkedin.photon.ml.hyperparameter.estimators.PredictionTransformation
  * @see "Practical Bayesian Optimization of Machine Learning Algorithms" (PBO),
  *   https://papers.nips.cc/paper/4522-practical-bayesian-optimization-of-machine-learning-algorithms.pdf
  *
- * @param evaluator the evaluator
  * @param bestEvaluation the current best evaluation
  */
-class ExpectedImprovement(evaluator: Evaluator, bestEvaluation: Double) extends PredictionTransformation {
+class ExpectedImprovement(bestEvaluation: Double) extends PredictionTransformation {
 
+  // Maximize EI to minimize the evaluation value.
   def isMaxOpt: Boolean = true
 
   private val standardNormal = new Gaussian(0, 1)
@@ -51,8 +50,7 @@ class ExpectedImprovement(evaluator: Evaluator, bestEvaluation: Double) extends 
     val std = sqrt(predictiveVariances)
 
     // PBO Eq. 1
-    val direction = if (evaluator.betterThan(1.0, -1.0)) 1.0 else -1.0
-    val gamma = (predictiveMeans - bestEvaluation) / std * direction
+    val gamma = - (predictiveMeans - bestEvaluation) / std
 
     // Eq. 2
     std :* ((gamma :* gamma.map(standardNormal.cdf(_))) + gamma.map(standardNormal.pdf(_)))

--- a/photon-lib/src/test/scala/com/linkedin/photon/ml/hyperparameter/criteria/ConfidenceBoundTest.scala
+++ b/photon-lib/src/test/scala/com/linkedin/photon/ml/hyperparameter/criteria/ConfidenceBoundTest.scala
@@ -15,11 +15,8 @@
 package com.linkedin.photon.ml.hyperparameter.criteria
 
 import breeze.linalg.DenseVector
-import org.apache.spark.rdd.RDD
-import org.mockito.Mockito.mock
 import org.testng.annotations.{DataProvider, Test}
 
-import com.linkedin.photon.ml.evaluation.{Evaluator, EvaluatorType}
 import com.linkedin.photon.ml.test.Assertions.assertIterableEqualsWithTolerance
 
 /**
@@ -27,9 +24,7 @@ import com.linkedin.photon.ml.test.Assertions.assertIterableEqualsWithTolerance
  */
 class ConfidenceBoundTest {
 
-  import ConfidenceBoundTest._
-
-  val tol = 1e-3
+  val TOL = 1e-3
 
   /**
    * Test data
@@ -46,48 +41,14 @@ class ConfidenceBoundTest {
   @Test(dataProvider = "modelDataProvider")
   def testApply(mu: DenseVector[Double], sigma: DenseVector[Double], testSetIndex: Int): Unit = {
 
-    val upperConfidenceBound = new ConfidenceBound(EVALUATOR_AUC)
-    val predictedMax = upperConfidenceBound(mu, sigma)
+    val confidenceBound = new ConfidenceBound
+    val predicted = confidenceBound(mu, sigma)
 
-    val expectedMax = testSetIndex match {
-      case 0 => DenseVector(3.0000, 4.8284, 6.4641)
-      case 1 => DenseVector(-0.5359, 7.8284, -4.0000)
-    }
-
-    assertIterableEqualsWithTolerance(predictedMax.toArray, expectedMax.toArray, tol)
-
-    val lowerConfidenceBound = new ConfidenceBound(EVALUATOR_RMSE)
-    val predictedMin = lowerConfidenceBound(mu, sigma)
-
-    val expectedMin = testSetIndex match {
+    val expected = testSetIndex match {
       case 0 => DenseVector(-1.0000, -0.8284, -0.4641)
       case 1 => DenseVector(-7.4641, 2.1716, -8.0000)
     }
 
-    assertIterableEqualsWithTolerance(predictedMin.toArray, expectedMin.toArray, tol)
-  }
-}
-
-object ConfidenceBoundTest {
-  val EVALUATOR_AUC: Evaluator = new Evaluator {
-
-    override protected[ml] val labelAndOffsetAndWeights: RDD[(Long, (Double, Double, Double))] =
-      mock(classOf[RDD[(Long, (Double, Double, Double))]])
-    override val evaluatorType: EvaluatorType = EvaluatorType.AUC
-    override protected[ml] def evaluateWithScoresAndLabelsAndWeights(
-        scoresAndLabelsAndWeights: RDD[(Long, (Double, Double, Double))]): Double = 0.0
-
-    override def betterThan(score1: Double, score2: Double): Boolean = score1 > score2
-  }
-
-  val EVALUATOR_RMSE: Evaluator = new Evaluator {
-
-    override protected[ml] val labelAndOffsetAndWeights: RDD[(Long, (Double, Double, Double))] =
-      mock(classOf[RDD[(Long, (Double, Double, Double))]])
-    override val evaluatorType: EvaluatorType = EvaluatorType.RMSE
-    override protected[ml] def evaluateWithScoresAndLabelsAndWeights(
-        scoresAndLabelsAndWeights: RDD[(Long, (Double, Double, Double))]): Double = 0.0
-
-    override def betterThan(score1: Double, score2: Double): Boolean = score1 < score2
+    assertIterableEqualsWithTolerance(predicted.toArray, expected.toArray, TOL)
   }
 }

--- a/photon-lib/src/test/scala/com/linkedin/photon/ml/hyperparameter/criteria/ExpectedImprovementTest.scala
+++ b/photon-lib/src/test/scala/com/linkedin/photon/ml/hyperparameter/criteria/ExpectedImprovementTest.scala
@@ -15,11 +15,8 @@
 package com.linkedin.photon.ml.hyperparameter.criteria
 
 import breeze.linalg.DenseVector
-import org.apache.spark.rdd.RDD
-import org.mockito.Mockito.mock
 import org.testng.annotations.{DataProvider, Test}
 
-import com.linkedin.photon.ml.evaluation.{Evaluator, EvaluatorType}
 import com.linkedin.photon.ml.test.Assertions.assertIterableEqualsWithTolerance
 
 /**
@@ -27,9 +24,7 @@ import com.linkedin.photon.ml.test.Assertions.assertIterableEqualsWithTolerance
   */
 class ExpectedImprovementTest {
 
-  import ExpectedImprovementTest._
-
-  val tol = 1e-3
+  val TOL = 1e-3
 
   /**
    * Test data
@@ -46,48 +41,15 @@ class ExpectedImprovementTest {
   @Test(dataProvider = "modelDataProvider")
   def testApply(mu: DenseVector[Double], sigma: DenseVector[Double], testSetIndex: Int): Unit = {
 
-    val expectedImprovementMax = new ExpectedImprovement(EVALUATOR_AUC, 0.0)
-    val predictedMax = expectedImprovementMax(mu, sigma)
+    val bestCandidate = 0.0
+    val expectedImprovement = new ExpectedImprovement(bestCandidate)
+    val predicted = expectedImprovement(mu, sigma)
 
-    val expectedMax = testSetIndex match {
-      case 0 => DenseVector(1.0833, 2.0503, 3.0293)
-      case 1 => DenseVector(0.0062, 5.0001, 0.0000)
-    }
-
-    assertIterableEqualsWithTolerance(predictedMax.toArray, expectedMax.toArray, tol)
-
-    val expectedImprovementMin = new ExpectedImprovement(EVALUATOR_RMSE, 0.0)
-    val predictedMin = expectedImprovementMin(mu, sigma)
-
-    val expectedMin = testSetIndex match {
+    val expected = testSetIndex match {
       case 0 => DenseVector(0.0833, 0.0503, 0.0292)
       case 1 => DenseVector(4.0062, 0.0000, 6.0000)
     }
 
-    assertIterableEqualsWithTolerance(predictedMin.toArray, expectedMin.toArray, tol)
-  }
-}
-
-object ExpectedImprovementTest {
-  val EVALUATOR_AUC: Evaluator = new Evaluator {
-
-    override protected[ml] val labelAndOffsetAndWeights: RDD[(Long, (Double, Double, Double))] =
-      mock(classOf[RDD[(Long, (Double, Double, Double))]])
-    override val evaluatorType: EvaluatorType = EvaluatorType.AUC
-    override protected[ml] def evaluateWithScoresAndLabelsAndWeights(
-        scoresAndLabelsAndWeights: RDD[(Long, (Double, Double, Double))]): Double = 0.0
-
-    override def betterThan(score1: Double, score2: Double): Boolean = score1 > score2
-  }
-
-  val EVALUATOR_RMSE: Evaluator = new Evaluator {
-
-    override protected[ml] val labelAndOffsetAndWeights: RDD[(Long, (Double, Double, Double))] =
-      mock(classOf[RDD[(Long, (Double, Double, Double))]])
-    override val evaluatorType: EvaluatorType = EvaluatorType.RMSE
-    override protected[ml] def evaluateWithScoresAndLabelsAndWeights(
-        scoresAndLabelsAndWeights: RDD[(Long, (Double, Double, Double))]): Double = 0.0
-
-    override def betterThan(score1: Double, score2: Double): Boolean = score1 < score2
+    assertIterableEqualsWithTolerance(predicted.toArray, expected.toArray, TOL)
   }
 }


### PR DESCRIPTION
Hi @joshvfleming @basukinjal, 
I didn't let the `GaussianProcessSearch` do minimization and let the `EvaluationFunction` handle flipping the sign based on two reasons:
1. `GaussianProcessSearch` will know that the problem is a min or max anyway because it will select the best eval of the prior data from past data sets, which all contain positive evals.
2. `findWithPriors` needs to know that the problem is a min or max to decide whether to flip the result for the output.
So I just keep the `EvaluationFunction` unchanged. Do you think it is a good way to implement? Thanks.