### PR TITLE
Remove the lower bound on passive dataset size as a tuning parameter

### DIFF
--- a/photon-api/src/main/scala/com/linkedin/photon/ml/data/CoordinateDataConfiguration.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/data/CoordinateDataConfiguration.scala
@@ -48,18 +48,9 @@ case class FixedEffectDataConfiguration(
  * @param numActiveDataPointsLowerBound The lower bound on the number of samples required to train a random effect model
  *                                      for an entity. If this bound is not met, the data is discarded.
  * @param numActiveDataPointsUpperBound The upper bound on the number of samples to keep (via reservoir sampling) as
- *                                      "active" for each individual-id level local dataset. The remaining samples that
- *                                      meet the numPassiveDataPointsToKeepLowerBound as discussed below will be kept as
- *                                      "passive" data.
- * @param numPassiveDataPointsLowerBound The lower bound on the number of data points required to create an
- *                                       individual-id level passive dataset using the data points leftover from the
- *                                       active dataset. In summary: IDs with fewer than
- *                                       [[numActiveDataPointsUpperBound]] samples will only an active dataset
- *                                       containing all samples; IDs with fewer than ([[numActiveDataPointsUpperBound]]
- *                                       + [[numPassiveDataPointsLowerBound]]) will have only an active dataset
- *                                       containing [[numActiveDataPointsUpperBound]] samples; all other IDs will have
- *                                       an active dataset containing [[numActiveDataPointsUpperBound]] samples and a
- *                                       passive dataset containing the remaining samples.
+ *                                      "active" for each individual-id level local dataset. The remaining samples will
+ *                                      be kept as "passive" data. "Active" data is used for model training and residual
+ *                                      computation. "Passive" data is used only for residual computation.
  * @param numFeaturesToSamplesRatioUpperBound The upper bound on the ratio between number of features and number of
  *                                            samples. Used for dimensionality reduction for IDs with very few samples.
  * @param projectorType The projector type, which is used to project the feature space of the random effect dataset
@@ -71,7 +62,6 @@ case class RandomEffectDataConfiguration(
     minNumPartitions: Int = 1,
     numActiveDataPointsLowerBound: Option[Int] = None,
     numActiveDataPointsUpperBound: Option[Int] = None,
-    numPassiveDataPointsLowerBound: Option[Int] = None,
     numFeaturesToSamplesRatioUpperBound: Option[Double] = None,
     projectorType: ProjectorType = IndexMapProjection)
   extends CoordinateDataConfiguration {
@@ -81,13 +71,10 @@ case class RandomEffectDataConfiguration(
     s"Active data lower bound must be greater than 0: ${numActiveDataPointsLowerBound.get}")
   require(
     numActiveDataPointsUpperBound.forall(_ > 0),
-    s"Active data upper bound must be greater than 0: ${numActiveDataPointsUpperBound.get}")
+    s"Active data upper bound must be greater than 0: $numActiveDataPointsUpperBound")
   require(
     numActiveDataPointsLowerBound.forall(_ <= numActiveDataPointsUpperBound.getOrElse(Int.MaxValue)),
     s"Active data lower bound must be less than active data upper bound (${numActiveDataPointsUpperBound.get})")
-  require(
-    numPassiveDataPointsLowerBound.forall(_ > 0),
-    s"Passive data lower bound must be greater than 0: ${numPassiveDataPointsLowerBound.get}")
   require(
     numFeaturesToSamplesRatioUpperBound.forall(_ > 0),
     s"Features to samples ratio must be greater than 0: ${numFeaturesToSamplesRatioUpperBound.get}")

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/data/RandomEffectDataset.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/data/RandomEffectDataset.scala
@@ -166,11 +166,11 @@ protected[ml] class RandomEffectDataset(
   }
 
   /**
-   * Update the data set.
+   * Update the dataset.
    *
    * @param updatedActiveData Updated active data
    * @param updatedPassiveData Updated passive data
-   * @return A new updated data set
+   * @return A new updated dataset
    */
   def update(
       updatedActiveData: RDD[(REId, LocalDataset)],
@@ -396,7 +396,7 @@ object RandomEffectDataset {
   }
 
   /**
-   * Generate passive data set.
+   * Generate passive dataset.
    *
    * @param gameDataset The raw input dataset
    * @param activeData The active dataset

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/data/RandomEffectDataset.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/data/RandomEffectDataset.scala
@@ -14,7 +14,6 @@
  */
 package com.linkedin.photon.ml.data
 
-import scala.collection.Set
 import scala.util.hashing.byteswap64
 
 import org.apache.spark.broadcast.Broadcast
@@ -38,16 +37,16 @@ import com.linkedin.photon.ml.spark.{BroadcastLike, RDDLike}
  *
  * @param activeData Grouped datasets mostly to train the sharded model and score the whole dataset.
  * @param uniqueIdToRandomEffectIds Unique id to random effect id map
- * @param passiveDataOption Flattened datasets used to score the whole dataset
- * @param passiveDataRandomEffectIdsOption Passive data individual IDs
+ * @param passiveData Flattened datasets used to score the whole dataset
+ * @param passiveDataRandomEffectIds Passive data individual IDs
  * @param randomEffectType The random effect type (e.g. "memberId")
  * @param featureShardId The feature shard ID
  */
 protected[ml] class RandomEffectDataset(
     val activeData: RDD[(REId, LocalDataset)],
     protected[data] val uniqueIdToRandomEffectIds: RDD[(UniqueSampleId, REId)],
-    val passiveDataOption: Option[RDD[(UniqueSampleId, (REId, LabeledPoint))]],
-    val passiveDataRandomEffectIdsOption: Option[Broadcast[Set[String]]],
+    val passiveData: RDD[(UniqueSampleId, (REId, LabeledPoint))],
+    val passiveDataRandomEffectIds: Broadcast[Set[REId]],
     val randomEffectType: REType,
     val featureShardId: FeatureShardId)
   extends Dataset[RandomEffectDataset]
@@ -56,7 +55,6 @@ protected[ml] class RandomEffectDataset(
 
   val randomEffectIdPartitioner: Partitioner = activeData.partitioner.get
   val uniqueIdPartitioner: Partitioner = uniqueIdToRandomEffectIds.partitioner.get
-  val hasPassiveData: Boolean = passiveDataOption.isDefined
 
   /**
    * Add residual scores to the data offsets.
@@ -77,13 +75,13 @@ protected[ml] class RandomEffectDataset(
       .join(scoresGroupedByRandomEffectId)
       .mapValues { case (localData, localScore) => localData.addScoresToOffsets(localScore) }
 
-    val updatedPassiveDataOption = passiveDataOption.map(
-      _.join(scores.scores)
-        .mapValues { case ((randomEffectId, LabeledPoint(response, features, offset, weight)), score) =>
-          (randomEffectId, LabeledPoint(response, features, offset + score, weight))
-        })
+    val updatedPassiveData = passiveData
+      .join(scores.scores)
+      .mapValues { case ((randomEffectId, LabeledPoint(response, features, offset, weight)), score) =>
+        (randomEffectId, LabeledPoint(response, features, offset + score, weight))
+      }
 
-    update(updatedActiveData, updatedPassiveDataOption)
+    update(updatedActiveData, updatedPassiveData)
   }
 
   /**
@@ -94,103 +92,95 @@ protected[ml] class RandomEffectDataset(
   override def sparkContext: SparkContext = activeData.sparkContext
 
   /**
-   * Assign a given name to [[activeData]], [[uniqueIdToRandomEffectIds]], and [[passiveDataOption]].
+   * Assign a given name to [[activeData]], [[uniqueIdToRandomEffectIds]], and [[passiveData]].
    *
    * @note Not used to reference models in the logic of photon-ml, only used for logging currently.
    * @param name The parent name for all [[RDD]]s in this class
-   * @return This object with the names [[activeData]], [[uniqueIdToRandomEffectIds]], and [[passiveDataOption]]
-   *         assigned
+   * @return This object with the names [[activeData]], [[uniqueIdToRandomEffectIds]], and [[passiveData]] assigned
    */
   override def setName(name: String): RandomEffectDataset = {
 
     activeData.setName(s"$name: Active data")
     uniqueIdToRandomEffectIds.setName(s"$name: unique id to individual Id")
-    passiveDataOption.foreach(_.setName(s"$name: Passive data"))
+    passiveData.setName(s"$name: Passive data")
 
     this
   }
 
   /**
-   * Set the storage level of [[activeData]], [[uniqueIdToRandomEffectIds]], and [[passiveDataOption]], and persist
+   * Set the storage level of [[activeData]], [[uniqueIdToRandomEffectIds]], and [[passiveData]], and persist
    * their values across the cluster the first time they are computed.
    *
    * @param storageLevel The storage level
-   * @return This object with the storage level of [[activeData]], [[uniqueIdToRandomEffectIds]], and
-   *         [[passiveDataOption]] set
+   * @return This object with the storage level of [[activeData]], [[uniqueIdToRandomEffectIds]], and [[passiveData]]
+   *         set
    */
   override def persistRDD(storageLevel: StorageLevel): RandomEffectDataset = {
 
     if (!activeData.getStorageLevel.isValid) activeData.persist(storageLevel)
     if (!uniqueIdToRandomEffectIds.getStorageLevel.isValid) uniqueIdToRandomEffectIds.persist(storageLevel)
-    passiveDataOption.foreach { passiveData =>
-      if (!passiveData.getStorageLevel.isValid) passiveData.persist(storageLevel)
-    }
+    if (!passiveData.getStorageLevel.isValid) passiveData.persist(storageLevel)
 
     this
   }
 
   /**
-   * Mark [[activeData]], [[uniqueIdToRandomEffectIds]], and [[passiveDataOption]] as non-persistent, and remove all
+   * Mark [[activeData]], [[uniqueIdToRandomEffectIds]], and [[passiveData]] as non-persistent, and remove all
    * blocks for them from memory and disk.
    *
-   * @return This object with [[activeData]], [[uniqueIdToRandomEffectIds]], and [[passiveDataOption]] marked
+   * @return This object with [[activeData]], [[uniqueIdToRandomEffectIds]], and [[passiveData]] marked
    *         non-persistent
    */
   override def unpersistRDD(): RandomEffectDataset = {
 
     if (activeData.getStorageLevel.isValid) activeData.unpersist()
     if (uniqueIdToRandomEffectIds.getStorageLevel.isValid) uniqueIdToRandomEffectIds.unpersist()
-    passiveDataOption.foreach { passiveData =>
-      if (passiveData.getStorageLevel.isValid) passiveData.unpersist()
-    }
+    if (passiveData.getStorageLevel.isValid) passiveData.unpersist()
 
     this
   }
 
   /**
-   * Materialize [[activeData]], [[uniqueIdToRandomEffectIds]], and [[passiveDataOption]] (Spark [[RDD]]s are lazy
+   * Materialize [[activeData]], [[uniqueIdToRandomEffectIds]], and [[passiveData]] (Spark [[RDD]]s are lazy
    * evaluated: this method forces them to be evaluated).
    *
-   * @return This object with [[activeData]], [[uniqueIdToRandomEffectIds]], and [[passiveDataOption]] materialized
+   * @return This object with [[activeData]], [[uniqueIdToRandomEffectIds]], and [[passiveData]] materialized
    */
   override def materialize(): RandomEffectDataset = {
 
-    passiveDataOption match {
-      case Some(passiveData) => materializeOnce(activeData, uniqueIdToRandomEffectIds, passiveData)
-      case None => materializeOnce(activeData, uniqueIdToRandomEffectIds)
-    }
+    materializeOnce(activeData, uniqueIdToRandomEffectIds, passiveData)
 
     this
   }
 
   /**
-   * Asynchronously delete cached copies of [[passiveDataRandomEffectIdsOption]] on the executors.
+   * Asynchronously delete cached copies of [[passiveDataRandomEffectIds]] on the executors.
    *
-   * @return This object with [[passiveDataRandomEffectIdsOption]] variables unpersisted
+   * @return This object with [[passiveDataRandomEffectIds]] variables unpersisted
    */
   override def unpersistBroadcast(): RandomEffectDataset = {
 
-    passiveDataRandomEffectIdsOption.foreach(_.unpersist())
+    passiveDataRandomEffectIds.unpersist()
 
     this
   }
 
   /**
-   * Update the dataset.
+   * Update the data set.
    *
    * @param updatedActiveData Updated active data
-   * @param updatedPassiveDataOption (Optional) Updated passive data
-   * @return A new updated dataset
+   * @param updatedPassiveData Updated passive data
+   * @return A new updated data set
    */
   def update(
       updatedActiveData: RDD[(REId, LocalDataset)],
-      updatedPassiveDataOption: Option[RDD[(UniqueSampleId, (REId, LabeledPoint))]]): RandomEffectDataset =
+      updatedPassiveData: RDD[(UniqueSampleId, (REId, LabeledPoint))]): RandomEffectDataset =
 
     new RandomEffectDataset(
       updatedActiveData,
       uniqueIdToRandomEffectIds,
-      updatedPassiveDataOption,
-      passiveDataRandomEffectIdsOption,
+      updatedPassiveData,
+      passiveDataRandomEffectIds,
       randomEffectType,
       featureShardId)
 
@@ -204,14 +194,13 @@ protected[ml] class RandomEffectDataset(
     val numActiveSamples = uniqueIdToRandomEffectIds.count()
     val activeSampleWeighSum = activeData.values.map(_.getWeights.map(_._2).sum).sum()
     val activeSampleResponseSum = activeData.values.map(_.getLabels.map(_._2).sum).sum()
-    val numPassiveSamples = if (hasPassiveData) passiveDataOption.get.count() else 0
-    val passiveSampleResponsesSum = if (hasPassiveData) passiveDataOption.get.values.map(_._2.label).sum() else 0
+    val numPassiveSamples = passiveData.count()
+    val passiveSampleResponsesSum = passiveData.values.map(_._2.label).sum()
     val numAllSamples = numActiveSamples + numPassiveSamples
     val numActiveSamplesStats = activeData.values.map(_.numDataPoints).stats()
     val activeSamplerResponseSumStats = activeData.values.map(_.getLabels.map(_._2).sum).stats()
     val numFeaturesStats = activeData.values.map(_.numFeatures).stats()
-    val numIdsWithPassiveData =
-      if (passiveDataRandomEffectIdsOption.isDefined) passiveDataRandomEffectIdsOption.get.value.size else 0
+    val numIdsWithPassiveData = passiveDataRandomEffectIds.value.size
 
     s"numActiveSamples: $numActiveSamples\n" +
       s"activeSampleWeighSum: $activeSampleWeighSum\n" +
@@ -227,6 +216,7 @@ protected[ml] class RandomEffectDataset(
 }
 
 object RandomEffectDataset {
+
   /**
    * Build the random effect dataset with the given configuration.
    *
@@ -252,8 +242,6 @@ object RandomEffectDataset {
       randomEffectPartitioner,
       existingModelKeysRddOpt)
     val activeData = featureSelectionOnActiveData(rawActiveData, randomEffectDataConfiguration)
-      .setName("Active data")
-      .persist(StorageLevel.DISK_ONLY)
 
     val globalIdToIndividualIds = activeData
       .flatMap { case (individualId, localDataset) =>
@@ -261,23 +249,14 @@ object RandomEffectDataset {
       }
       .partitionBy(gameDataPartitioner)
 
-    val passiveDataOption = randomEffectDataConfiguration
-      .numPassiveDataPointsLowerBound
-      .map { passiveDataLowerBound =>
-        generatePassiveData(
-          gameDataset,
-          activeData,
-          gameDataPartitioner,
-          randomEffectType,
-          featureShardId,
-          passiveDataLowerBound)
-      }
+    val (passiveData, passiveDataRandomEffectIds) =
+      generatePassiveData(gameDataset, activeData, gameDataPartitioner, randomEffectType, featureShardId)
 
     new RandomEffectDataset(
       activeData,
       globalIdToIndividualIds,
-      passiveDataOption.map(_._1),
-      passiveDataOption.map(_._2),
+      passiveData,
+      passiveDataRandomEffectIds,
       randomEffectType,
       featureShardId)
   }
@@ -395,7 +374,7 @@ object RandomEffectDataset {
     // node failure. We attempt to maximize the likelihood of successful recovery through RDD replication, however there
     // is a non-zero possibility of massive failure. If this becomes an issue, we may need to resort to check-pointing
     // the raw data RDD after uniqueId assignment.
-    val localDatasets = rawKeyedDataset
+    rawKeyedDataset
       .mapValues { case (uniqueId, labeledPoint) =>
         val comparableKey = (byteswap64(randomEffectType.hashCode) ^ byteswap64(uniqueId)).hashCode()
         ComparableLabeledPointWithId(comparableKey, uniqueId, labeledPoint)
@@ -409,35 +388,29 @@ object RandomEffectDataset {
         val count = minHeapWithFixedCapacity.getCount
         val data = minHeapWithFixedCapacity.getData
         val weightMultiplierOpt = if (count > sampleCap) Some(1D * count / sampleCap) else None
-        val dataPoints =
-          data.map { case ComparableLabeledPointWithId(_, uniqueId, LabeledPoint(label, features, offset, weight)) =>
-            (uniqueId, LabeledPoint(label, features, offset, weightMultiplierOpt.map(_ * weight).getOrElse(weight)))
-          }
-        dataPoints
-      }
 
-    localDatasets
+        data.map { case ComparableLabeledPointWithId(_, uniqueId, LabeledPoint(label, features, offset, weight)) =>
+          (uniqueId, LabeledPoint(label, features, offset, weightMultiplierOpt.map(_ * weight).getOrElse(weight)))
+        }
+      }
   }
 
   /**
-   * Generate passive dataset.
+   * Generate passive data set.
    *
    * @param gameDataset The raw input dataset
    * @param activeData The active dataset
    * @param gameDataPartitioner A global partitioner
    * @param randomEffectType The corresponding random effect type of the dataset
    * @param featureShardId Key of the feature shard used to generate the dataset
-   * @param passiveDataLowerBound The lower bound on the number of data points required to create a passive dataset
-   * @return The passive dataset
+   * @return The passive dataset and set of random effects with passive data
    */
   private def generatePassiveData(
       gameDataset: RDD[(UniqueSampleId, GameDatum)],
       activeData: RDD[(REId, LocalDataset)],
       gameDataPartitioner: Partitioner,
       randomEffectType: REType,
-      featureShardId: FeatureShardId,
-      passiveDataLowerBound: Int):
-    (RDD[(UniqueSampleId, (REId, LabeledPoint))], Broadcast[Set[REId]]) = {
+      featureShardId: FeatureShardId): (RDD[(UniqueSampleId, (REId, LabeledPoint))], Broadcast[Set[REId]]) = {
 
     // The remaining data not included in the active data will be kept as passive data
     val activeDataUniqueIds = activeData.flatMapValues(_.dataPoints.map(_._1)).map(_.swap)
@@ -448,33 +421,16 @@ object RandomEffectDataset {
     }
 
     val passiveData = keyedRandomEffectDataset.subtractByKey(activeDataUniqueIds, gameDataPartitioner)
-        .setName("tmp passive data")
-        .persist(StorageLevel.DISK_ONLY)
-
-    val passiveDataRandomEffectIdCountsMap = passiveData
+    val passiveDataRandomEffectIds: Set[REId] = passiveData
       .map { case (_, (randomEffectId, _)) =>
-        (randomEffectId, 1)
+        randomEffectId
       }
-      .reduceByKey(_ + _)
-      .collectAsMap()
+      .distinct()
+      .collect()
+      .toSet
+    val passiveDataRandomEffectIdsBroadcast = gameDataset.sparkContext.broadcast(passiveDataRandomEffectIds)
 
-    // Only keep the passive data whose total number of data points is larger than the given lower bound
-    val passiveDataRandomEffectIds = passiveDataRandomEffectIdCountsMap
-      .filter(_._2 > passiveDataLowerBound)
-      .keySet
-    val sparkContext = gameDataset.sparkContext
-    val passiveDataRandomEffectIdsBroadcast = sparkContext.broadcast(passiveDataRandomEffectIds)
-    val filteredPassiveData = passiveData
-      .filter { case (_, (id, _)) =>
-        passiveDataRandomEffectIdsBroadcast.value.contains(id)
-      }
-      .setName("passive data")
-      .persist(StorageLevel.DISK_ONLY)
-
-    filteredPassiveData.count()
-    passiveData.unpersist()
-
-    (filteredPassiveData, passiveDataRandomEffectIdsBroadcast)
+    (passiveData, passiveDataRandomEffectIdsBroadcast)
   }
 
   /**

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/data/RandomEffectDatasetInProjectedSpace.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/data/RandomEffectDatasetInProjectedSpace.scala
@@ -31,8 +31,8 @@ class RandomEffectDatasetInProjectedSpace(
   extends RandomEffectDataset(
     randomEffectDatasetInProjectedSpace.activeData,
     randomEffectDatasetInProjectedSpace.uniqueIdToRandomEffectIds,
-    randomEffectDatasetInProjectedSpace.passiveDataOption,
-    randomEffectDatasetInProjectedSpace.passiveDataRandomEffectIdsOption,
+    randomEffectDatasetInProjectedSpace.passiveData,
+    randomEffectDatasetInProjectedSpace.passiveDataRandomEffectIds,
     randomEffectDatasetInProjectedSpace.randomEffectType,
     randomEffectDatasetInProjectedSpace.featureShardId) {
 
@@ -94,6 +94,7 @@ class RandomEffectDatasetInProjectedSpace(
 }
 
 object RandomEffectDatasetInProjectedSpace {
+
   /**
    * Build an instance of a random effect dataset in projected space with the given projector type.
    *

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/estimators/GameEstimator.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/estimators/GameEstimator.scala
@@ -534,7 +534,7 @@ class GameEstimator(val sc: SparkContext, implicit val logger: Logger) extends P
 
                 case _ =>
                   rawRandomEffectDataset.activeData.unpersist()
-                  rawRandomEffectDataset.passiveDataOption.foreach(_.unpersist())
+                  rawRandomEffectDataset.passiveData.unpersist()
               }
 
               randomEffectDatasetInProjectedSpace

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/projector/ProjectionMatrixBroadcast.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/projector/ProjectionMatrixBroadcast.scala
@@ -45,17 +45,12 @@ protected[ml] class ProjectionMatrixBroadcast(projectionMatrixBroadcast: Broadca
   override def projectRandomEffectDataset(randomEffectDataset: RandomEffectDataset): RandomEffectDataset = {
 
     val activeData = randomEffectDataset.activeData
-    val passiveDataOption = randomEffectDataset.passiveDataOption
+    val passiveData = randomEffectDataset.passiveData
     val projectedActiveData = activeData.mapValues(_.projectFeatures(projectionMatrixBroadcast.value))
-
-    val projectedPassiveData = if (passiveDataOption.isDefined) {
-      passiveDataOption.map(_.mapValues { case (shardId, LabeledPoint(response, features, offset, weight)) =>
-        val projectedFeatures = projectionMatrixBroadcast.value.projectFeatures(features)
-        (shardId, LabeledPoint(response, projectedFeatures, offset, weight))
-      })
-    } else {
-      None
-    }
+    val projectedPassiveData =
+      passiveData.mapValues { case (shardId, LabeledPoint(response, features, offset, weight)) =>
+        (shardId, LabeledPoint(response, projectionMatrixBroadcast.value.projectFeatures(features), offset, weight))
+      }
 
     randomEffectDataset.update(projectedActiveData, projectedPassiveData)
   }

--- a/photon-api/src/test/scala/com/linkedin/photon/ml/data/CoordinateDataConfigurationTest.scala
+++ b/photon-api/src/test/scala/com/linkedin/photon/ml/data/CoordinateDataConfigurationTest.scala
@@ -26,12 +26,11 @@ class CoordinateDataConfigurationTest {
 
   @DataProvider
   def invalidInput(): Array[Array[Any]] = Array(
-    Array(-1, 1, 1, 1, 1D),
-    Array(1, -1, 1, 1, 1D),
-    Array(1, 1, -1, 1, 1D),
-    Array(1, 1, 1, -1, 1D),
-    Array(1, 1, 1, 1, -1D),
-    Array(1, 2, 1, 1, 1D))
+    Array(-1, 1, 1, 1D),
+    Array(1, -1, 1, 1D),
+    Array(1, 1, -1, 1D),
+    Array(1, 1, 1, -1D),
+    Array(1, 2, 1, 1D))
 
   /**
    * Test that invalid input will be rejected.
@@ -39,7 +38,6 @@ class CoordinateDataConfigurationTest {
    * @param minPartitions The minimum number of data partitions
    * @param activeLowerBound The lower bound on number of active data samples
    * @param activeUpperBound The upper bound on number of active data samples
-   * @param passiveLowerBound The lower bound on number of passive data samples
    * @param featuresToSamplesRatio The upper bound on the ratio between data samples and features
    */
   @Test(dataProvider = "invalidInput", expectedExceptions = Array(classOf[IllegalArgumentException]))
@@ -47,7 +45,6 @@ class CoordinateDataConfigurationTest {
       minPartitions: Int,
       activeLowerBound: Int,
       activeUpperBound: Int,
-      passiveLowerBound: Int,
       featuresToSamplesRatio: Double): Unit = {
 
     val mockREType = "reType"
@@ -60,15 +57,14 @@ class CoordinateDataConfigurationTest {
       minPartitions,
       Some(activeLowerBound),
       Some(activeUpperBound),
-      Some(passiveLowerBound),
       Some(featuresToSamplesRatio),
       mockProjector)
   }
 
   @DataProvider
   def validInput(): Array[Array[Any]] = Array(
-    Array(1, 1, 1, 1, 1D),
-    Array(1, 2, 3, 4, 5D))
+    Array(1, 1, 1, 1D),
+    Array(1, 2, 3, 5D))
 
   /**
    * Test that valid input will not be rejected.
@@ -76,7 +72,6 @@ class CoordinateDataConfigurationTest {
    * @param minPartitions The minimum number of data partitions
    * @param activeLowerBound The lower bound on number of active data samples
    * @param activeUpperBound The upper bound on number of active data samples
-   * @param passiveLowerBound The lower bound on number of passive data samples
    * @param featuresToSamplesRatio The upper bound on the ratio between data samples and features
    */
   @Test(dataProvider = "validInput")
@@ -84,7 +79,6 @@ class CoordinateDataConfigurationTest {
       minPartitions: Int,
       activeLowerBound: Int,
       activeUpperBound: Int,
-      passiveLowerBound: Int,
       featuresToSamplesRatio: Double): Unit = {
 
     val mockREType = "reType"
@@ -97,7 +91,6 @@ class CoordinateDataConfigurationTest {
       minPartitions,
       Some(activeLowerBound),
       Some(activeUpperBound),
-      Some(passiveLowerBound),
       Some(featuresToSamplesRatio),
       mockProjector)
   }

--- a/photon-api/src/test/scala/com/linkedin/photon/ml/util/GameTestUtils.scala
+++ b/photon-api/src/test/scala/com/linkedin/photon/ml/util/GameTestUtils.scala
@@ -21,6 +21,7 @@ import org.apache.spark.{HashPartitioner, SparkConf}
 import org.testng.annotations.DataProvider
 
 import com.linkedin.photon.ml.SparkSessionConfiguration
+import com.linkedin.photon.ml.Types.{REId, UniqueSampleId}
 import com.linkedin.photon.ml.algorithm.{FixedEffectCoordinate, RandomEffectCoordinateInProjectedSpace}
 import com.linkedin.photon.ml.data._
 import com.linkedin.photon.ml.function.glm.{DistributedGLMLossFunction, LogisticLossFunction, SingleNodeGLMLossFunction}
@@ -220,8 +221,16 @@ trait GameTestUtils extends TestTemplateWithTmpDir {
     val uniqueIdToRandomEffectIds = sc.parallelize(
       randomEffectIds.map(addUniqueId)).partitionBy(partitioner)
     val activeData = sc.parallelize(datasets).partitionBy(partitioner)
+    val passiveData = sc.emptyRDD[(UniqueSampleId, (REId, LabeledPoint))]
+    val passiveDataRandomEffectIds = sc.broadcast(Set[REId]())
 
-    new RandomEffectDataset(activeData, uniqueIdToRandomEffectIds, None, None, randomEffectType, featureShardId)
+    new RandomEffectDataset(
+      activeData,
+      uniqueIdToRandomEffectIds,
+      passiveData,
+      passiveDataRandomEffectIds,
+      randomEffectType,
+      featureShardId)
   }
 
   /**

--- a/photon-client/src/integTest/scala/com/linkedin/photon/ml/cli/game/training/GameTrainingDriverIntegTest.scala
+++ b/photon-client/src/integTest/scala/com/linkedin/photon/ml/cli/game/training/GameTrainingDriverIntegTest.scala
@@ -360,7 +360,7 @@ class GameTrainingDriverIntegTest extends SparkTestUtils with GameTestUtils with
    * photon-ml. Hyperparameter tuning is still available in LinkedIn internal library li-photon-ml.)
    */
 //  @Test
-//  def c(): Unit = sparkTest("testHyperParameterTuning", useKryo = true) {
+//  def testHyperParameterTuning(): Unit = sparkTest("testHyperParameterTuning", useKryo = true) {
 //
 //    val hyperParameterTuningIter = 1
 //    val outputDir = new Path(getTmpDir, "hyperParameterTuning")

--- a/photon-client/src/integTest/scala/com/linkedin/photon/ml/cli/game/training/GameTrainingDriverIntegTest.scala
+++ b/photon-client/src/integTest/scala/com/linkedin/photon/ml/cli/game/training/GameTrainingDriverIntegTest.scala
@@ -339,18 +339,6 @@ class GameTrainingDriverIntegTest extends SparkTestUtils with GameTestUtils with
     assertModelSane(globalModelPath, expectedNumCoefficients = 15019)
     assertTrue(AvroUtils.modelContainsIntercept(sc, globalModelPath))
 
-    assertTrue(fs.exists(userModelPath))
-    assertModelSane(userModelPath, expectedNumCoefficients = 29, modelId = Some("1436929"))
-    assertTrue(AvroUtils.modelContainsIntercept(sc, userModelPath))
-
-    assertTrue(fs.exists(songModelPath))
-    assertModelSane(songModelPath, expectedNumCoefficients = 21)
-    assertTrue(AvroUtils.modelContainsIntercept(sc, songModelPath))
-
-    assertTrue(fs.exists(artistModelPath))
-    assertModelSane(artistModelPath, expectedNumCoefficients = 21)
-    assertTrue(AvroUtils.modelContainsIntercept(sc, artistModelPath))
-
     assertTrue(evaluateModel(new Path(outputDir, GameTrainingDriver.BEST_MODEL_DIR)) < errorThreshold)
   }
 
@@ -476,7 +464,7 @@ class GameTrainingDriverIntegTest extends SparkTestUtils with GameTestUtils with
     assertModelSane(globalModelPath, expectedNumCoefficients = 0)
 
     assertTrue(fs.exists(userModelPath))
-    assertModelSane(userModelPath, expectedNumCoefficients = 0, modelId = Some("1436929"))
+    assertModelSane(userModelPath, expectedNumCoefficients = 0)
 
     assertTrue(fs.exists(songModelPath))
     assertModelSane(songModelPath, expectedNumCoefficients = 0)
@@ -569,22 +557,14 @@ class GameTrainingDriverIntegTest extends SparkTestUtils with GameTestUtils with
    * @param expectedNumCoefficients Expected number of non-zero coefficients
    * @return True if the model is sane
    */
-  private def assertModelSane(path: Path, expectedNumCoefficients: Int, modelId: Option[String] = None): Unit = {
+  private def assertModelSane(path: Path, expectedNumCoefficients: Int): Unit = {
 
     val modelAvro = AvroUtils.readFromSingleAvro[BayesianLinearModelAvro](
       sc,
       path.toString,
       BayesianLinearModelAvro.getClassSchema.toString)
 
-    val model = modelId match {
-      case Some(id) =>
-        val m = modelAvro.find { m => m.getModelId.toString == id }
-        assertTrue(m.isDefined, s"Model id $id not found.")
-        m.get
-      case _ => modelAvro.head
-    }
-
-    assertEquals(model.getMeans.count(x => x.getValue != 0), expectedNumCoefficients)
+    assertEquals(modelAvro.head.getMeans.count(x => x.getValue != 0), expectedNumCoefficients)
   }
 
   /**

--- a/photon-client/src/main/scala/com/linkedin/photon/ml/io/scopt/ScoptParserHelpers.scala
+++ b/photon-client/src/main/scala/com/linkedin/photon/ml/io/scopt/ScoptParserHelpers.scala
@@ -17,6 +17,7 @@ package com.linkedin.photon.ml.io.scopt
 import java.util.StringJoiner
 
 import scala.collection.mutable
+import scala.util.matching.Regex
 
 import com.linkedin.photon.ml.Types.{CoordinateId, FeatureShardId}
 import com.linkedin.photon.ml.data.{FixedEffectDataConfiguration, InputColumnsNames, RandomEffectDataConfiguration}
@@ -41,7 +42,7 @@ object ScoptParserHelpers extends Logging {
   val SECONDARY_LIST_DELIMITER = '|'
   val RANGE_DELIMITER = '-'
   val DOUBLE_PATTERN = """\s*[+-]?\d+(\.\d+)?([eE][+-]?\d+)?\s*"""
-  val DOUBLE_RANGE_PATTERN = s"($DOUBLE_PATTERN)$RANGE_DELIMITER($DOUBLE_PATTERN)".r
+  val DOUBLE_RANGE_PATTERN: Regex = s"($DOUBLE_PATTERN)$RANGE_DELIMITER($DOUBLE_PATTERN)".r
 
   // Feature shard configuration parameters
   val FEATURE_SHARD_CONFIG_NAME = "name"
@@ -61,7 +62,6 @@ object ScoptParserHelpers extends Logging {
   val COORDINATE_DATA_CONFIG_MIN_PARTITIONS = "min.partitions"
   val COORDINATE_DATA_CONFIG_ACTIVE_DATA_LOWER_BOUND = "active.data.lower.bound"
   val COORDINATE_DATA_CONFIG_ACTIVE_DATA_UPPER_BOUND = "active.data.upper.bound"
-  val COORDINATE_DATA_CONFIG_PASSIVE_DATA_BOUND = "passive.data.bound"
   val COORDINATE_DATA_CONFIG_FEATURES_TO_SAMPLES_RATIO = "features.to.samples.ratio"
 
   val COORDINATE_OPT_CONFIG_OPTIMIZER = "optimizer"
@@ -94,14 +94,12 @@ object ScoptParserHelpers extends Logging {
   val COORDINATE_CONFIG_RANDOM_EFFECT_OPTIONAL_ARGS = Map(
     (COORDINATE_DATA_CONFIG_ACTIVE_DATA_LOWER_BOUND, "<value>"),
     (COORDINATE_DATA_CONFIG_ACTIVE_DATA_UPPER_BOUND, "<value>"),
-    (COORDINATE_DATA_CONFIG_PASSIVE_DATA_BOUND, "<value>"),
     (COORDINATE_DATA_CONFIG_FEATURES_TO_SAMPLES_RATIO, "<value>"))
 
   val COORDINATE_CONFIG_FIXED_ONLY_ARGS = Seq(COORDINATE_OPT_CONFIG_DOWN_SAMPLING_RATE)
   val COORDINATE_CONFIG_RANDOM_ONLY_ARGS = Seq(
     COORDINATE_DATA_CONFIG_ACTIVE_DATA_LOWER_BOUND,
     COORDINATE_DATA_CONFIG_ACTIVE_DATA_UPPER_BOUND,
-    COORDINATE_DATA_CONFIG_PASSIVE_DATA_BOUND,
     COORDINATE_DATA_CONFIG_FEATURES_TO_SAMPLES_RATIO)
 
   //
@@ -239,7 +237,6 @@ object ScoptParserHelpers extends Logging {
           minPartitions,
           input.get(COORDINATE_DATA_CONFIG_ACTIVE_DATA_LOWER_BOUND).map(_.toInt),
           input.get(COORDINATE_DATA_CONFIG_ACTIVE_DATA_UPPER_BOUND).map(_.toInt),
-          input.get(COORDINATE_DATA_CONFIG_PASSIVE_DATA_BOUND).map(_.toInt),
           input.get(COORDINATE_DATA_CONFIG_FEATURES_TO_SAMPLES_RATIO).map(_.toDouble),
           IndexMapProjection)
         val optConfig = RandomEffectOptimizationConfiguration(
@@ -445,9 +442,6 @@ object ScoptParserHelpers extends Logging {
           }
           reDataConfig.numActiveDataPointsUpperBound.foreach { bound =>
             argsMap += (COORDINATE_DATA_CONFIG_ACTIVE_DATA_UPPER_BOUND -> bound.toString)
-          }
-          reDataConfig.numPassiveDataPointsLowerBound.foreach { bound =>
-            argsMap += (COORDINATE_DATA_CONFIG_PASSIVE_DATA_BOUND -> bound.toString)
           }
           reDataConfig.numFeaturesToSamplesRatioUpperBound.foreach { ratio =>
             argsMap += (COORDINATE_DATA_CONFIG_FEATURES_TO_SAMPLES_RATIO -> ratio.toString)

--- a/photon-client/src/test/scala/com/linkedin/photon/ml/data/avro/NameAndTermFeatureBagsDriverTest.scala
+++ b/photon-client/src/test/scala/com/linkedin/photon/ml/data/avro/NameAndTermFeatureBagsDriverTest.scala
@@ -118,7 +118,7 @@ class NameAndTermFeatureBagsDriverTest {
   /**
    * Test that set parameters can be cleared correctly.
    */
-  @Test
+  @Test(dependsOnMethods = Array("testDefaultParams"))
   def testClear(): Unit = {
 
     val mockPath = mock(classOf[Path])

--- a/photon-client/src/test/scala/com/linkedin/photon/ml/index/FeatureIndexingDriverTest.scala
+++ b/photon-client/src/test/scala/com/linkedin/photon/ml/index/FeatureIndexingDriverTest.scala
@@ -136,7 +136,7 @@ class FeatureIndexingDriverTest {
   /**
    * Test that set parameters can be cleared correctly.
    */
-  @Test
+  @Test(dependsOnMethods = Array("testDefaultParams"))
   def testClear(): Unit = {
 
     val mockPath = mock(classOf[Path])

--- a/photon-client/src/test/scala/com/linkedin/photon/ml/io/scopt/ScoptParserHelpersTest.scala
+++ b/photon-client/src/test/scala/com/linkedin/photon/ml/io/scopt/ScoptParserHelpersTest.scala
@@ -121,12 +121,10 @@ class ScoptParserHelpersTest {
     val activeDataLowerBound2 = Some(5)
     val activeDataUpperBound1 = None
     val activeDataUpperBound2 = Some(6)
-    val passiveDataLowerBound1 = None
-    val passiveDataLowerBound2 = Some(7)
     val featuresSamplesRatio1 = None
-    val featuresSamplesRatio2 = Some(8)
+    val featuresSamplesRatio2 = Some(7)
     val downSamplingRate1 = 1.0
-    val downSamplingRate2 = 0.9
+    val downSamplingRate2 = 0.8
 
     val inputMap1 = Map[String, String](
       ScoptParserHelpers.COORDINATE_CONFIG_NAME -> coordinateId,
@@ -146,7 +144,6 @@ class ScoptParserHelpersTest {
       ScoptParserHelpers.COORDINATE_DATA_CONFIG_RANDOM_EFFECT_TYPE -> reType,
       ScoptParserHelpers.COORDINATE_DATA_CONFIG_ACTIVE_DATA_LOWER_BOUND -> activeDataLowerBound2.get.toString,
       ScoptParserHelpers.COORDINATE_DATA_CONFIG_ACTIVE_DATA_UPPER_BOUND -> activeDataUpperBound2.get.toString,
-      ScoptParserHelpers.COORDINATE_DATA_CONFIG_PASSIVE_DATA_BOUND -> passiveDataLowerBound2.get.toString,
       ScoptParserHelpers.COORDINATE_DATA_CONFIG_FEATURES_TO_SAMPLES_RATIO -> featuresSamplesRatio2.get.toString,
       ScoptParserHelpers.COORDINATE_OPT_CONFIG_REGULARIZATION -> regularizationType.toString,
       ScoptParserHelpers.COORDINATE_OPT_CONFIG_REG_WEIGHTS -> regWeights2Str,
@@ -187,7 +184,6 @@ class ScoptParserHelpersTest {
         assertEquals(reConfig.dataConfiguration.minNumPartitions, minPartitions)
         assertEquals(reConfig.dataConfiguration.numActiveDataPointsLowerBound, activeDataLowerBound1)
         assertEquals(reConfig.dataConfiguration.numActiveDataPointsUpperBound, activeDataUpperBound1)
-        assertEquals(reConfig.dataConfiguration.numPassiveDataPointsLowerBound, passiveDataLowerBound1)
         assertEquals(reConfig.dataConfiguration.numFeaturesToSamplesRatioUpperBound, featuresSamplesRatio1)
         assertEquals(reConfig.optimizationConfiguration.optimizerConfig.optimizerType, optimizer)
         assertEquals(reConfig.optimizationConfiguration.optimizerConfig.maximumIterations, maxIter)
@@ -204,7 +200,6 @@ class ScoptParserHelpersTest {
       case reConfig: RandomEffectCoordinateConfiguration =>
         assertEquals(reConfig.dataConfiguration.numActiveDataPointsLowerBound, activeDataLowerBound2)
         assertEquals(reConfig.dataConfiguration.numActiveDataPointsUpperBound, activeDataUpperBound2)
-        assertEquals(reConfig.dataConfiguration.numPassiveDataPointsLowerBound, passiveDataLowerBound2)
         assertEquals(reConfig.dataConfiguration.numFeaturesToSamplesRatioUpperBound, featuresSamplesRatio2)
         assertEquals(reConfig.optimizationConfiguration.regularizationContext, regularization2)
         assertEquals(reConfig.regularizationWeights, regWeights2)
@@ -437,11 +432,10 @@ class ScoptParserHelpersTest {
     val reType = "type"
     val activeDataLowerBound = 4
     val activeDataUpperBound = 5
-    val passiveDataBound = 6
-    val featuresSamplesRatio = 7.0
+    val featuresSamplesRatio = 6.0
     val regularizationType = RegularizationType.ELASTIC_NET
-    val regularizationAlpha = 0.8
-    val regularizationWeights = SortedSet[Double](9.9, 10.1).asInstanceOf[Set[Double]]
+    val regularizationAlpha = 0.7
+    val regularizationWeights = SortedSet[Double](8.8, 9.9).asInstanceOf[Set[Double]]
 
     val feDataConfig = FixedEffectDataConfiguration(featureShardId, minPartitions)
 
@@ -463,7 +457,6 @@ class ScoptParserHelpersTest {
       None,
       None,
       None,
-      None,
       IdentityProjection)
     val optConfig3 = RandomEffectOptimizationConfiguration(optimizerConfig)
     val coordinateConfig3 = RandomEffectCoordinateConfiguration(dataConfig3, optConfig3)
@@ -475,7 +468,6 @@ class ScoptParserHelpersTest {
       minPartitions,
       Some(activeDataLowerBound),
       Some(activeDataUpperBound),
-      Some(passiveDataBound),
       Some(featuresSamplesRatio),
       IdentityProjection)
     val optConfig4 = RandomEffectOptimizationConfiguration(
@@ -519,7 +511,6 @@ class ScoptParserHelpersTest {
         ScoptParserHelpers.COORDINATE_DATA_CONFIG_RANDOM_EFFECT_TYPE -> reType,
         ScoptParserHelpers.COORDINATE_DATA_CONFIG_ACTIVE_DATA_LOWER_BOUND -> activeDataLowerBound.toString,
         ScoptParserHelpers.COORDINATE_DATA_CONFIG_ACTIVE_DATA_UPPER_BOUND -> activeDataUpperBound.toString,
-        ScoptParserHelpers.COORDINATE_DATA_CONFIG_PASSIVE_DATA_BOUND -> passiveDataBound.toString,
         ScoptParserHelpers.COORDINATE_DATA_CONFIG_FEATURES_TO_SAMPLES_RATIO -> featuresSamplesRatio.toString,
         ScoptParserHelpers.COORDINATE_OPT_CONFIG_REGULARIZATION -> regularizationType.toString,
         ScoptParserHelpers.COORDINATE_OPT_CONFIG_REG_ALPHA -> regularizationAlpha.toString,

--- a/photon-client/src/test/scala/com/linkedin/photon/ml/io/scopt/game/ScoptGameTrainingParametersParserTest.scala
+++ b/photon-client/src/test/scala/com/linkedin/photon/ml/io/scopt/game/ScoptGameTrainingParametersParserTest.scala
@@ -103,7 +103,6 @@ class ScoptGameTrainingParametersParserTest {
     val randomEffectPartitions = 10
     val randomEffectActiveLowerBound = Some(11)
     val randomEffectActiveUpperBound = Some(11)
-    val randomEffectPassiveLowerBound = Some(12)
     val randomEffectFeatureRatio = Some(13.0)
     val randomEffectDataConfiguration = RandomEffectDataConfiguration(
       randomEffectType,
@@ -111,7 +110,6 @@ class ScoptGameTrainingParametersParserTest {
       randomEffectPartitions,
       randomEffectActiveLowerBound,
       randomEffectActiveUpperBound,
-      randomEffectPassiveLowerBound,
       randomEffectFeatureRatio,
       IndexMapProjection)
     val randomEffectOptimizerType = OptimizerType.TRON
@@ -229,7 +227,6 @@ class ScoptGameTrainingParametersParserTest {
     assertEquals(finalRandomDataCoordinateConfig.minNumPartitions, randomEffectPartitions)
     assertEquals(finalRandomDataCoordinateConfig.numActiveDataPointsLowerBound, randomEffectActiveLowerBound)
     assertEquals(finalRandomDataCoordinateConfig.numActiveDataPointsUpperBound, randomEffectActiveUpperBound)
-    assertEquals(finalRandomDataCoordinateConfig.numPassiveDataPointsLowerBound, randomEffectPassiveLowerBound)
     assertEquals(finalRandomDataCoordinateConfig.numFeaturesToSamplesRatioUpperBound, randomEffectFeatureRatio)
     assertEquals(finalRandomDataCoordinateConfig.projectorType, IndexMapProjection)
 


### PR DESCRIPTION
The reasoning is that it is a rarely-used tuning parameter which requires rather specific knowledge of the implementation of Photon ML (i.e. the difference between "active" and "passive" data).

Maintaining this tuning parameter increases training time (the code for computing passive datasets is run regardless - but with the tuning parameter, the number of samples per entity now also need to be counted and filtered), reduces accuracy (since records for entities which do not break the bound threshold will not be scored), and introduces additional code complexity (lots of `Option` objects).