### PR TITLE
Fix 3 bugs found in DataValidators

### DIFF
--- a/photon-client/src/integTest/scala/com/linkedin/photon/ml/data/DataValidatorsIntegTest.scala
+++ b/photon-client/src/integTest/scala/com/linkedin/photon/ml/data/DataValidatorsIntegTest.scala
@@ -14,295 +14,327 @@
  */
 package com.linkedin.photon.ml.data
 
-import scala.util.{Success, Try}
+import scala.util.{Failure, Success, Try}
 
-import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.Row
 import org.apache.spark.ml.linalg.SQLDataTypes.VectorType
-import org.apache.spark.ml.linalg.Vectors
-import org.testng.Assert
+import org.apache.spark.ml.linalg.Vector
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema
+import org.apache.spark.sql.types._
+import org.testng.Assert.assertEquals
 import org.testng.annotations.{DataProvider, Test}
 
 import com.linkedin.photon.ml.DataValidationType.DataValidationType
 import com.linkedin.photon.ml.TaskType.TaskType
 import com.linkedin.photon.ml.supervised.classification.BinaryClassifier
 import com.linkedin.photon.ml.test.{CommonTestUtils, SparkTestUtils}
+import com.linkedin.photon.ml.util.VectorUtils
 import com.linkedin.photon.ml.{DataValidationType, TaskType}
-import org.apache.spark.sql.types._
 
 /**
  * Integration tests for [[DataValidators]].
  */
 class DataValidatorsIntegTest extends SparkTestUtils {
 
+  import DataValidatorsIntegTest._
+
+  /**
+   * Helper function to generate [[org.apache.spark.sql.DataFrame]] rows.
+   *
+   * @param features1 First sample features vector
+   * @param features2 Second sample features vector
+   * @param response Sample response
+   * @param offset Sample offset
+   * @param weight Sample weight
+   * @return Input data grouped into a [[Row]] with the expected schema
+   */
+  private def getRow(
+      features1: Vector,
+      features2: Vector,
+      response: Double = 1D,
+      offset: Double = 0D,
+      weight: Double = 1D): Row =
+    new GenericRowWithSchema(Array[Any](response, offset, weight, features1, features2), ROW_SCHEMA)
+
+  /**
+   * Generate input data for [[DataValidators.sanityCheckData]].
+   */
   @DataProvider
-  def getSuccessArgumentsForSanityCheckData: Array[Array[Any]] = {
+  def sanityCheckDataInput: Array[Array[Any]] = {
+
     val vectors = CommonTestUtils.generateDenseFeatureVectors(1, 1, 20)
     val validVector = vectors.head
     val invalidVector = vectors.last
 
-    // labeled points with valid vectors
-    val lpPositiveLabel = new LabeledPoint(5.0, validVector)
-    val lpNegativeLabel = new LabeledPoint(-5.0, validVector)
-    val lpBinaryLabel = new LabeledPoint(BinaryClassifier.negativeClassLabel, validVector)
+    // LabeledPoints with valid vectors
+    val positiveLabel = new LabeledPoint(5D, validVector)
+    val negativeLabel = new LabeledPoint(-5D, validVector)
+    val binaryLabel = new LabeledPoint(BinaryClassifier.positiveClassLabel, validVector)
+    val zeroLabel = new LabeledPoint(0D, validVector)
+    val nanLabel = new LabeledPoint(Double.NaN, validVector)
 
-    // labeled point with invalid label
-    val lpInfLabel = new LabeledPoint(Double.PositiveInfinity, validVector)
+    // LabeledPoint with invalid vectors
+    val badFeatures = new LabeledPoint(BinaryClassifier.positiveClassLabel, invalidVector)
 
-    // labeled point with invalid offset
-    val lpInfOffset = new LabeledPoint(BinaryClassifier.positiveClassLabel, validVector, Double.NaN)
+    // LabeledPoint with invalid offset
+    val badOffset = new LabeledPoint(BinaryClassifier.positiveClassLabel, validVector, Double.NaN)
 
-    // labeled points with invalid vectors
-    val lpNonBinaryLabelInfFeatures = new LabeledPoint(-2.0, invalidVector)
-    val lpBinaryLabelInfFeatures = new LabeledPoint(BinaryClassifier.negativeClassLabel, invalidVector)
+    // LabeledPoint with invalid weight
+    val badWeight = new LabeledPoint(BinaryClassifier.positiveClassLabel, validVector, 0D, Double.NaN)
 
-    Assert.assertNotNull(sc)
-
-    // All RDDs have one valid point and at least one invalid point
     Array(
+      // Test linear regression checks for finite labels
       Array(
-        sc.parallelize(List(lpPositiveLabel, lpBinaryLabel)),
+        Seq(positiveLabel, negativeLabel, binaryLabel, zeroLabel),
         TaskType.LINEAR_REGRESSION,
-        DataValidationType.VALIDATE_DISABLED),
-      Array(
-        sc.parallelize(List(lpPositiveLabel, lpInfLabel)),
-        TaskType.LINEAR_REGRESSION,
-        DataValidationType.VALIDATE_DISABLED),
-      Array(
-        sc.parallelize(List(lpPositiveLabel, lpNonBinaryLabelInfFeatures)),
-        TaskType.LINEAR_REGRESSION,
-        DataValidationType.VALIDATE_DISABLED),
-      Array(
-        sc.parallelize(List(lpPositiveLabel, lpInfOffset)),
-        TaskType.LINEAR_REGRESSION,
-        DataValidationType.VALIDATE_DISABLED),
-      Array(
-        sc.parallelize(List(lpPositiveLabel, lpBinaryLabel)),
-        TaskType.LINEAR_REGRESSION,
-        DataValidationType.VALIDATE_FULL),
+        DataValidationType.VALIDATE_FULL,
+        true),
+      Array(Seq(nanLabel), TaskType.LINEAR_REGRESSION, DataValidationType.VALIDATE_FULL, false),
 
-      Array(
-        sc.parallelize(List(lpBinaryLabel)),
-        TaskType.LOGISTIC_REGRESSION,
-        DataValidationType.VALIDATE_DISABLED),
-      Array(
-        sc.parallelize(List(lpBinaryLabel, lpPositiveLabel)),
-        TaskType.LOGISTIC_REGRESSION,
-        DataValidationType.VALIDATE_DISABLED),
-      Array(
-        sc.parallelize(List(lpBinaryLabel, lpInfLabel)),
-        TaskType.LOGISTIC_REGRESSION,
-        DataValidationType.VALIDATE_DISABLED),
-      Array(
-        sc.parallelize(List(lpBinaryLabel, lpBinaryLabelInfFeatures)),
-        TaskType.LOGISTIC_REGRESSION,
-        DataValidationType.VALIDATE_DISABLED),
-      Array(
-        sc.parallelize(List(lpPositiveLabel, lpInfOffset)),
-        TaskType.LOGISTIC_REGRESSION,
-        DataValidationType.VALIDATE_DISABLED),
-      Array(
-        sc.parallelize(List(lpBinaryLabel)),
-        TaskType.LOGISTIC_REGRESSION,
-        DataValidationType.VALIDATE_FULL),
+      // Test logistic regression checks for binary label
+      Array(Seq(binaryLabel, zeroLabel), TaskType.LOGISTIC_REGRESSION, DataValidationType.VALIDATE_FULL, true),
+      Array(Seq(positiveLabel), TaskType.LOGISTIC_REGRESSION, DataValidationType.VALIDATE_FULL, false),
+      Array(Seq(negativeLabel), TaskType.LOGISTIC_REGRESSION, DataValidationType.VALIDATE_FULL, false),
+      Array(Seq(nanLabel), TaskType.LOGISTIC_REGRESSION, DataValidationType.VALIDATE_FULL, false),
 
+      // Test smoothed hinge loss checks for binary label
       Array(
-        sc.parallelize(List(lpPositiveLabel, lpBinaryLabel)),
-        TaskType.POISSON_REGRESSION,
-        DataValidationType.VALIDATE_DISABLED),
+        Seq(binaryLabel, zeroLabel),
+        TaskType.SMOOTHED_HINGE_LOSS_LINEAR_SVM,
+        DataValidationType.VALIDATE_FULL,
+        true),
+      Array(Seq(positiveLabel), TaskType.SMOOTHED_HINGE_LOSS_LINEAR_SVM, DataValidationType.VALIDATE_FULL, false),
+      Array(Seq(negativeLabel), TaskType.SMOOTHED_HINGE_LOSS_LINEAR_SVM, DataValidationType.VALIDATE_FULL, false),
+      Array(Seq(nanLabel), TaskType.SMOOTHED_HINGE_LOSS_LINEAR_SVM, DataValidationType.VALIDATE_FULL, false),
+
+      // Test Poisson regression checks for non-negative label
       Array(
-        sc.parallelize(List(lpPositiveLabel, lpInfLabel)),
+        Seq(positiveLabel, binaryLabel, zeroLabel),
         TaskType.POISSON_REGRESSION,
-        DataValidationType.VALIDATE_DISABLED),
+        DataValidationType.VALIDATE_FULL,
+        true),
+      Array(Seq(negativeLabel), TaskType.POISSON_REGRESSION, DataValidationType.VALIDATE_FULL, false),
+      Array(Seq(nanLabel), TaskType.POISSON_REGRESSION, DataValidationType.VALIDATE_FULL, false),
+
+      // Test all task types require finite features
+      Array(Seq(badFeatures), TaskType.LINEAR_REGRESSION, DataValidationType.VALIDATE_FULL, false),
+      Array(Seq(badFeatures), TaskType.LOGISTIC_REGRESSION, DataValidationType.VALIDATE_FULL, false),
+      Array(Seq(badFeatures), TaskType.SMOOTHED_HINGE_LOSS_LINEAR_SVM, DataValidationType.VALIDATE_FULL, false),
+      Array(Seq(badFeatures), TaskType.POISSON_REGRESSION, DataValidationType.VALIDATE_FULL, false),
+
+      // Test all task types require finite offset
+      Array(Seq(badOffset), TaskType.LINEAR_REGRESSION, DataValidationType.VALIDATE_FULL, false),
+      Array(Seq(badOffset), TaskType.LOGISTIC_REGRESSION, DataValidationType.VALIDATE_FULL, false),
+      Array(Seq(badOffset), TaskType.SMOOTHED_HINGE_LOSS_LINEAR_SVM, DataValidationType.VALIDATE_FULL, false),
+      Array(Seq(badOffset), TaskType.POISSON_REGRESSION, DataValidationType.VALIDATE_FULL, false),
+
+      // Test all task types require valid weight
+      Array(Seq(badWeight), TaskType.LINEAR_REGRESSION, DataValidationType.VALIDATE_FULL, false),
+      Array(Seq(badWeight), TaskType.LOGISTIC_REGRESSION, DataValidationType.VALIDATE_FULL, false),
+      Array(Seq(badWeight), TaskType.SMOOTHED_HINGE_LOSS_LINEAR_SVM, DataValidationType.VALIDATE_FULL, false),
+      Array(Seq(badWeight), TaskType.POISSON_REGRESSION, DataValidationType.VALIDATE_FULL, false),
+
+      // Test that even one bad sample causes failure
       Array(
-        sc.parallelize(List(lpPositiveLabel, lpNegativeLabel)),
+        Seq(positiveLabel, binaryLabel, zeroLabel),
         TaskType.POISSON_REGRESSION,
-        DataValidationType.VALIDATE_DISABLED),
+        DataValidationType.VALIDATE_FULL,
+        true),
       Array(
-        sc.parallelize(List(lpPositiveLabel, lpNonBinaryLabelInfFeatures)),
+        Seq(positiveLabel, binaryLabel, zeroLabel, negativeLabel),
         TaskType.POISSON_REGRESSION,
-        DataValidationType.VALIDATE_DISABLED),
-      Array(
-        sc.parallelize(List(lpPositiveLabel, lpInfOffset)),
-        TaskType.POISSON_REGRESSION,
-        DataValidationType.VALIDATE_DISABLED),
-      Array(
-        sc.parallelize(List(lpPositiveLabel, lpBinaryLabel)),
-        TaskType.POISSON_REGRESSION,
-        DataValidationType.VALIDATE_FULL)
+        DataValidationType.VALIDATE_FULL,
+        false),
+
+      // Test that VALIDATE_DISABLED will ignore bad rows
+      Array(Seq(positiveLabel), TaskType.LOGISTIC_REGRESSION, DataValidationType.VALIDATE_FULL, false),
+      Array(Seq(positiveLabel), TaskType.LOGISTIC_REGRESSION, DataValidationType.VALIDATE_DISABLED, true)
     )
   }
 
+  /**
+   * Generate input data for [[DataValidators.sanityCheckDataFrameForTraining]].
+   */
   @DataProvider
-  def getFailureArgumentsForSanityCheckData: Array[Array[Any]] = {
+  def sanityCheckDataFrameForTrainingInput: Array[Array[Any]] = {
+
     val vectors = CommonTestUtils.generateDenseFeatureVectors(1, 1, 20)
-    val validVector = vectors.head
-    val invalidVector = vectors.last
+    val validVector = VectorUtils.breezeToMl(vectors.head)
+    val invalidVector = VectorUtils.breezeToMl(vectors.last)
 
-    // labeled points with valid vectors
-    val lpPositiveLabel = new LabeledPoint(5.0, validVector)
-    val lpNegativeLabel = new LabeledPoint(-5.0, validVector)
-    val lpBinaryLabel = new LabeledPoint(BinaryClassifier.negativeClassLabel, validVector)
+    // Rows with valid vectors
+    val positiveLabel = getRow(validVector, validVector, 5D)
+    val negativeLabel = getRow(validVector, validVector, -5D)
+    val binaryLabel = getRow(validVector, validVector, BinaryClassifier.positiveClassLabel)
+    val zeroLabel = getRow(validVector, validVector, 0D)
+    val nanLabel = getRow(validVector, validVector, Double.NaN)
 
-    // labeled point with invalid label
-    val lpInfLabel = new LabeledPoint(Double.PositiveInfinity, validVector)
+    // Rows with invalid vectors
+    val badFeatures1 = getRow(invalidVector, validVector, BinaryClassifier.positiveClassLabel)
+    val badFeatures2 = getRow(validVector, invalidVector, BinaryClassifier.positiveClassLabel)
+    val badFeaturesBoth = getRow(invalidVector, invalidVector, BinaryClassifier.positiveClassLabel)
 
-    // labeled point with invalid offset
-    val lpInfOffset = new LabeledPoint(BinaryClassifier.positiveClassLabel, validVector, Double.NaN)
+    // Row with invalid offset
+    val badOffset = getRow(validVector, validVector, offset = Double.NaN)
 
-    // labeled points with invalid vectors
-    val lpNonBinaryLabelInfFeatures = new LabeledPoint(-2.0, invalidVector)
-    val lpBinaryLabelInfFeatures = new LabeledPoint(BinaryClassifier.negativeClassLabel, invalidVector)
+    // Row with invalid weight
+    val badWeight = getRow(validVector, validVector, weight = Double.NaN)
 
-    Assert.assertNotNull(sc)
-
-    // All RDDs have one valid point and at least one invalid point
     Array(
+      // Test linear regression checks for finite labels
       Array(
-        sc.parallelize(List(lpPositiveLabel, lpInfLabel)),
+        Seq(positiveLabel, negativeLabel, binaryLabel, zeroLabel),
         TaskType.LINEAR_REGRESSION,
-        DataValidationType.VALIDATE_FULL, false),
-      Array(
-        sc.parallelize(List(lpPositiveLabel, lpNonBinaryLabelInfFeatures)),
-        TaskType.LINEAR_REGRESSION,
-        DataValidationType.VALIDATE_FULL, false),
-      Array(
-        sc.parallelize(List(lpPositiveLabel, lpInfOffset)),
-        TaskType.LINEAR_REGRESSION,
-        DataValidationType.VALIDATE_FULL, false),
+        DataValidationType.VALIDATE_FULL,
+        true),
+      Array(Seq(nanLabel), TaskType.LINEAR_REGRESSION, DataValidationType.VALIDATE_FULL, false),
 
-      Array(
-        sc.parallelize(List(lpBinaryLabel, lpPositiveLabel)),
-        TaskType.LOGISTIC_REGRESSION,
-        DataValidationType.VALIDATE_FULL, false),
-      Array(
-        sc.parallelize(List(lpBinaryLabel, lpInfLabel)),
-        TaskType.LOGISTIC_REGRESSION,
-        DataValidationType.VALIDATE_FULL, false),
-      Array(
-        sc.parallelize(List(lpBinaryLabel, lpBinaryLabelInfFeatures)),
-        TaskType.LOGISTIC_REGRESSION,
-        DataValidationType.VALIDATE_FULL, false),
-      Array(
-        sc.parallelize(List(lpBinaryLabel, lpInfOffset)),
-        TaskType.LOGISTIC_REGRESSION,
-        DataValidationType.VALIDATE_FULL, false),
+      // Test logistic regression checks for binary label
+      Array(Seq(binaryLabel, zeroLabel), TaskType.LOGISTIC_REGRESSION, DataValidationType.VALIDATE_FULL, true),
+      Array(Seq(positiveLabel), TaskType.LOGISTIC_REGRESSION, DataValidationType.VALIDATE_FULL, false),
+      Array(Seq(negativeLabel), TaskType.LOGISTIC_REGRESSION, DataValidationType.VALIDATE_FULL, false),
+      Array(Seq(nanLabel), TaskType.LOGISTIC_REGRESSION, DataValidationType.VALIDATE_FULL, false),
 
+      // Test smoothed hinge loss checks for binary label
       Array(
-        sc.parallelize(List(lpPositiveLabel, lpInfLabel)),
-        TaskType.POISSON_REGRESSION,
-        DataValidationType.VALIDATE_FULL, false),
+        Seq(binaryLabel, zeroLabel),
+        TaskType.SMOOTHED_HINGE_LOSS_LINEAR_SVM,
+        DataValidationType.VALIDATE_FULL,
+        true),
+      Array(Seq(positiveLabel), TaskType.SMOOTHED_HINGE_LOSS_LINEAR_SVM, DataValidationType.VALIDATE_FULL, false),
+      Array(Seq(negativeLabel), TaskType.SMOOTHED_HINGE_LOSS_LINEAR_SVM, DataValidationType.VALIDATE_FULL, false),
+      Array(Seq(nanLabel), TaskType.SMOOTHED_HINGE_LOSS_LINEAR_SVM, DataValidationType.VALIDATE_FULL, false),
+
+      // Test Poisson regression checks for non-negative label
       Array(
-        sc.parallelize(List(lpPositiveLabel, lpNegativeLabel)),
+        Seq(positiveLabel, binaryLabel, zeroLabel),
         TaskType.POISSON_REGRESSION,
-        DataValidationType.VALIDATE_FULL, false),
+        DataValidationType.VALIDATE_FULL,
+        true),
+      Array(Seq(negativeLabel), TaskType.POISSON_REGRESSION, DataValidationType.VALIDATE_FULL, false),
+      Array(Seq(nanLabel), TaskType.POISSON_REGRESSION, DataValidationType.VALIDATE_FULL, false),
+
+      // Test all task types require finite features
+      Array(Seq(badFeatures1), TaskType.LINEAR_REGRESSION, DataValidationType.VALIDATE_FULL, false),
+      Array(Seq(badFeatures2), TaskType.LINEAR_REGRESSION, DataValidationType.VALIDATE_FULL, false),
+      Array(Seq(badFeaturesBoth), TaskType.LINEAR_REGRESSION, DataValidationType.VALIDATE_FULL, false),
+      Array(Seq(badFeatures1), TaskType.LOGISTIC_REGRESSION, DataValidationType.VALIDATE_FULL, false),
+      Array(Seq(badFeatures2), TaskType.LOGISTIC_REGRESSION, DataValidationType.VALIDATE_FULL, false),
+      Array(Seq(badFeaturesBoth), TaskType.LOGISTIC_REGRESSION, DataValidationType.VALIDATE_FULL, false),
+      Array(Seq(badFeatures1), TaskType.SMOOTHED_HINGE_LOSS_LINEAR_SVM, DataValidationType.VALIDATE_FULL, false),
+      Array(Seq(badFeatures2), TaskType.SMOOTHED_HINGE_LOSS_LINEAR_SVM, DataValidationType.VALIDATE_FULL, false),
+      Array(Seq(badFeaturesBoth), TaskType.SMOOTHED_HINGE_LOSS_LINEAR_SVM, DataValidationType.VALIDATE_FULL, false),
+      Array(Seq(badFeatures1), TaskType.POISSON_REGRESSION, DataValidationType.VALIDATE_FULL, false),
+      Array(Seq(badFeatures2), TaskType.POISSON_REGRESSION, DataValidationType.VALIDATE_FULL, false),
+      Array(Seq(badFeaturesBoth), TaskType.POISSON_REGRESSION, DataValidationType.VALIDATE_FULL, false),
+
+      // Test all task types require finite offset
+      Array(Seq(badOffset), TaskType.LINEAR_REGRESSION, DataValidationType.VALIDATE_FULL, false),
+      Array(Seq(badOffset), TaskType.LOGISTIC_REGRESSION, DataValidationType.VALIDATE_FULL, false),
+      Array(Seq(badOffset), TaskType.SMOOTHED_HINGE_LOSS_LINEAR_SVM, DataValidationType.VALIDATE_FULL, false),
+      Array(Seq(badOffset), TaskType.POISSON_REGRESSION, DataValidationType.VALIDATE_FULL, false),
+
+      // Test all task types require valid weight
+      Array(Seq(badWeight), TaskType.LINEAR_REGRESSION, DataValidationType.VALIDATE_FULL, false),
+      Array(Seq(badWeight), TaskType.LOGISTIC_REGRESSION, DataValidationType.VALIDATE_FULL, false),
+      Array(Seq(badWeight), TaskType.SMOOTHED_HINGE_LOSS_LINEAR_SVM, DataValidationType.VALIDATE_FULL, false),
+      Array(Seq(badWeight), TaskType.POISSON_REGRESSION, DataValidationType.VALIDATE_FULL, false),
+
+      // Test that even one bad sample causes failure
       Array(
-        sc.parallelize(List(lpPositiveLabel, lpNonBinaryLabelInfFeatures)),
+        Seq(positiveLabel, binaryLabel, zeroLabel),
         TaskType.POISSON_REGRESSION,
-        DataValidationType.VALIDATE_FULL, false),
+        DataValidationType.VALIDATE_FULL,
+        true),
       Array(
-        sc.parallelize(List(lpPositiveLabel, lpInfOffset)),
+        Seq(positiveLabel, binaryLabel, zeroLabel, negativeLabel),
         TaskType.POISSON_REGRESSION,
-        DataValidationType.VALIDATE_FULL, false)
+        DataValidationType.VALIDATE_FULL,
+        false),
+
+      // Test that VALIDATE_DISABLED will ignore bad rows
+      Array(Seq(positiveLabel), TaskType.LOGISTIC_REGRESSION, DataValidationType.VALIDATE_FULL, false),
+      Array(Seq(positiveLabel), TaskType.LOGISTIC_REGRESSION, DataValidationType.VALIDATE_DISABLED, true)
     )
   }
 
-  // TODO: Unlike other tests, these tests require the Spark context in the data provider. These tests do not work as
-  // usual because our sparkTest framework initializes the context after the data provider rather than before. The tests
-  // have been temporarily implemented without using the DataProvider annotation.
+  /**
+   * Test that well-formed datasets will not cause errors during validation and poorly-formed datasets will.
+   *
+   * @param input Input data
+   * @param taskType Training task
+   * @param validationType Type of validation to perform
+   * @param expectedResult Whether or not validation errors are expected for the input data
+   */
+  @Test(dataProvider = "sanityCheckDataInput")
+  def testSanityCheckData(
+      input: Seq[LabeledPoint],
+      taskType: TaskType,
+      validationType: DataValidationType,
+      expectedResult: Boolean): Unit = sparkTest("testSanityCheckData") {
 
-  @Test
-  def testSuccessSanityCheckData(): Unit = sparkTest("testSanityCheckData") {
-    val input = getSuccessArgumentsForSanityCheckData
+    val rdd = sc.parallelize(input)
 
-    for (x <- input) {
-      DataValidators.sanityCheckData(
-        x(0).asInstanceOf[RDD[LabeledPoint]],
-        x(1).asInstanceOf[TaskType],
-        x(2).asInstanceOf[DataValidationType])
+    val actualResult = Try(DataValidators.sanityCheckData(rdd, taskType, validationType)) match {
+      case Success(_) => true
+      case Failure(_: IllegalArgumentException) => false
+      case Failure(e) => throw new MatchError(s"Unexpected Error: ${e.getMessage}")
     }
+
+    assertEquals(actualResult, expectedResult)
   }
 
-  @Test
-  def testFailureSanityCheckData(): Unit = sparkTest("testSanityCheckData") {
-    val input = getFailureArgumentsForSanityCheckData
+  /**
+   * Test that well-formed datasets will not cause errors during validation and poorly-formed datasets will.
+   *
+   * @param input Input data
+   * @param taskType Training task
+   * @param validationType Type of validation to perform
+   * @param expectedResult Whether or not validation errors are expected for the input data
+   */
+  @Test(dataProvider = "sanityCheckDataFrameForTrainingInput")
+  def testSanityCheckDataFrameForTraining(
+      input: Seq[Row],
+      taskType: TaskType,
+      validationType: DataValidationType,
+      expectedResult: Boolean): Unit = sparkTest("testSanityCheckDataFrameForTraining") {
 
-    for (x <- input) {
-      val result = Try(
-        DataValidators.sanityCheckData(
-          x(0).asInstanceOf[RDD[LabeledPoint]],
-          x(1).asInstanceOf[TaskType],
-          x(2).asInstanceOf[DataValidationType]))
+    val dataFrame = sparkSession.createDataFrame(sc.parallelize(input), ROW_SCHEMA)
 
-      result match {
-        case Success(_) => throw new IllegalArgumentException("Unexpected success for bad data")
-        case _ =>
-      }
-    }
-  }
-
-  @Test
-  def testSuccessSanityCheckDataFrame(): Unit = sparkTest("testSanityCheckDataFrame") {
-
-    val schema = new StructType(Array(StructField(InputColumnsNames.RESPONSE.toString, DoubleType),
-      StructField(InputColumnsNames.WEIGHT.toString, DoubleType),
-      StructField(InputColumnsNames.OFFSET.toString, DoubleType),
-      StructField(InputColumnsNames.FEATURES_DEFAULT.toString, VectorType)))
-
-    val input = getSuccessArgumentsForSanityCheckData
-
-    for (x <- input) {
-      val labeledPoints = x(0).asInstanceOf[RDD[LabeledPoint]]
-
-      val rows = labeledPoints.map(lp => {
-        val features = Vectors.dense(lp.features.toArray).toSparse
-        Row(lp.label, lp.weight, lp.offset, features)
-      })
-
-      val inputColumnsNames = InputColumnsNames()
-      val featureNames = Set(InputColumnsNames.FEATURES_DEFAULT.toString)
-
+    val tryResult = Try(
       DataValidators.sanityCheckDataFrameForTraining(
-        sparkSession.createDataFrame(rows, schema),
-        x(1).asInstanceOf[TaskType],
-        x(2).asInstanceOf[DataValidationType],
-        inputColumnsNames,
-        featureNames)
+        dataFrame,
+        taskType,
+        validationType,
+        INPUT_COLUMN_NAMES,
+        FEATURE_COLUMNS))
+    val actualResult = tryResult match {
+      case Success(_) => true
+      case Failure(_: IllegalArgumentException) => false
+      case Failure(e) => throw new MatchError(s"Unexpected Error: ${e.getMessage}")
     }
+
+    assertEquals(actualResult, expectedResult)
   }
+}
 
-  @Test
-  def testFailureSanityCheckDataFrame(): Unit = sparkTest("testSanityCheckDataFrame") {
+object DataValidatorsIntegTest {
 
-    val schema = new StructType(Array(StructField(InputColumnsNames.RESPONSE.toString, DoubleType),
-      StructField(InputColumnsNames.WEIGHT.toString, DoubleType),
-      StructField(InputColumnsNames.OFFSET.toString, DoubleType),
-      StructField(InputColumnsNames.FEATURES_DEFAULT.toString, VectorType)))
+  private val INPUT_COLUMN_NAMES = InputColumnsNames()
 
-    val input = getFailureArgumentsForSanityCheckData
+  private val RESPONSE = InputColumnsNames.RESPONSE.toString
+  private val OFFSET = InputColumnsNames.OFFSET.toString
+  private val WEIGHT = InputColumnsNames.WEIGHT.toString
+  private val FEATURES_BAG_1 = "featureBag1"
+  private val FEATURES_BAG_2 = "featureBag2"
+  private val FEATURE_COLUMNS = Set(FEATURES_BAG_1, FEATURES_BAG_2)
 
-    for (x <- input) {
-      val labeledPoints = x(0).asInstanceOf[RDD[LabeledPoint]]
+  private val RESPONSE_COLUMN = StructField(RESPONSE, DoubleType)
+  private val OFFSET_COLUMN = StructField(OFFSET, DoubleType)
+  private val WEIGHT_COLUMN = StructField(WEIGHT, DoubleType)
+  private val FEATURES_COLUMN_1 = StructField(FEATURES_BAG_1, VectorType)
+  private val FEATURES_COLUMN_2 = StructField(FEATURES_BAG_2, VectorType)
 
-      val rows = labeledPoints.map(lp => {
-        val features = Vectors.dense(lp.features.toArray).toSparse
-        Row(lp.label, lp.weight, lp.offset, features)
-      })
-
-      val inputColumnsNames = InputColumnsNames()
-      val featureNames = Set(InputColumnsNames.FEATURES_DEFAULT.toString)
-
-      val result = Try(DataValidators.sanityCheckDataFrameForTraining(
-        sparkSession.createDataFrame(rows, schema),
-        x(1).asInstanceOf[TaskType],
-        x(2).asInstanceOf[DataValidationType],
-        inputColumnsNames,
-        featureNames))
-
-      result match {
-        case Success(_) => throw new IllegalArgumentException("Unexpected success for bad data")
-        case _ =>
-      }
-    }
-  }
+  private val ROW_SCHEMA =
+    new StructType(Array(RESPONSE_COLUMN, OFFSET_COLUMN, WEIGHT_COLUMN, FEATURES_COLUMN_1, FEATURES_COLUMN_2))
 }

--- a/photon-client/src/main/scala/com/linkedin/photon/ml/data/DataValidators.scala
+++ b/photon-client/src/main/scala/com/linkedin/photon/ml/data/DataValidators.scala
@@ -69,8 +69,13 @@ object DataValidators extends Logging {
    */
   def rowHasFiniteColumn(row: Row, inputColumnName: String): Boolean =
     row.getAs[Any](inputColumnName) match {
-      case col: Double => !(col.isNaN || col.isInfinite)
-      case _ => false
+      case col: Number =>
+        val d = col.doubleValue()
+
+        !(d.isNaN || d.isInfinite)
+
+      case _ =>
+        false
     }
 
   /**
@@ -101,8 +106,13 @@ object DataValidators extends Logging {
    */
   def rowHasBinaryLabel(row: Row, inputColumnName: String): Boolean =
     row.getAs[Any](inputColumnName) match {
-      case label: Double => BinaryClassifier.positiveClassLabel == label || BinaryClassifier.negativeClassLabel == label
-      case _ => false
+      case label: Number =>
+        val d = label.doubleValue()
+
+        BinaryClassifier.positiveClassLabel == d || BinaryClassifier.negativeClassLabel == d
+
+      case _ =>
+        false
     }
 
   /**
@@ -123,8 +133,13 @@ object DataValidators extends Logging {
    */
   def rowHasNonNegativeLabel(row: Row, inputColumnName: String): Boolean =
     row.getAs[Any](inputColumnName) match {
-      case label: Double => !(label.isNaN || label.isInfinite) && (label >= 0)
-      case _ => false
+      case label: Number =>
+        val d = label.doubleValue()
+
+        !(d.isNaN || d.isInfinite) && (d >= 0)
+
+      case _ =>
+        false
     }
 
   /**
@@ -180,8 +195,13 @@ object DataValidators extends Logging {
   def rowHasValidWeight(row: Row, inputColumnName: String): Boolean =
     row.getAs[Any](inputColumnName) match {
       // Weight should be significantly larger than 0
-      case weight: Double =>  !(weight.isNaN || weight.isInfinite) && (weight > MathConst.EPSILON)
-      case _ => false
+      case weight: Number =>
+        val d = weight.doubleValue()
+
+        !(d.isNaN || d.isInfinite) && (d > MathConst.EPSILON)
+
+      case _ =>
+        false
     }
 
   /**

--- a/photon-client/src/main/scala/com/linkedin/photon/ml/data/DataValidators.scala
+++ b/photon-client/src/main/scala/com/linkedin/photon/ml/data/DataValidators.scala
@@ -14,18 +14,17 @@
  */
 package com.linkedin.photon.ml.data
 
+import org.apache.spark.ml.linalg.{DenseVector, SparseVector}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{DataFrame, Row}
-import org.apache.spark.ml.linalg.SparseVector
 
 import com.linkedin.photon.ml.DataValidationType.DataValidationType
 import com.linkedin.photon.ml.TaskType.TaskType
 import com.linkedin.photon.ml.Types.FeatureShardId
+import com.linkedin.photon.ml.constants.MathConst
 import com.linkedin.photon.ml.supervised.classification.BinaryClassifier
 import com.linkedin.photon.ml.util.Logging
 import com.linkedin.photon.ml.{DataValidationType, TaskType}
-
-import com.linkedin.photon.ml.constants.MathConst
 
 /**
  * A collection of methods used to validate data before applying ML algorithms.
@@ -36,7 +35,7 @@ object DataValidators extends Logging {
   val baseValidators: List[((LabeledPoint => Boolean), String)] = List(
     (finiteFeatures, "Data contains row(s) with invalid (+/- Inf or NaN) feature(s)"),
     (finiteOffset, "Data contains row(s) with invalid (+/- Inf or NaN) offset(s)"),
-    (nonNegativeWeight, "Data contains row(s) with invalid (-, Inf, or NaN) weight(s)"))
+    (validWeight, "Data contains row(s) with invalid (-, 0, Inf, or NaN) weight(s)"))
   val linearRegressionValidators: List[((LabeledPoint => Boolean), String)] =
     (finiteLabel _, "Data contains row(s) with invalid (+/- Inf or NaN) label(s)") :: baseValidators
   val logisticRegressionValidators: List[((LabeledPoint => Boolean), String)] =
@@ -50,7 +49,7 @@ object DataValidators extends Logging {
       InputColumnsNames.FEATURES_DEFAULT,
       "Data contains row(s) with invalid (+/- Inf or NaN) feature(s)"),
     (rowHasFiniteColumn, InputColumnsNames.OFFSET, "Data contains row(s) with invalid (+/- Inf or NaN) offset(s)"),
-    (rowHasNonNegativeWeight, InputColumnsNames.WEIGHT, "Data contains row(s) with invalid (-, Inf, or NaN) weight(s)"))
+    (rowHasValidWeight, InputColumnsNames.WEIGHT, "Data contains row(s) with invalid (-, 0, Inf, or NaN) weight(s)"))
   val dataFrameLinearRegressionValidators: List[(((Row, String) => Boolean), InputColumnsNames.Value, String)] =
     (rowHasFiniteColumn _, InputColumnsNames.RESPONSE, "Data contains row(s) with invalid (+/- Inf or NaN) label(s)") ::
       dataFrameBaseValidators
@@ -149,6 +148,7 @@ object DataValidators extends Logging {
   def rowHasFiniteFeatures(row: Row, inputColumnName: String): Boolean =
     row.getAs[Any](inputColumnName) match {
       case features: SparseVector => features.values.forall(value => !(value.isNaN || value.isInfinite))
+      case features: DenseVector => features.values.forall(value => !(value.isNaN || value.isInfinite))
       case _ => false
     }
 
@@ -167,7 +167,7 @@ object DataValidators extends Logging {
    * @param labeledPoint The input data point
    * @return Whether the weight of the input data point is finite
    */
-  def nonNegativeWeight(labeledPoint: LabeledPoint): Boolean =
+  def validWeight(labeledPoint: LabeledPoint): Boolean =
     !(labeledPoint.weight.isNaN || labeledPoint.weight.isInfinite) && (labeledPoint.weight > MathConst.EPSILON)
 
   /**
@@ -177,7 +177,7 @@ object DataValidators extends Logging {
    * @param inputColumnName The column name we want to validate
    * @return Whether the weight column of the row is positive
    */
-  def rowHasNonNegativeWeight(row: Row, inputColumnName: String): Boolean =
+  def rowHasValidWeight(row: Row, inputColumnName: String): Boolean =
     row.getAs[Any](inputColumnName) match {
       // Weight should be significantly larger than 0
       case weight: Double =>  !(weight.isNaN || weight.isInfinite) && (weight > MathConst.EPSILON)
@@ -259,27 +259,32 @@ object DataValidators extends Logging {
       featureSectionKeys: Set[FeatureShardId]): Seq[String] = {
 
     val columns = dataset.columns
-    dataset
-      .rdd
-      .flatMap { r =>
-        perSampleValidators
-          .flatMap { case (validator, columnName, msg) =>
-            if (columnName == InputColumnsNames.FEATURES_DEFAULT) {
-              featureSectionKeys.map(features => (validator(r, features), msg))
-            } else {
-              val result = if (columns.contains(inputColumnsNames(columnName))) {
-                (validator(r, inputColumnsNames(columnName)), msg)
-              } else {
-                (true, "")
-              }
+    val rdd = dataset.rdd
 
-              Seq(result)
-            }
+    perSampleValidators
+      .flatMap { case (validator, columnName, msg) =>
+
+        val validatorBroadcast = dataset.sparkSession.sparkContext.broadcast(validator)
+
+        def aggregatorHelper(columnName: String): Boolean =
+          rdd.aggregate(true)(
+            seqOp = (result, row) => result && (validatorBroadcast.value)(row, columnName),
+            combOp = (result1, result2) => result1 && result2)
+
+        if (columnName == InputColumnsNames.FEATURES_DEFAULT) {
+          featureSectionKeys.map(featureColumn => (aggregatorHelper(featureColumn), s"$msg: $featureColumn"))
+        } else {
+          val result = if (columns.contains(inputColumnsNames(columnName))) {
+            aggregatorHelper(inputColumnsNames(columnName))
+          } else {
+            true
           }
-          .filterNot(_._1)
-          .map(_._2)
+
+          Seq((result, msg))
+        }
       }
-      .collect()
+      .filterNot(_._1)
+      .map(_._2)
   }
 
   /**
@@ -346,33 +351,35 @@ object DataValidators extends Logging {
       dataValidationType: DataValidationType,
       inputColumnsNames: InputColumnsNames,
       featureSectionKeys: Set[FeatureShardId],
-      taskTypeOpt: Option[TaskType] = None): Unit = taskTypeOpt match {
-    case Some(taskType) =>
-      sanityCheckDataFrameForTraining(inputData, taskType, dataValidationType, inputColumnsNames, featureSectionKeys)
+      taskTypeOpt: Option[TaskType] = None): Unit =
 
-    case None =>
-      // Check the data properties
-      val dataErrors = dataValidationType match {
-        case DataValidationType.VALIDATE_FULL =>
-          validateDataFrame(
-            inputData,
-            dataFrameBaseValidators,
-            inputColumnsNames,
-            featureSectionKeys)
+    taskTypeOpt match {
+      case Some(taskType) =>
+        sanityCheckDataFrameForTraining(inputData, taskType, dataValidationType, inputColumnsNames, featureSectionKeys)
 
-        case DataValidationType.VALIDATE_SAMPLE =>
-          validateDataFrame(
-            inputData.sample(withReplacement = false, fraction = 0.10),
-            dataFrameBaseValidators,
-            inputColumnsNames,
-            featureSectionKeys)
+      case None =>
+        // Check the data properties
+        val dataErrors = dataValidationType match {
+          case DataValidationType.VALIDATE_FULL =>
+            validateDataFrame(
+              inputData,
+              dataFrameBaseValidators,
+              inputColumnsNames,
+              featureSectionKeys)
 
-        case DataValidationType.VALIDATE_DISABLED =>
-          Seq()
-      }
+          case DataValidationType.VALIDATE_SAMPLE =>
+            validateDataFrame(
+              inputData.sample(withReplacement = false, fraction = 0.10),
+              dataFrameBaseValidators,
+              inputColumnsNames,
+              featureSectionKeys)
 
-      if (dataErrors.nonEmpty) {
-        throw new IllegalArgumentException(s"Data Validation failed:\n${dataErrors.mkString("\n")}")
-      }
-  }
+          case DataValidationType.VALIDATE_DISABLED =>
+            Seq()
+        }
+
+        if (dataErrors.nonEmpty) {
+          throw new IllegalArgumentException(s"Data Validation failed:\n${dataErrors.mkString("\n")}")
+        }
+    }
 }

--- a/photon-client/src/test/scala/com/linkedin/photon/ml/data/DataValidatorsTest.scala
+++ b/photon-client/src/test/scala/com/linkedin/photon/ml/data/DataValidatorsTest.scala
@@ -14,59 +14,235 @@
  */
 package com.linkedin.photon.ml.data
 
-import org.testng.Assert
+import org.apache.spark.ml.linalg.SQLDataTypes.VectorType
+import org.apache.spark.ml.linalg.Vector
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema
+import org.apache.spark.sql.types.DataTypes.DoubleType
+import org.apache.spark.sql.types.{StructField, StructType}
+import org.testng.Assert.{assertFalse, assertTrue}
 import org.testng.annotations.Test
 
+import com.linkedin.photon.ml.constants.MathConst
 import com.linkedin.photon.ml.supervised.classification.BinaryClassifier
 import com.linkedin.photon.ml.test.CommonTestUtils
+import com.linkedin.photon.ml.util.VectorUtils
 
 /**
  * Unit tests for [[DataValidators]].
  */
 class DataValidatorsTest {
 
+  import DataValidatorsTest._
+
+  /**
+   * Helper function to generate [[org.apache.spark.sql.DataFrame]] rows.
+   *
+   * @param features Sample features vector
+   * @param response Sample response
+   * @param offset Sample offset
+   * @param weight Sample weight
+   * @return Input data grouped into a [[Row]] with the expected schema
+   */
+  private def getRow(features: Vector, response: Double = 1D, offset: Double = 0D, weight: Double = 1D): Row =
+    new GenericRowWithSchema(Array[Any](response, offset, weight, features), ROW_SCHEMA)
+
+  /**
+   * Test that [[Row]] column values can be determined as finite or not.
+   */
   @Test
-  def testNonNegativeLabels(): Unit = {
-    val vectors = CommonTestUtils.generateDenseFeatureVectors(1, 0, 10)
-    val featVec = vectors.head
-    Assert.assertTrue(DataValidators.nonNegativeLabel(new LabeledPoint(2.0, featVec)))
-    Assert.assertFalse(DataValidators.nonNegativeLabel(new LabeledPoint(-5.0, featVec)))
+  def testRowHasFiniteColumn(): Unit = {
+
+    val featuresVector = VectorUtils.breezeToMl(CommonTestUtils.generateDenseFeatureVectors(1, 0, 10).head)
+    val row = getRow(featuresVector, response = 0D, offset = Double.NaN, weight = Double.NaN)
+
+    assertTrue(DataValidators.rowHasFiniteColumn(row, RESPONSE))
+    assertFalse(DataValidators.rowHasFiniteColumn(row, OFFSET))
+    assertFalse(DataValidators.rowHasFiniteColumn(row, WEIGHT))
+    assertTrue(DataValidators.rowHasFiniteColumn(getRow(featuresVector, Double.MaxValue), RESPONSE))
+    assertTrue(DataValidators.rowHasFiniteColumn(getRow(featuresVector, Double.MinValue), RESPONSE))
+    assertFalse(DataValidators.rowHasFiniteColumn(getRow(featuresVector, Double.PositiveInfinity), RESPONSE))
+    assertFalse(DataValidators.rowHasFiniteColumn(getRow(featuresVector, Double.NegativeInfinity), RESPONSE))
   }
 
+  /**
+   * Test that [[LabeledPoint]] label values can be determined as finite or not.
+   */
+  @Test
+  def testFiniteLabel(): Unit = {
+
+    val featuresVector = CommonTestUtils.generateDenseFeatureVectors(1, 0, 10).head
+
+    assertTrue(DataValidators.finiteLabel(new LabeledPoint(0D, featuresVector)))
+    assertTrue(DataValidators.finiteLabel(new LabeledPoint(Double.MaxValue, featuresVector)))
+    assertTrue(DataValidators.finiteLabel(new LabeledPoint(Double.MinValue, featuresVector)))
+    assertFalse(DataValidators.finiteLabel(new LabeledPoint(Double.NaN, featuresVector)))
+    assertFalse(DataValidators.finiteLabel(new LabeledPoint(Double.PositiveInfinity, featuresVector)))
+    assertFalse(DataValidators.finiteLabel(new LabeledPoint(Double.NegativeInfinity, featuresVector)))
+  }
+
+  /**
+   * Test that [[LabeledPoint]] label values can be determined as binary or not.
+   */
   @Test
   def testBinaryLabel(): Unit = {
-    val vectors = CommonTestUtils.generateDenseFeatureVectors(1, 0, 10)
-    val featVec = vectors.head
-    Assert.assertTrue(DataValidators.binaryLabel(new LabeledPoint(BinaryClassifier.positiveClassLabel, featVec)))
-    Assert.assertTrue(DataValidators.binaryLabel(new LabeledPoint(BinaryClassifier.negativeClassLabel, featVec)))
-    Assert.assertFalse(DataValidators.binaryLabel(new LabeledPoint(5.0, featVec)))
-    Assert.assertFalse(DataValidators.binaryLabel(new LabeledPoint(-5.0, featVec)))
+
+    val featuresVector = CommonTestUtils.generateDenseFeatureVectors(1, 0, 10).head
+
+    assertTrue(DataValidators.binaryLabel(new LabeledPoint(BinaryClassifier.positiveClassLabel, featuresVector)))
+    assertTrue(DataValidators.binaryLabel(new LabeledPoint(BinaryClassifier.negativeClassLabel, featuresVector)))
+    assertFalse(DataValidators.binaryLabel(new LabeledPoint(Double.NaN, featuresVector)))
+    assertFalse(DataValidators.binaryLabel(new LabeledPoint(0.5, featuresVector)))
+    assertFalse(DataValidators.binaryLabel(new LabeledPoint(-1D, featuresVector)))
+    assertFalse(DataValidators.binaryLabel(new LabeledPoint(Double.MaxValue, featuresVector)))
+    assertFalse(DataValidators.binaryLabel(new LabeledPoint(Double.MinValue, featuresVector)))
+    assertFalse(DataValidators.binaryLabel(new LabeledPoint(Double.PositiveInfinity, featuresVector)))
+    assertFalse(DataValidators.binaryLabel(new LabeledPoint(Double.NegativeInfinity, featuresVector)))
   }
 
+  /**
+   * Test that [[Row]] label column values can be determined as binary or not.
+   */
   @Test
-  def testFiniteLabels(): Unit = {
-    val vectors = CommonTestUtils.generateDenseFeatureVectors(1, 0, 10)
-    val featVec = vectors.head
-    Assert.assertTrue(DataValidators.finiteLabel(new LabeledPoint(2.0, featVec)))
-    Assert.assertFalse(DataValidators.finiteLabel(new LabeledPoint(Double.NaN, featVec)))
-    Assert.assertFalse(DataValidators.finiteLabel(new LabeledPoint(Double.PositiveInfinity, featVec)))
-    Assert.assertFalse(DataValidators.finiteLabel(new LabeledPoint(Double.NegativeInfinity, featVec)))
+  def testRowHasBinaryLabel(): Unit = {
+
+    val featuresVector = VectorUtils.breezeToMl(CommonTestUtils.generateDenseFeatureVectors(1, 0, 10).head)
+
+    assertTrue(DataValidators.rowHasBinaryLabel(getRow(featuresVector), RESPONSE))
+    assertTrue(DataValidators.rowHasBinaryLabel(getRow(featuresVector, BinaryClassifier.negativeClassLabel), RESPONSE))
+    assertFalse(DataValidators.rowHasBinaryLabel(getRow(featuresVector, Double.NaN), RESPONSE))
+    assertFalse(DataValidators.rowHasBinaryLabel(getRow(featuresVector, 0.5), RESPONSE))
+    assertFalse(DataValidators.rowHasBinaryLabel(getRow(featuresVector, -1D), RESPONSE))
+    assertFalse(DataValidators.rowHasBinaryLabel(getRow(featuresVector, Double.MaxValue), RESPONSE))
+    assertFalse(DataValidators.rowHasBinaryLabel(getRow(featuresVector, Double.MinValue), RESPONSE))
+    assertFalse(DataValidators.rowHasBinaryLabel(getRow(featuresVector, Double.PositiveInfinity), RESPONSE))
+    assertFalse(DataValidators.rowHasBinaryLabel(getRow(featuresVector, Double.NegativeInfinity), RESPONSE))
   }
 
+  /**
+   * Test that [[LabeledPoint]] label values can be determined as non-negative or not.
+   */
   @Test
-  def testFiniteOffset(): Unit = {
-    val vectors = CommonTestUtils.generateDenseFeatureVectors(1, 0, 10)
-    val featVec = vectors.head
-    Assert.assertTrue(DataValidators.finiteOffset(new LabeledPoint(2.0, featVec, 2.5)))
-    Assert.assertFalse(DataValidators.finiteOffset(new LabeledPoint(2.0, featVec, Double.NaN)))
-    Assert.assertFalse(DataValidators.finiteOffset(new LabeledPoint(2.0, featVec, Double.PositiveInfinity)))
-    Assert.assertFalse(DataValidators.finiteOffset(new LabeledPoint(2.0, featVec, Double.NegativeInfinity)))
+  def testNonNegativeLabel(): Unit = {
+
+    val featuresVector = CommonTestUtils.generateDenseFeatureVectors(1, 0, 10).head
+
+    assertTrue(DataValidators.nonNegativeLabel(new LabeledPoint(0D, featuresVector)))
+    assertTrue(DataValidators.nonNegativeLabel(new LabeledPoint(Double.MaxValue, featuresVector)))
+    assertFalse(DataValidators.nonNegativeLabel(new LabeledPoint(Double.NaN, featuresVector)))
+    assertFalse(DataValidators.nonNegativeLabel(new LabeledPoint(Double.MinValue, featuresVector)))
+    assertFalse(DataValidators.nonNegativeLabel(new LabeledPoint(Double.PositiveInfinity, featuresVector)))
+    assertFalse(DataValidators.nonNegativeLabel(new LabeledPoint(Double.NegativeInfinity, featuresVector)))
   }
 
+  /**
+   * Test that [[Row]] label column values can be determined as non-negative or not.
+   */
+  @Test
+  def testRowHasNonNegativeLabel(): Unit = {
+
+    val featuresVector = VectorUtils.breezeToMl(CommonTestUtils.generateDenseFeatureVectors(1, 0, 10).head)
+
+    assertTrue(DataValidators.rowHasNonNegativeLabel(getRow(featuresVector), RESPONSE))
+    assertTrue(DataValidators.rowHasNonNegativeLabel(getRow(featuresVector, Double.MaxValue), RESPONSE))
+    assertFalse(DataValidators.rowHasNonNegativeLabel(getRow(featuresVector, Double.NaN), RESPONSE))
+    assertFalse(DataValidators.rowHasNonNegativeLabel(getRow(featuresVector, Double.MinValue), RESPONSE))
+    assertFalse(DataValidators.rowHasNonNegativeLabel(getRow(featuresVector, Double.PositiveInfinity), RESPONSE))
+    assertFalse(DataValidators.rowHasNonNegativeLabel(getRow(featuresVector, Double.NegativeInfinity), RESPONSE))
+  }
+
+  /**
+   * Test that [[LabeledPoint]] feature values can be determined as finite or not.
+   */
   @Test
   def testFiniteFeatures(): Unit = {
+
     val vectors = CommonTestUtils.generateDenseFeatureVectors(1, 1, 10)
-    Assert.assertTrue(DataValidators.finiteFeatures(new LabeledPoint(2.0, vectors.head)))
-    Assert.assertFalse(DataValidators.finiteFeatures(new LabeledPoint(2.0, vectors.last)))
+
+    assertTrue(DataValidators.finiteFeatures(new LabeledPoint(2.0, vectors.head)))
+    assertFalse(DataValidators.finiteFeatures(new LabeledPoint(2.0, vectors.last)))
   }
+
+  /**
+   * Test that [[Row]] feature column values can be determined as finite or not.
+   */
+  @Test
+  def testRowHasFiniteFeatures(): Unit = {
+
+    val vectors = CommonTestUtils.generateDenseFeatureVectors(1, 1, 10)
+
+    assertTrue(DataValidators.rowHasFiniteFeatures(getRow(VectorUtils.breezeToMl(vectors.head)), FEATURES))
+    assertFalse(DataValidators.rowHasFiniteFeatures(getRow(VectorUtils.breezeToMl(vectors.last)), FEATURES))
+  }
+
+  /**
+   * Test that [[LabeledPoint]] offset values can be determined as finite or not.
+   */
+  @Test
+  def testFiniteOffset(): Unit = {
+
+    val featuresVector = CommonTestUtils.generateDenseFeatureVectors(1, 0, 10).head
+
+    assertTrue(DataValidators.finiteOffset(new LabeledPoint(2.0, featuresVector)))
+    assertTrue(DataValidators.finiteOffset(new LabeledPoint(2.0, featuresVector, Double.MaxValue)))
+    assertTrue(DataValidators.finiteOffset(new LabeledPoint(2.0, featuresVector, Double.MinValue)))
+    assertFalse(DataValidators.finiteOffset(new LabeledPoint(2.0, featuresVector, Double.NaN)))
+    assertFalse(DataValidators.finiteOffset(new LabeledPoint(2.0, featuresVector, Double.PositiveInfinity)))
+    assertFalse(DataValidators.finiteOffset(new LabeledPoint(2.0, featuresVector, Double.NegativeInfinity)))
+  }
+
+  /**
+   * Test that [[LabeledPoint]] weight values can be determined as valid or not.
+   */
+  @Test
+  def testValidWeight(): Unit = {
+
+    val featuresVector = CommonTestUtils.generateDenseFeatureVectors(1, 0, 10).head
+
+    assertTrue(DataValidators.validWeight(new LabeledPoint(2.0, featuresVector)))
+    assertTrue(DataValidators.validWeight(new LabeledPoint(2.0, featuresVector, weight = MathConst.EPSILON * 2)))
+    assertTrue(DataValidators.validWeight(new LabeledPoint(2.0, featuresVector, weight = Double.MaxValue)))
+    assertFalse(DataValidators.validWeight(new LabeledPoint(2.0, featuresVector, weight = Double.NaN)))
+    assertFalse(DataValidators.validWeight(new LabeledPoint(2.0, featuresVector, weight = 0D)))
+    assertFalse(DataValidators.validWeight(new LabeledPoint(2.0, featuresVector, weight = MathConst.EPSILON)))
+    assertFalse(DataValidators.validWeight(new LabeledPoint(2.0, featuresVector, weight = -1D)))
+    assertFalse(DataValidators.validWeight(new LabeledPoint(2.0, featuresVector, weight = Double.MinValue)))
+    assertFalse(DataValidators.validWeight(new LabeledPoint(2.0, featuresVector, weight = Double.PositiveInfinity)))
+    assertFalse(DataValidators.validWeight(new LabeledPoint(2.0, featuresVector, weight = Double.NegativeInfinity)))
+  }
+
+  /**
+   * Test that [[Row]] weight column values can be determined as valid or not.
+   */
+  @Test
+  def testRowHasValidWeight(): Unit = {
+
+    val featuresVector = VectorUtils.breezeToMl(CommonTestUtils.generateDenseFeatureVectors(1, 0, 10).head)
+
+    assertTrue(DataValidators.rowHasValidWeight(getRow(featuresVector), WEIGHT))
+    assertTrue(DataValidators.rowHasValidWeight(getRow(featuresVector, weight = MathConst.EPSILON * 2), WEIGHT))
+    assertTrue(DataValidators.rowHasValidWeight(getRow(featuresVector, weight = Double.MaxValue), WEIGHT))
+    assertFalse(DataValidators.rowHasValidWeight(getRow(featuresVector, weight = Double.NaN), WEIGHT))
+    assertFalse(DataValidators.rowHasValidWeight(getRow(featuresVector, weight = 0D), WEIGHT))
+    assertFalse(DataValidators.rowHasValidWeight(getRow(featuresVector, weight = MathConst.EPSILON), WEIGHT))
+    assertFalse(DataValidators.rowHasValidWeight(getRow(featuresVector, weight = -1D), WEIGHT))
+    assertFalse(DataValidators.rowHasValidWeight(getRow(featuresVector, weight = Double.MinValue), WEIGHT))
+    assertFalse(DataValidators.rowHasValidWeight(getRow(featuresVector, weight = Double.PositiveInfinity), WEIGHT))
+    assertFalse(DataValidators.rowHasValidWeight(getRow(featuresVector, weight = Double.NegativeInfinity), WEIGHT))
+  }
+}
+
+object DataValidatorsTest {
+
+  private val RESPONSE = InputColumnsNames.RESPONSE.toString
+  private val OFFSET = InputColumnsNames.OFFSET.toString
+  private val WEIGHT = InputColumnsNames.WEIGHT.toString
+  private val FEATURES = InputColumnsNames.FEATURES_DEFAULT.toString
+
+  private val RESPONSE_COLUMN = StructField(RESPONSE, DoubleType)
+  private val OFFSET_COLUMN = StructField(OFFSET, DoubleType)
+  private val WEIGHT_COLUMN = StructField(WEIGHT, DoubleType)
+  private val FEATURES_COLUMN = StructField(FEATURES, VectorType)
+
+  private val ROW_SCHEMA = new StructType(Array(RESPONSE_COLUMN, OFFSET_COLUMN, WEIGHT_COLUMN, FEATURES_COLUMN))
 }

--- a/photon-client/src/test/scala/com/linkedin/photon/ml/data/DataValidatorsTest.scala
+++ b/photon-client/src/test/scala/com/linkedin/photon/ml/data/DataValidatorsTest.scala
@@ -18,7 +18,7 @@ import org.apache.spark.ml.linalg.SQLDataTypes.VectorType
 import org.apache.spark.ml.linalg.Vector
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema
-import org.apache.spark.sql.types.DataTypes.DoubleType
+import org.apache.spark.sql.types.DataTypes._
 import org.apache.spark.sql.types.{StructField, StructType}
 import org.testng.Assert.{assertFalse, assertTrue}
 import org.testng.annotations.Test
@@ -229,6 +229,28 @@ class DataValidatorsTest {
     assertFalse(DataValidators.rowHasValidWeight(getRow(featuresVector, weight = Double.MinValue), WEIGHT))
     assertFalse(DataValidators.rowHasValidWeight(getRow(featuresVector, weight = Double.PositiveInfinity), WEIGHT))
     assertFalse(DataValidators.rowHasValidWeight(getRow(featuresVector, weight = Double.NegativeInfinity), WEIGHT))
+  }
+
+  /**
+   * Test that numeric types aside from [[Double]] are valid for data validation.
+   */
+  @Test
+  def testNonDoubleNumbers(): Unit = {
+
+    val response: Int = 1
+    val offset: Long = 0L
+    val weight: Float = 1F
+
+    val schema = new StructType(
+      Array(
+        StructField(RESPONSE, IntegerType),
+        StructField(OFFSET, LongType),
+        StructField(WEIGHT, FloatType)))
+    val row = new GenericRowWithSchema(Array[Any](response, offset, weight), schema)
+
+    assertTrue(DataValidators.rowHasNonNegativeLabel(row, RESPONSE))
+    assertTrue(DataValidators.rowHasFiniteColumn(row, OFFSET))
+    assertTrue(DataValidators.rowHasValidWeight(row, WEIGHT))
   }
 }
 


### PR DESCRIPTION
- Add support for all numeric types (not just `Double`)
- Support Spark `DenseVector`
- Fix bug that would cause OOM failure when generating error message