### PR TITLE
Switch to atlas-ml for hyper-parameter tuning

### DIFF
--- a/photon-api/src/main/scala/com/linkedin/photon/ml/hyperparameter/tuner/AtlasTuner.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/hyperparameter/tuner/AtlasTuner.scala
@@ -18,7 +18,6 @@ import breeze.linalg.DenseVector
 
 import com.linkedin.photon.ml.HyperparameterTuningMode
 import com.linkedin.photon.ml.HyperparameterTuningMode.HyperparameterTuningMode
-import com.linkedin.photon.ml.evaluation.Evaluator
 import com.linkedin.photon.ml.hyperparameter.EvaluationFunction
 import com.linkedin.photon.ml.hyperparameter.search.{GaussianProcessSearch, RandomSearch}
 

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/hyperparameter/tuner/DummyTuner.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/hyperparameter/tuner/DummyTuner.scala
@@ -17,7 +17,6 @@ package com.linkedin.photon.ml.hyperparameter.tuner
 import breeze.linalg.DenseVector
 
 import com.linkedin.photon.ml.HyperparameterTuningMode.HyperparameterTuningMode
-import com.linkedin.photon.ml.evaluation.Evaluator
 import com.linkedin.photon.ml.hyperparameter.EvaluationFunction
 
 /**

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/hyperparameter/tuner/HyperparameterTuner.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/hyperparameter/tuner/HyperparameterTuner.scala
@@ -17,7 +17,6 @@ package com.linkedin.photon.ml.hyperparameter.tuner
 import breeze.linalg.DenseVector
 
 import com.linkedin.photon.ml.HyperparameterTuningMode.HyperparameterTuningMode
-import com.linkedin.photon.ml.evaluation.Evaluator
 import com.linkedin.photon.ml.hyperparameter.EvaluationFunction
 
 /**

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/hyperparameter/tuner/HyperparameterTunerFactory.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/hyperparameter/tuner/HyperparameterTunerFactory.scala
@@ -20,11 +20,7 @@ object HyperparameterTunerFactory {
 
   // Use DUMMY_TUNER for photon-ml, which does an empty operation for hyper-parameter tuning
   val DUMMY_TUNER = "com.linkedin.photon.ml.hyperparameter.tuner.DummyTuner"
-
-  // TODO: Move AtlasTuner into atlas-ml for the auto-tuning system migration:
-  // TODO: val ATLAS_TUNER = "com.linkedin.atlas.ml.hyperparameter.tuner.AtlasTuner".
-  // TODO: Temporarily stay in photon-ml for test purpose.
-  val ATLAS_TUNER = "com.linkedin.photon.ml.hyperparameter.tuner.AtlasTuner"
+  val ATLAS_TUNER = "com.linkedin.atlas.tuner.AtlasTuner"
 
   /**
    * Factory for different packages of [[HyperparameterTuner]].


### PR DESCRIPTION
@joshvfleming @basukinjal @ashelkovnykov Since atlas-ml is created now, we use atlas-ml for hyper-parameter-tuning.