### PR TITLE
Fix a bug in using expected improvement to predict minimization problems

### DIFF
--- a/photon-lib/src/main/scala/com/linkedin/photon/ml/hyperparameter/criteria/ConfidenceBound.scala
+++ b/photon-lib/src/main/scala/com/linkedin/photon/ml/hyperparameter/criteria/ConfidenceBound.scala
@@ -33,6 +33,8 @@ class ConfidenceBound(
     explorationFactor: Double = 2.0)
   extends PredictionTransformation {
 
+  def isMaxOpt: Boolean = evaluator.betterThan(1.0, 0.0)
+
   /**
    * Applies the confidence bound transformation to the model output
    *

--- a/photon-lib/src/main/scala/com/linkedin/photon/ml/hyperparameter/criteria/ExpectedImprovement.scala
+++ b/photon-lib/src/main/scala/com/linkedin/photon/ml/hyperparameter/criteria/ExpectedImprovement.scala
@@ -33,10 +33,16 @@ import com.linkedin.photon.ml.hyperparameter.estimators.PredictionTransformation
  */
 class ExpectedImprovement(evaluator: Evaluator, bestEvaluation: Double) extends PredictionTransformation {
 
+  def isMaxOpt: Boolean = true
+
   private val standardNormal = new Gaussian(0, 1)
 
   /**
    * Applies the expected improvement transformation to the model output
+   *
+   * @param predictiveMeans predictive mean output from the model
+   * @param predictiveVariances predictive variance output from the model
+   * @return the expected improvement
    */
   def apply(
       predictiveMeans: DenseVector[Double],

--- a/photon-lib/src/main/scala/com/linkedin/photon/ml/hyperparameter/estimators/PredictionTransformation.scala
+++ b/photon-lib/src/main/scala/com/linkedin/photon/ml/hyperparameter/estimators/PredictionTransformation.scala
@@ -22,6 +22,8 @@ import breeze.linalg.DenseVector
  */
 trait PredictionTransformation {
 
+  def isMaxOpt: Boolean
+
   /**
    * Applies the transformation. Implementing classes should provide specific transformations here.
    *

--- a/photon-lib/src/main/scala/com/linkedin/photon/ml/hyperparameter/search/GaussianProcessSearch.scala
+++ b/photon-lib/src/main/scala/com/linkedin/photon/ml/hyperparameter/search/GaussianProcessSearch.scala
@@ -170,7 +170,9 @@ class GaussianProcessSearch[T](
   }
 
   /**
-   * Selects the best candidate according to the predicted values, where "best" is determined by the given transformation
+   * Selects the best candidate according to the predicted values, where "best" is determined by the given
+   * transformation. In the case of EI, we always search for the max; In the case of CB, we search for max or min given
+   * the optimization problem.
    *
    * @param candidates matrix of candidates
    * @param predictions predicted values for each candidate
@@ -184,7 +186,7 @@ class GaussianProcessSearch[T](
 
     val init = (candidates(0,::).t, predictions(0))
 
-    val direction = if(transformation.isMaxOpt) 1 else -1
+    val direction = if (transformation.isMaxOpt) 1 else -1
 
     val (selectedCandidate, _) = (1 until candidates.rows).foldLeft(init) {
       case ((bestCandidate, bestPrediction), i) =>

--- a/photon-lib/src/main/scala/com/linkedin/photon/ml/hyperparameter/search/GaussianProcessSearch.scala
+++ b/photon-lib/src/main/scala/com/linkedin/photon/ml/hyperparameter/search/GaussianProcessSearch.scala
@@ -20,8 +20,8 @@ import breeze.stats.mean
 import com.linkedin.photon.ml.evaluation.Evaluator
 import com.linkedin.photon.ml.hyperparameter.EvaluationFunction
 import com.linkedin.photon.ml.hyperparameter.criteria.ExpectedImprovement
-import com.linkedin.photon.ml.hyperparameter.estimators.{GaussianProcessEstimator, GaussianProcessModel}
-import com.linkedin.photon.ml.hyperparameter.estimators.kernels.{StationaryKernel, Matern52}
+import com.linkedin.photon.ml.hyperparameter.estimators.{GaussianProcessEstimator, GaussianProcessModel, PredictionTransformation}
+import com.linkedin.photon.ml.hyperparameter.estimators.kernels.{Matern52, StationaryKernel}
 
 /**
  * Performs a guided random search of the given ranges, where the search is guided by a Gaussian Process estimated from
@@ -121,7 +121,7 @@ class GaussianProcessSearch[T](
 
         val predictions = model.predictTransformed(candidates)
 
-        selectBestCandidate(candidates, predictions)
+        selectBestCandidate(candidates, predictions, transformation)
 
       // If we've received fewer observations than the number of parameters, fall back to a uniform search, to ensure
       // that the problem is not under-determined.
@@ -170,21 +170,25 @@ class GaussianProcessSearch[T](
   }
 
   /**
-   * Selects the best candidate according to the predicted values, where "best" is determined by the given evaluator
+   * Selects the best candidate according to the predicted values, where "best" is determined by the given transformation
    *
    * @param candidates matrix of candidates
    * @param predictions predicted values for each candidate
+   * @param transformation prediction transformation function
    * @return the candidate with the best value
    */
   protected[search] def selectBestCandidate(
       candidates: DenseMatrix[Double],
-      predictions: DenseVector[Double]): DenseVector[Double] = {
+      predictions: DenseVector[Double],
+      transformation: PredictionTransformation): DenseVector[Double] = {
 
     val init = (candidates(0,::).t, predictions(0))
 
+    val direction = if(transformation.isMaxOpt) 1 else -1
+
     val (selectedCandidate, _) = (1 until candidates.rows).foldLeft(init) {
       case ((bestCandidate, bestPrediction), i) =>
-        if (evaluator.betterThan(predictions(i), bestPrediction)) {
+        if (predictions(i) * direction > bestPrediction * direction) {
           (candidates(i,::).t, predictions(i))
         } else {
           (bestCandidate, bestPrediction)

--- a/photon-lib/src/main/scala/com/linkedin/photon/ml/hyperparameter/search/RandomSearch.scala
+++ b/photon-lib/src/main/scala/com/linkedin/photon/ml/hyperparameter/search/RandomSearch.scala
@@ -15,11 +15,12 @@
 package com.linkedin.photon.ml.hyperparameter.search
 
 import scala.math.floor
+
 import breeze.linalg.{DenseMatrix, DenseVector}
 import org.apache.commons.math3.random.SobolSequenceGenerator
+
 import com.linkedin.photon.ml.hyperparameter.EvaluationFunction
 import com.linkedin.photon.ml.hyperparameter.estimators.kernels.{Matern52, StationaryKernel}
-
 
 /**
  * Performs a random search of the bounded space.

--- a/photon-lib/src/test/scala/com/linkedin/photon/ml/hyperparameter/criteria/ConfidenceBoundTest.scala
+++ b/photon-lib/src/test/scala/com/linkedin/photon/ml/hyperparameter/criteria/ConfidenceBoundTest.scala
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2018 LinkedIn Corp. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linkedin.photon.ml.hyperparameter.criteria
+
+import breeze.linalg.DenseVector
+import org.apache.spark.rdd.RDD
+import org.mockito.Mockito.mock
+import org.testng.annotations.{DataProvider, Test}
+
+import com.linkedin.photon.ml.evaluation.{Evaluator, EvaluatorType}
+import com.linkedin.photon.ml.test.Assertions.assertIterableEqualsWithTolerance
+
+/**
+ * Test cases for the ConfidenceBound class
+ */
+class ConfidenceBoundTest {
+
+  import ConfidenceBoundTest._
+
+  val tol = 1e-3
+
+  /**
+   * Test data
+   */
+  @DataProvider
+  def modelDataProvider() =
+    Array(
+      Array(DenseVector(1.0, 2.0, 3.0), DenseVector(1.0, 2.0, 3.0), 0),
+      Array(DenseVector(-4.0, 5.0, -6.0), DenseVector(3.0, 2.0, 1.0), 1))
+
+  /**
+   * Unit tests for [[ConfidenceBound.apply]]
+   */
+  @Test(dataProvider = "modelDataProvider")
+  def testApply(mu: DenseVector[Double], sigma: DenseVector[Double], testSetIndex: Int): Unit = {
+
+    val upperConfidenceBound = new ConfidenceBound(EVALUATOR_AUC)
+    val predictedMax = upperConfidenceBound(mu, sigma)
+
+    val expectedMax = testSetIndex match {
+      case 0 => DenseVector(3.0000, 4.8284, 6.4641)
+      case 1 => DenseVector(-0.5359, 7.8284, -4.0000)
+    }
+
+    assertIterableEqualsWithTolerance(predictedMax.toArray, expectedMax.toArray, tol)
+
+    val lowerConfidenceBound = new ConfidenceBound(EVALUATOR_RMSE)
+    val predictedMin = lowerConfidenceBound(mu, sigma)
+
+    val expectedMin = testSetIndex match {
+      case 0 => DenseVector(-1.0000, -0.8284, -0.4641)
+      case 1 => DenseVector(-7.4641, 2.1716, -8.0000)
+    }
+
+    assertIterableEqualsWithTolerance(predictedMin.toArray, expectedMin.toArray, tol)
+  }
+}
+
+object ConfidenceBoundTest {
+  val EVALUATOR_AUC: Evaluator = new Evaluator {
+
+    override protected[ml] val labelAndOffsetAndWeights: RDD[(Long, (Double, Double, Double))] =
+      mock(classOf[RDD[(Long, (Double, Double, Double))]])
+    override val evaluatorType: EvaluatorType = EvaluatorType.AUC
+    override protected[ml] def evaluateWithScoresAndLabelsAndWeights(
+        scoresAndLabelsAndWeights: RDD[(Long, (Double, Double, Double))]): Double = 0.0
+
+    override def betterThan(score1: Double, score2: Double): Boolean = score1 > score2
+  }
+
+  val EVALUATOR_RMSE: Evaluator = new Evaluator {
+
+    override protected[ml] val labelAndOffsetAndWeights: RDD[(Long, (Double, Double, Double))] =
+      mock(classOf[RDD[(Long, (Double, Double, Double))]])
+    override val evaluatorType: EvaluatorType = EvaluatorType.RMSE
+    override protected[ml] def evaluateWithScoresAndLabelsAndWeights(
+        scoresAndLabelsAndWeights: RDD[(Long, (Double, Double, Double))]): Double = 0.0
+
+    override def betterThan(score1: Double, score2: Double): Boolean = score1 < score2
+  }
+}

--- a/photon-lib/src/test/scala/com/linkedin/photon/ml/hyperparameter/criteria/ExpectedImprovementTest.scala
+++ b/photon-lib/src/test/scala/com/linkedin/photon/ml/hyperparameter/criteria/ExpectedImprovementTest.scala
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2018 LinkedIn Corp. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linkedin.photon.ml.hyperparameter.criteria
+
+import breeze.linalg.DenseVector
+import org.apache.spark.rdd.RDD
+import org.mockito.Mockito.mock
+import org.testng.annotations.{DataProvider, Test}
+
+import com.linkedin.photon.ml.evaluation.{Evaluator, EvaluatorType}
+import com.linkedin.photon.ml.test.Assertions.assertIterableEqualsWithTolerance
+
+/**
+  * Test cases for the ExpectedImprovement class
+  */
+class ExpectedImprovementTest {
+
+  import ExpectedImprovementTest._
+
+  val tol = 1e-3
+
+  /**
+   * Test data
+   */
+  @DataProvider
+  def modelDataProvider() =
+    Array(
+      Array(DenseVector(1.0, 2.0, 3.0), DenseVector(1.0, 2.0, 3.0), 0),
+      Array(DenseVector(-4.0, 5.0, -6.0), DenseVector(3.0, 2.0, 1.0), 1))
+
+  /**
+   * Unit tests for [[ExpectedImprovement.apply]]
+   */
+  @Test(dataProvider = "modelDataProvider")
+  def testApply(mu: DenseVector[Double], sigma: DenseVector[Double], testSetIndex: Int): Unit = {
+
+    val expectedImprovementMax = new ExpectedImprovement(EVALUATOR_AUC, 0.0)
+    val predictedMax = expectedImprovementMax(mu, sigma)
+
+    val expectedMax = testSetIndex match {
+      case 0 => DenseVector(1.0833, 2.0503, 3.0293)
+      case 1 => DenseVector(0.0062, 5.0001, 0.0000)
+    }
+
+    assertIterableEqualsWithTolerance(predictedMax.toArray, expectedMax.toArray, tol)
+
+    val expectedImprovementMin = new ExpectedImprovement(EVALUATOR_RMSE, 0.0)
+    val predictedMin = expectedImprovementMin(mu, sigma)
+
+    val expectedMin = testSetIndex match {
+      case 0 => DenseVector(0.0833, 0.0503, 0.0292)
+      case 1 => DenseVector(4.0062, 0.0000, 6.0000)
+    }
+
+    assertIterableEqualsWithTolerance(predictedMin.toArray, expectedMin.toArray, tol)
+  }
+}
+
+object ExpectedImprovementTest {
+  val EVALUATOR_AUC: Evaluator = new Evaluator {
+
+    override protected[ml] val labelAndOffsetAndWeights: RDD[(Long, (Double, Double, Double))] =
+      mock(classOf[RDD[(Long, (Double, Double, Double))]])
+    override val evaluatorType: EvaluatorType = EvaluatorType.AUC
+    override protected[ml] def evaluateWithScoresAndLabelsAndWeights(
+        scoresAndLabelsAndWeights: RDD[(Long, (Double, Double, Double))]): Double = 0.0
+
+    override def betterThan(score1: Double, score2: Double): Boolean = score1 > score2
+  }
+
+  val EVALUATOR_RMSE: Evaluator = new Evaluator {
+
+    override protected[ml] val labelAndOffsetAndWeights: RDD[(Long, (Double, Double, Double))] =
+      mock(classOf[RDD[(Long, (Double, Double, Double))]])
+    override val evaluatorType: EvaluatorType = EvaluatorType.RMSE
+    override protected[ml] def evaluateWithScoresAndLabelsAndWeights(
+        scoresAndLabelsAndWeights: RDD[(Long, (Double, Double, Double))]): Double = 0.0
+
+    override def betterThan(score1: Double, score2: Double): Boolean = score1 < score2
+  }
+}

--- a/photon-lib/src/test/scala/com/linkedin/photon/ml/hyperparameter/estimators/GaussianProcessModelTest.scala
+++ b/photon-lib/src/test/scala/com/linkedin/photon/ml/hyperparameter/estimators/GaussianProcessModelTest.scala
@@ -105,6 +105,7 @@ class GaussianProcessModelTest {
       1.7 * means / std
 
     val transformation = new PredictionTransformation {
+      def isMaxOpt: Boolean = true
       def apply(
           predictiveMeans: DenseVector[Double],
           predictiveVariances: DenseVector[Double]): DenseVector[Double] =

--- a/photon-lib/src/test/scala/com/linkedin/photon/ml/hyperparameter/search/GaussianProcessSearchTest.scala
+++ b/photon-lib/src/test/scala/com/linkedin/photon/ml/hyperparameter/search/GaussianProcessSearchTest.scala
@@ -130,7 +130,7 @@ class GaussianProcessSearchTest {
     val selectedMax = searcher.selectBestCandidate(candidates, predictions, transformationEI)
     assertEquals(selectedMax, expectedMax)
 
-    val transformationCB = new ConfidenceBound(EVALUATOR_RMSE, 0.0)
+    val transformationCB = new ConfidenceBound(EVALUATOR_RMSE)
     val selectedMin = searcher.selectBestCandidate(candidates, predictions, transformationCB)
     assertEquals(selectedMin, expectedMin)
   }

--- a/photon-lib/src/test/scala/com/linkedin/photon/ml/hyperparameter/search/GaussianProcessSearchTest.scala
+++ b/photon-lib/src/test/scala/com/linkedin/photon/ml/hyperparameter/search/GaussianProcessSearchTest.scala
@@ -22,6 +22,7 @@ import org.testng.annotations.{DataProvider, Test}
 
 import com.linkedin.photon.ml.evaluation.{Evaluator, EvaluatorType}
 import com.linkedin.photon.ml.hyperparameter.EvaluationFunction
+import com.linkedin.photon.ml.hyperparameter.criteria.{ConfidenceBound, ExpectedImprovement}
 import com.linkedin.photon.ml.hyperparameter.estimators.kernels.Matern52
 
 /**
@@ -34,26 +35,28 @@ class GaussianProcessSearchTest {
   val searcher = new GaussianProcessSearch[TestModel](
     DIM,
     EVALUATION_FUNCTION,
-    EVALUATOR,
+    EVALUATOR_AUC,
     DISCRETE_PARAMS,
     KERNEL,
     seed = SEED)
 
   var observedPoints: Option[DenseMatrix[Double]] = None
   var observedEvals: Option[DenseVector[Double]] = None
-  var bestEval: Double = EVALUATOR.defaultScore
+  var bestEval: Double = EVALUATOR_AUC.defaultScore
   var priorObservedPoints: Option[DenseMatrix[Double]] = None
   var priorObservedEvals: Option[DenseVector[Double]] = None
-  var priorBestEval: Double = EVALUATOR.defaultScore
+  var priorBestEval: Double = EVALUATOR_AUC.defaultScore
 
   @DataProvider
   def priorDataProvider: Array[Array[Any]] = {
 
-    val candidate1 = (DenseVector(0.25, 0.2, 0.1999, 0.125, 0.999), 0.1)
-    val candidate2 = (DenseVector(0.2, 0.2, 0.2, 0.2, 0.2), 0.2)
-    val candidate3 = (DenseVector(0.3, 0.3, 0.3, 0.3, 0.3), 0.3)
-    val observations = Seq(candidate1, candidate2)
-    val priorObservations = Seq(candidate2, candidate3)
+    val candidate1 = (DenseVector(0.25, 0.125, 0.999), 0.1)
+    val candidate2 = (DenseVector(0.2, 0.2, 0.2), 0.2)
+    val candidate3 = (DenseVector(0.3, 0.3, 0.3), -0.3)
+    val candidate4 = (DenseVector(0.2, 0.2, 0.2), 0.4)
+    val candidate5 = (DenseVector(0.3, 0.3, 0.3), -0.4)
+    val observations = Seq(candidate1, candidate2, candidate3)
+    val priorObservations = Seq(candidate4, candidate5)
 
     Array(
       Array(observations, Seq(), 0),
@@ -106,19 +109,30 @@ class GaussianProcessSearchTest {
       candidate3.asDenseMatrix)
 
     Array(
-      Array(candidates, DenseVector(2.0, 1.0, 0.0), candidate1),
-      Array(candidates, DenseVector(1.0, 2.0, 0.0), candidate2),
-      Array(candidates, DenseVector(0.0, 1.0, 2.0), candidate3))
+      Array(candidates, DenseVector(2.0, 1.0, 0.0), candidate1, candidate3),
+      Array(candidates, DenseVector(1.0, 2.0, 0.0), candidate2, candidate3),
+      Array(candidates, DenseVector(0.0, 1.0, 2.0), candidate3, candidate1))
   }
 
+  /**
+   * Unit test for [[GaussianProcessSearch.selectBestCandidate]].
+   * If transformation is EI, always select the best candidate that maximize the prediction.
+   * If transformation is CB, the best candidate is determined by the evaluator.
+   */
   @Test(dataProvider = "bestCandidateDataProvider")
   def testSelectBestCandidate(
       candidates: DenseMatrix[Double],
       predictions: DenseVector[Double],
-      expected: DenseVector[Double]): Unit = {
+      expectedMax: DenseVector[Double],
+      expectedMin: DenseVector[Double]): Unit = {
 
-    val selected = searcher.selectBestCandidate(candidates, predictions)
-    assertEquals(selected, expected)
+    val transformationEI = new ExpectedImprovement(EVALUATOR_AUC, 0.0)
+    val selectedMax = searcher.selectBestCandidate(candidates, predictions, transformationEI)
+    assertEquals(selectedMax, expectedMax)
+
+    val transformationCB = new ConfidenceBound(EVALUATOR_RMSE, 0.0)
+    val selectedMin = searcher.selectBestCandidate(candidates, predictions, transformationCB)
+    assertEquals(selectedMin, expectedMin)
   }
 
   @Test(dataProvider = "priorDataProvider")
@@ -137,7 +151,7 @@ class GaussianProcessSearchTest {
         .map(DenseVector.vertcat(_, DenseVector(value)))
         .orElse(Some(DenseVector(value)))
 
-      if (EVALUATOR.betterThan(value, bestEval)) {
+      if (EVALUATOR_AUC.betterThan(value, bestEval)) {
         bestEval = value
       }
     }
@@ -151,28 +165,28 @@ class GaussianProcessSearchTest {
         .map(DenseVector.vertcat(_, DenseVector(value)))
         .orElse(Some(DenseVector(value)))
 
-      if (EVALUATOR.betterThan(value, priorBestEval)) {
+      if (EVALUATOR_AUC.betterThan(value, priorBestEval)) {
         priorBestEval = value
       }
     }
 
     testSetIndex match {
       case 0 =>
-        assertEquals(observedPoints.get.rows, 2)
-        assertEquals(observedPoints.get.cols, 5)
-        assertEquals(observedEvals.get.length, 2)
+        assertEquals(observedPoints.get.rows, 3)
+        assertEquals(observedPoints.get.cols, 3)
+        assertEquals(observedEvals.get.length, 3)
         assertEquals(bestEval, 0.2)
         assertFalse(priorObservedPoints.isDefined)
         assertFalse(priorObservedEvals.isDefined)
       case 1 =>
-        assertEquals(observedPoints.get.rows, 4)
-        assertEquals(observedPoints.get.cols, 5)
-        assertEquals(observedEvals.get.length, 4)
+        assertEquals(observedPoints.get.rows, 6)
+        assertEquals(observedPoints.get.cols, 3)
+        assertEquals(observedEvals.get.length, 6)
         assertEquals(bestEval, 0.2)
         assertEquals(priorObservedPoints.get.rows, 2)
-        assertEquals(priorObservedPoints.get.cols, 5)
+        assertEquals(priorObservedPoints.get.cols, 3)
         assertEquals(priorObservedEvals.get.length, 2)
-        assertEquals(priorBestEval, 0.3)
+        assertEquals(priorBestEval, 0.4)
     }
   }
 }
@@ -180,9 +194,9 @@ class GaussianProcessSearchTest {
 object GaussianProcessSearchTest {
 
   val SEED = 1L
-  val DIM = 5
-  val N = 25
-  val DISCRETE_PARAMS = Map(0 -> 5, 1 -> 5, 2 -> 5, 4 -> 9)
+  val DIM = 3
+  val N = 5
+  val DISCRETE_PARAMS = Map(0 -> 5, 2 -> 9)
   val KERNEL = new Matern52
   val TOLERANCE = 1E-12
 
@@ -204,7 +218,7 @@ object GaussianProcessSearchTest {
     def getEvaluationValue(result: TestModel): Double = result.evaluation
   }
 
-  val EVALUATOR: Evaluator = new Evaluator {
+  val EVALUATOR_AUC: Evaluator = new Evaluator {
 
     override protected[ml] val labelAndOffsetAndWeights: RDD[(Long, (Double, Double, Double))] =
       mock(classOf[RDD[(Long, (Double, Double, Double))]])
@@ -213,5 +227,16 @@ object GaussianProcessSearchTest {
         scoresAndLabelsAndWeights: RDD[(Long, (Double, Double, Double))]): Double = 0.0
 
     override def betterThan(score1: Double, score2: Double): Boolean = score1 > score2
+  }
+
+  val EVALUATOR_RMSE: Evaluator = new Evaluator {
+
+    override protected[ml] val labelAndOffsetAndWeights: RDD[(Long, (Double, Double, Double))] =
+      mock(classOf[RDD[(Long, (Double, Double, Double))]])
+    override val evaluatorType: EvaluatorType = EvaluatorType.RMSE
+    override protected[ml] def evaluateWithScoresAndLabelsAndWeights(
+        scoresAndLabelsAndWeights: RDD[(Long, (Double, Double, Double))]): Double = 0.0
+
+    override def betterThan(score1: Double, score2: Double): Boolean = score1 < score2
   }
 }

--- a/photon-lib/src/test/scala/com/linkedin/photon/ml/hyperparameter/search/RandomSearchTest.scala
+++ b/photon-lib/src/test/scala/com/linkedin/photon/ml/hyperparameter/search/RandomSearchTest.scala
@@ -33,11 +33,13 @@ class RandomSearchTest {
   @DataProvider
   def priorDataProvider: Array[Array[Any]] = {
 
-    val candidate1 = (DenseVector(0.25, 0.2, 0.1999, 0.125, 0.999), 0.1)
-    val candidate2 = (DenseVector(0.2, 0.2, 0.2, 0.2, 0.2), 0.2)
-    val candidate3 = (DenseVector(0.3, 0.3, 0.3, 0.3, 0.3), 0.3)
-    val observations = Seq(candidate1)
-    val priorObservations = Seq(candidate2, candidate3)
+    val candidate1 = (DenseVector(0.25, 0.125, 0.999), 0.1)
+    val candidate2 = (DenseVector(0.2, 0.2, 0.2), 0.2)
+    val candidate3 = (DenseVector(0.3, 0.3, 0.3), -0.3)
+    val candidate4 = (DenseVector(0.2, 0.2, 0.2), 0.4)
+    val candidate5 = (DenseVector(0.3, 0.3, 0.3), -0.4)
+    val observations = Seq(candidate1, candidate2, candidate3)
+    val priorObservations = Seq(candidate4, candidate5)
 
     Array(Array(observations, priorObservations))
   }
@@ -105,7 +107,7 @@ class RandomSearchTest {
       priorObservations: Seq[(DenseVector[Double], Double)]): Unit = {
 
     val candidate = observations.head._1
-    val expectedData = DenseVector(0.2, 0.2, 0, 0.125, 8.0 / 9.0)
+    val expectedData = DenseVector(0.2, 0.125, 8.0 / 9.0)
 
     val candidateWithDiscrete = searcher.discretizeCandidate(candidate, DISCRETE_PARAMS)
     assertEquals(norm(candidateWithDiscrete), norm(expectedData), TOLERANCE)
@@ -115,9 +117,9 @@ class RandomSearchTest {
 object RandomSearchTest {
 
   val SEED = 1L
-  val DIM = 5
-  val N = 25
-  val DISCRETE_PARAMS = Map(0 -> 5, 1 -> 5, 2 -> 5, 4 -> 9)
+  val DIM = 3
+  val N = 5
+  val DISCRETE_PARAMS = Map(0 -> 5, 2 -> 9)
   val KERNEL = new Matern52
   val TOLERANCE = 1E-12
 


### PR DESCRIPTION
@joshvfleming @basukinjal @yunboouyang
Tests are done for using EI and CB as prediction transformation to maximize and minimize normal distribution PDF. Other than the title literally, this PR also includes a change which reduce the time of unit tests.