### PR TITLE
Remove reference to mllib.linalg.Vectors

### DIFF
--- a/photon-api/src/test/scala/com/linkedin/photon/ml/util/GameTestUtils.scala
+++ b/photon-api/src/test/scala/com/linkedin/photon/ml/util/GameTestUtils.scala
@@ -16,7 +16,7 @@ package com.linkedin.photon.ml.util
 
 import java.util.concurrent.atomic.AtomicLong
 
-import org.apache.spark.mllib.linalg.Vectors
+import org.apache.spark.ml.linalg.Vectors
 import org.apache.spark.{HashPartitioner, SparkConf}
 import org.testng.annotations.DataProvider
 

--- a/photon-client/src/integTest/scala/com/linkedin/photon/ml/data/DataValidatorsIntegTest.scala
+++ b/photon-client/src/integTest/scala/com/linkedin/photon/ml/data/DataValidatorsIntegTest.scala
@@ -18,7 +18,8 @@ import scala.util.{Success, Try}
 
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.Row
-import org.apache.spark.mllib.linalg.{VectorUDT, Vectors}
+import org.apache.spark.ml.linalg.SQLDataTypes.VectorType
+import org.apache.spark.ml.linalg.Vectors
 import org.testng.Assert
 import org.testng.annotations.{DataProvider, Test}
 
@@ -246,7 +247,7 @@ class DataValidatorsIntegTest extends SparkTestUtils {
     val schema = new StructType(Array(StructField(InputColumnsNames.RESPONSE.toString, DoubleType),
       StructField(InputColumnsNames.WEIGHT.toString, DoubleType),
       StructField(InputColumnsNames.OFFSET.toString, DoubleType),
-      StructField(InputColumnsNames.FEATURES_DEFAULT.toString, new VectorUDT)))
+      StructField(InputColumnsNames.FEATURES_DEFAULT.toString, VectorType)))
 
     val input = getSuccessArgumentsForSanityCheckData
 
@@ -276,7 +277,7 @@ class DataValidatorsIntegTest extends SparkTestUtils {
     val schema = new StructType(Array(StructField(InputColumnsNames.RESPONSE.toString, DoubleType),
       StructField(InputColumnsNames.WEIGHT.toString, DoubleType),
       StructField(InputColumnsNames.OFFSET.toString, DoubleType),
-      StructField(InputColumnsNames.FEATURES_DEFAULT.toString, new VectorUDT)))
+      StructField(InputColumnsNames.FEATURES_DEFAULT.toString, VectorType)))
 
     val input = getFailureArgumentsForSanityCheckData
 

--- a/photon-client/src/main/scala/com/linkedin/photon/ml/data/DataValidators.scala
+++ b/photon-client/src/main/scala/com/linkedin/photon/ml/data/DataValidators.scala
@@ -16,7 +16,7 @@ package com.linkedin.photon.ml.data
 
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{DataFrame, Row}
-import org.apache.spark.mllib.linalg.SparseVector
+import org.apache.spark.ml.linalg.SparseVector
 
 import com.linkedin.photon.ml.DataValidationType.DataValidationType
 import com.linkedin.photon.ml.TaskType.TaskType

--- a/photon-client/src/test/scala/com/linkedin/photon/ml/data/avro/AvroDataWriterTest.scala
+++ b/photon-client/src/test/scala/com/linkedin/photon/ml/data/avro/AvroDataWriterTest.scala
@@ -18,7 +18,7 @@ import org.apache.spark.sql.Row
 import org.apache.spark.sql.types.DataTypes._
 import org.testng.Assert._
 import org.apache.spark.ml.linalg.Vectors
-import org.apache.spark.mllib.linalg.VectorUDT
+import org.apache.spark.ml.linalg.SQLDataTypes.VectorType
 import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema
 import org.apache.spark.sql.types.{StructField, StructType}
 import org.testng.annotations.{DataProvider, Test}
@@ -51,7 +51,7 @@ class AvroDataWriterTest {
         StructField("response", DoubleType),
         StructField("offset", NullType),
         StructField("weight", NullType),
-        StructField("features", new VectorUDT)))
+        StructField("features", VectorType)))
     val nullRow = new GenericRowWithSchema(nullArray, nullSchema)
 
     val rows = arrays
@@ -62,7 +62,7 @@ class AvroDataWriterTest {
             StructField("response", t),
             StructField("offset", t),
             StructField("weight", t),
-            StructField("features", new VectorUDT)))
+            StructField("features", VectorType)))
 
         Array(new GenericRowWithSchema(a, schema))
       }

--- a/photon-lib/src/integTest/scala/com/linkedin/photon/ml/stat/FeatureDataStatisticsIntegTest.scala
+++ b/photon-lib/src/integTest/scala/com/linkedin/photon/ml/stat/FeatureDataStatisticsIntegTest.scala
@@ -16,8 +16,7 @@ package com.linkedin.photon.ml.stat
 
 import breeze.linalg.{DenseMatrix, max => Bmax, min => Bmin, norm => Bnorm}
 import breeze.stats.{MeanAndVariance, meanAndVariance}
-import org.apache.spark.ml.linalg.{Vector => SparkMLVector}
-import org.apache.spark.mllib.linalg.Vectors
+import org.apache.spark.ml.linalg.{Vector, Vectors}
 import org.apache.spark.sql.DataFrame
 import org.testng.Assert._
 import org.testng.annotations.{DataProvider, Test}
@@ -70,7 +69,7 @@ class FeatureDataStatisticsIntegTest extends SparkTestUtils {
         .toDF("response", featureShardId)
 
       // Calling rdd explicitly here to avoid a typed encoder lookup in Spark 2.1
-      val stats = FeatureDataStatistics(trainingData.select(featureShardId).rdd.map(_.getAs[SparkMLVector](0)), None)
+      val stats = FeatureDataStatistics(trainingData.select(featureShardId).rdd.map(_.getAs[Vector](0)), None)
 
       assertEquals(stats.count, 10)
       assertEquals(stats.mean(0), 0.3847210904276229, CommonTestUtils.HIGH_PRECISION_TOLERANCE)

--- a/photon-lib/src/main/scala/com/linkedin/photon/ml/Types.scala
+++ b/photon-lib/src/main/scala/com/linkedin/photon/ml/Types.scala
@@ -20,9 +20,9 @@ package com.linkedin.photon.ml
  */
 object Types {
 
-  type SDV = org.apache.spark.mllib.linalg.DenseVector
-  type SSV = org.apache.spark.mllib.linalg.SparseVector
-  type SparkVector = org.apache.spark.mllib.linalg.Vector
+  type SDV = org.apache.spark.ml.linalg.DenseVector
+  type SSV = org.apache.spark.ml.linalg.SparseVector
+  type SparkVector = org.apache.spark.ml.linalg.Vector
 
   // A "sample" is a training, validation or scoring vector of feature values
   type UniqueSampleId = Long

--- a/photon-lib/src/main/scala/com/linkedin/photon/ml/data/LabeledPoint.scala
+++ b/photon-lib/src/main/scala/com/linkedin/photon/ml/data/LabeledPoint.scala
@@ -93,7 +93,7 @@ object LabeledPoint {
       features: SparkVector,
       offset: Double = 0.0,
       weight: Double = 1.0): LabeledPoint = {
-    new LabeledPoint(label, VectorUtils.mllibToBreeze(features), offset, weight)
+    new LabeledPoint(label, VectorUtils.mlToBreeze(features), offset, weight)
   }
 
   /**

--- a/photon-lib/src/main/scala/com/linkedin/photon/ml/util/VectorUtils.scala
+++ b/photon-lib/src/main/scala/com/linkedin/photon/ml/util/VectorUtils.scala
@@ -17,11 +17,11 @@ package com.linkedin.photon.ml.util
 import scala.collection.mutable
 
 import breeze.linalg.{DenseVector, SparseVector, Vector}
-import org.apache.spark.ml.linalg.{Vector => SparkMLVector}
-import org.apache.spark.mllib.linalg.{Vectors, DenseVector => SparkDenseVector, SparseVector => SparkSparseVector, Vector => SparkVector}
+import org.apache.spark.ml.linalg.{DenseVector => SparkMLDenseVector, SparseVector => SparkMLSparseVector, Vector => SparkMLVector}
+import org.apache.spark.mllib.linalg.{DenseVector => SparkDenseVector, SparseVector => SparkSparseVector, Vector => SparkVector}
 
 /**
- * A utility object that contains operations to create, copy, compare, and convert Breeze [[Vector]] objects.
+ * A utility object that contains operations to create, copy, compare, and convert [[Vector]] objects.
  */
 object VectorUtils {
 
@@ -199,7 +199,13 @@ object VectorUtils {
    * @param mlVector The spark.ml vector
    * @return The Breeze vector
    */
-  def mlToBreeze(mlVector: SparkMLVector): Vector[Double] = mllibToBreeze(Vectors.fromML(mlVector))
+  def mlToBreeze(mlVector: SparkMLVector): Vector[Double] =
+    mlVector match {
+      case dv: SparkMLDenseVector =>
+        new DenseVector[Double](dv.values)
+      case sv: SparkMLSparseVector =>
+        new SparseVector[Double](sv.indices, sv.values, sv.size)
+    }
 
   /**
    * Determines when two vectors are "equal" within a very small tolerance.


### PR DESCRIPTION
All references to mllib.linalg.Vectors are contained within VectorUtils.scala.
Ideally we should remove all references to mllib.linalg.Vectors, but there are
certain cases where mllib.linalg.Vectors are still needed and cannot be refactored easily.