### PR TITLE
Fix elastic net bug

### DIFF
--- a/photon-api/src/integTest/scala/com/linkedin/photon/ml/function/glm/DistributedGLMLossFunctionIntegTest.scala
+++ b/photon-api/src/integTest/scala/com/linkedin/photon/ml/function/glm/DistributedGLMLossFunctionIntegTest.scala
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2019 LinkedIn Corp. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linkedin.photon.ml.function.glm
+
+import breeze.linalg.{DenseVector, Vector}
+import org.mockito.Mockito._
+import org.testng.Assert.assertEquals
+import org.testng.annotations.Test
+
+import com.linkedin.photon.ml.data.LabeledPoint
+import com.linkedin.photon.ml.normalization.NoNormalization
+import com.linkedin.photon.ml.optimization._
+import com.linkedin.photon.ml.optimization.game.FixedEffectOptimizationConfiguration
+import com.linkedin.photon.ml.test.SparkTestUtils
+import com.linkedin.photon.ml.util.PhotonNonBroadcast
+
+/**
+ * Integration tests for [[DistributedGLMLossFunction]].
+ */
+class DistributedGLMLossFunctionIntegTest extends SparkTestUtils {
+
+  import DistributedGLMLossFunctionIntegTest._
+
+  /**
+   * Verify the value of loss function without regularization.
+   */
+  @Test()
+  def testValueNoRegularization(): Unit = sparkTest("testValueNoRegularization") {
+
+    val labeledPoints = sc.parallelize(Array(LABELED_POINT_1, LABELED_POINT_2))
+    val coefficients = sc.broadcast(COEFFICIENT_VECTOR)
+
+    val fixedEffectRegularizationContext = NoRegularizationContext
+    val fixedEffectOptimizationConfiguration = FixedEffectOptimizationConfiguration(
+      FIXED_EFFECT_OPTIMIZER_CONFIG,
+      fixedEffectRegularizationContext)
+    val distributedGLMLossFunction = DistributedGLMLossFunction(
+      fixedEffectOptimizationConfiguration,
+      LogisticLossFunction,
+      TREE_AGGREGATE_DEPTH)
+    val value = distributedGLMLossFunction.value(
+      labeledPoints,
+      coefficients,
+      PhotonNonBroadcast(NORMALIZATION_CONTEXT))
+
+    // expectValue = log(1 + exp(3)) + log(1 + exp(2)) = 5.1755
+    assertEquals(value, 5.1755, EPSILON)
+  }
+
+  /**
+   * Verify the value of loss function with L2 regularization.
+   */
+  @Test()
+  def testValueWithL2Regularization(): Unit = sparkTest("testValueWithL2Regularization") {
+
+    val labeledPoints = sc.parallelize(Array(LABELED_POINT_1, LABELED_POINT_2))
+    val coefficients = sc.broadcast(COEFFICIENT_VECTOR)
+
+    val fixedEffectRegularizationContext = L2RegularizationContext
+    val fixedEffectOptimizationConfiguration = FixedEffectOptimizationConfiguration(
+      FIXED_EFFECT_OPTIMIZER_CONFIG,
+      fixedEffectRegularizationContext,
+      FIXED_EFFECT_REGULARIZATION_WEIGHT)
+    val distributedGLMLossFunction = DistributedGLMLossFunction(
+      fixedEffectOptimizationConfiguration,
+      LogisticLossFunction,
+      TREE_AGGREGATE_DEPTH)
+    val value = distributedGLMLossFunction.value(
+      labeledPoints,
+      coefficients,
+      PhotonNonBroadcast(NORMALIZATION_CONTEXT))
+
+    // expectedValue = log(1 + exp(3)) + log(1 + exp(2)) + 1 * ((-2)^2 + 3^2) / 2 = 11.6755
+    assertEquals(value, 11.6755, EPSILON)
+  }
+
+  /**
+   * Verify the value of loss function with elastic net regularization.
+   */
+  @Test()
+  def testValueWithElasticNetRegularization(): Unit = sparkTest("testValueWithElasticNetRegularization") {
+
+    val labeledPoints = sc.parallelize(Array(LABELED_POINT_1, LABELED_POINT_2))
+    val coefficients = sc.broadcast(COEFFICIENT_VECTOR)
+
+    val fixedEffectRegularizationContext = ElasticNetRegularizationContext(ALPHA)
+    val fixedEffectOptimizationConfiguration = FixedEffectOptimizationConfiguration(
+      FIXED_EFFECT_OPTIMIZER_CONFIG,
+      fixedEffectRegularizationContext,
+      FIXED_EFFECT_REGULARIZATION_WEIGHT)
+    val distributedGLMLossFunction = DistributedGLMLossFunction(
+      fixedEffectOptimizationConfiguration,
+      LogisticLossFunction,
+      TREE_AGGREGATE_DEPTH)
+    val value = distributedGLMLossFunction.value(
+      labeledPoints,
+      coefficients,
+      PhotonNonBroadcast(NORMALIZATION_CONTEXT))
+
+    // L1 is computed by the optimizer.
+    // expectedValue = log(1 + exp(3)) + log(1 + exp(2)) + (1 - 0.4) * 1 * ((-2)^2 + 3^2) / 2 = 9.0755
+    assertEquals(value, 9.0755, EPSILON)
+  }
+}
+
+object DistributedGLMLossFunctionIntegTest {
+
+  private val FIXED_EFFECT_OPTIMIZER_CONFIG = mock(classOf[OptimizerConfig])
+  private val LABELED_POINT_1 = new LabeledPoint(0, DenseVector(0.0, 1.0))
+  private val LABELED_POINT_2 = new LabeledPoint(1, DenseVector(1.0, 0.0))
+  private val COEFFICIENT_VECTOR = Vector(-2.0, 3.0)
+  private val NORMALIZATION_CONTEXT = NoNormalization()
+  private val FIXED_EFFECT_REGULARIZATION_WEIGHT = 1D
+  private val ALPHA = 0.4
+  private val TREE_AGGREGATE_DEPTH = 2
+  private val EPSILON = 1e-3
+}

--- a/photon-api/src/integTest/scala/com/linkedin/photon/ml/function/svm/DistributedSmoothedHingeLossFunctionIntegTest.scala
+++ b/photon-api/src/integTest/scala/com/linkedin/photon/ml/function/svm/DistributedSmoothedHingeLossFunctionIntegTest.scala
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2019 LinkedIn Corp. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linkedin.photon.ml.function.svm
+
+import breeze.linalg.{DenseVector, Vector}
+import org.mockito.Mockito._
+import org.testng.Assert.assertEquals
+import org.testng.annotations.Test
+
+import com.linkedin.photon.ml.data.LabeledPoint
+import com.linkedin.photon.ml.normalization.NoNormalization
+import com.linkedin.photon.ml.optimization._
+import com.linkedin.photon.ml.optimization.game.FixedEffectOptimizationConfiguration
+import com.linkedin.photon.ml.test.SparkTestUtils
+import com.linkedin.photon.ml.util.PhotonNonBroadcast
+
+/**
+ * Integration tests for [[DistributedSmoothedHingeLossFunction]].
+ */
+class DistributedSmoothedHingeLossFunctionIntegTest extends SparkTestUtils {
+
+  import DistributedSmoothedHingeLossFunctionIntegTest._
+
+  /**
+   * Verify the value of loss function without regularization.
+   */
+  @Test()
+  def testValueNoRegularization(): Unit = sparkTest("testValueNoRegularization") {
+
+    val labeledPoints = sc.parallelize(Array(LABELED_POINT_1, LABELED_POINT_2))
+    val coefficients = sc.broadcast(COEFFICIENT_VECTOR)
+
+    val fixedEffectRegularizationContext = NoRegularizationContext
+    val fixedEffectOptimizationConfiguration = FixedEffectOptimizationConfiguration(
+      FIXED_EFFECT_OPTIMIZER_CONFIG,
+      fixedEffectRegularizationContext)
+    val distributedSmoothedHingeLossFunction = DistributedSmoothedHingeLossFunction(
+      fixedEffectOptimizationConfiguration,
+      TREE_AGGREGATE_DEPTH)
+    val value = distributedSmoothedHingeLossFunction.value(
+      labeledPoints,
+      coefficients,
+      PhotonNonBroadcast(NORMALIZATION_CONTEXT))
+
+    assertEquals(value, 6.0, EPSILON)
+  }
+
+  /**
+   * Verify the value of loss function with L2 regularization.
+   */
+  @Test()
+  def testValueWithL2Regularization(): Unit = sparkTest("testValueWithL2Regularization") {
+
+    val labeledPoints = sc.parallelize(Array(LABELED_POINT_1, LABELED_POINT_2))
+    val coefficients = sc.broadcast(COEFFICIENT_VECTOR)
+
+    val fixedEffectRegularizationContext = L2RegularizationContext
+    val fixedEffectOptimizationConfiguration = FixedEffectOptimizationConfiguration(
+      FIXED_EFFECT_OPTIMIZER_CONFIG,
+      fixedEffectRegularizationContext,
+      FIXED_EFFECT_REGULARIZATION_WEIGHT)
+    val distributedSmoothedHingeLossFunction = DistributedSmoothedHingeLossFunction(
+      fixedEffectOptimizationConfiguration,
+      TREE_AGGREGATE_DEPTH)
+    val value = distributedSmoothedHingeLossFunction.value(
+      labeledPoints,
+      coefficients,
+      PhotonNonBroadcast(NORMALIZATION_CONTEXT))
+
+    // expectedValue = 6 + 1 * ((-2)^2 + 3^2) / 2 = 12.5
+    assertEquals(value, 12.5, EPSILON)
+  }
+
+  /**
+   * Verify the value of loss function with elastic net regularization.
+   */
+  @Test()
+  def testValueWithElasticNetRegularization(): Unit = sparkTest("testValueWithElasticNetRegularization") {
+
+    val labeledPoints = sc.parallelize(Array(LABELED_POINT_1, LABELED_POINT_2))
+    val coefficients = sc.broadcast(COEFFICIENT_VECTOR)
+
+    val fixedEffectRegularizationContext = ElasticNetRegularizationContext(ALPHA)
+    val fixedEffectOptimizationConfiguration = FixedEffectOptimizationConfiguration(
+      FIXED_EFFECT_OPTIMIZER_CONFIG,
+      fixedEffectRegularizationContext,
+      FIXED_EFFECT_REGULARIZATION_WEIGHT)
+    val distributedSmoothedHingeLossFunction = DistributedSmoothedHingeLossFunction(
+      fixedEffectOptimizationConfiguration,
+      TREE_AGGREGATE_DEPTH)
+    val value = distributedSmoothedHingeLossFunction.value(
+      labeledPoints,
+      coefficients,
+      PhotonNonBroadcast(NORMALIZATION_CONTEXT))
+
+    // L1 is computed by the optimizer.
+    // expectedValue = 6 + (1 - 0.4) * 1 * ((-2)^2 + 3^2) / 2 = 9.9
+    assertEquals(value, 9.9, EPSILON)
+  }
+}
+
+object DistributedSmoothedHingeLossFunctionIntegTest {
+
+  private val FIXED_EFFECT_OPTIMIZER_CONFIG = mock(classOf[OptimizerConfig])
+  private val LABELED_POINT_1 = new LabeledPoint(0, DenseVector(0.0, 1.0))
+  private val LABELED_POINT_2 = new LabeledPoint(1, DenseVector(1.0, 0.0))
+  private val COEFFICIENT_VECTOR = Vector(-2.0, 3.0)
+  private val NORMALIZATION_CONTEXT = NoNormalization()
+  private val FIXED_EFFECT_REGULARIZATION_WEIGHT = 1D
+  private val ALPHA = 0.4
+  private val TREE_AGGREGATE_DEPTH = 2
+  private val EPSILON = 1e-3
+}

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/function/glm/DistributedGLMLossFunction.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/function/glm/DistributedGLMLossFunction.scala
@@ -166,7 +166,7 @@ object DistributedGLMLossFunction {
     val regularizationWeight = configuration.regularizationWeight
 
     regularizationContext.regularizationType match {
-      case RegularizationType.L2 =>
+      case RegularizationType.L2 | RegularizationType.ELASTIC_NET =>
         new DistributedGLMLossFunction(singleLossFunction, treeAggregateDepth)
           with L2RegularizationTwiceDiff {
 

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/function/glm/SingleNodeGLMLossFunction.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/function/glm/SingleNodeGLMLossFunction.scala
@@ -154,7 +154,7 @@ object SingleNodeGLMLossFunction {
     val regularizationWeight = configuration.regularizationWeight
 
     regularizationContext.regularizationType match {
-      case RegularizationType.L2 =>
+      case RegularizationType.L2 | RegularizationType.ELASTIC_NET =>
         new SingleNodeGLMLossFunction(singleLossFunction) with L2RegularizationTwiceDiff {
           l2RegWeight = regularizationContext.getL2RegularizationWeight(regularizationWeight)
         }

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/function/svm/DistributedSmoothedHingeLossFunction.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/function/svm/DistributedSmoothedHingeLossFunction.scala
@@ -118,7 +118,7 @@ object DistributedSmoothedHingeLossFunction {
     val regularizationContext = configuration.regularizationContext
 
     regularizationContext.regularizationType match {
-      case RegularizationType.L2 =>
+      case RegularizationType.L2 | RegularizationType.ELASTIC_NET =>
         new DistributedSmoothedHingeLossFunction(treeAggregateDepth) with L2RegularizationDiff {
           l2RegWeight = regularizationContext.getL2RegularizationWeight(configuration.regularizationWeight)
         }

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/function/svm/SingleNodeSmoothedHingeLossFunction.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/function/svm/SingleNodeSmoothedHingeLossFunction.scala
@@ -105,7 +105,7 @@ object SingleNodeSmoothedHingeLossFunction {
     val regularizationWeight = configuration.regularizationWeight
 
     regularizationContext.regularizationType match {
-      case RegularizationType.L2 =>
+      case RegularizationType.L2 | RegularizationType.ELASTIC_NET =>
         new SingleNodeSmoothedHingeLossFunction with L2RegularizationDiff {
           l2RegWeight = regularizationContext.getL2RegularizationWeight(regularizationWeight)
         }

--- a/photon-api/src/test/scala/com/linkedin/photon/ml/function/glm/SingleNodeGLMLossFunctionTest.scala
+++ b/photon-api/src/test/scala/com/linkedin/photon/ml/function/glm/SingleNodeGLMLossFunctionTest.scala
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2019 LinkedIn Corp. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linkedin.photon.ml.function.glm
+
+import breeze.linalg.DenseVector
+import org.mockito.Mockito._
+import org.testng.Assert.assertEquals
+import org.testng.annotations.Test
+
+import com.linkedin.photon.ml.data.LabeledPoint
+import com.linkedin.photon.ml.normalization.NoNormalization
+import com.linkedin.photon.ml.optimization._
+import com.linkedin.photon.ml.optimization.game.RandomEffectOptimizationConfiguration
+import com.linkedin.photon.ml.util.PhotonNonBroadcast
+
+/**
+ * Unit tests for [[SingleNodeGLMLossFunction]].
+ */
+class SingleNodeGLMLossFunctionTest {
+
+  import SingleNodeGLMLossFunctionTest._
+
+  /**
+   * Verify the value of loss function without regularization.
+   */
+  @Test()
+  def testValueNoRegularization(): Unit = {
+
+    val labeledPoints = Iterable(LABELED_POINT_1, LABELED_POINT_2)
+    val coefficients = COEFFICIENT_VECTOR
+
+    val randomEffectRegularizationContext = NoRegularizationContext
+    val randomEffectOptimizationConfiguration = RandomEffectOptimizationConfiguration(
+      RANDOM_EFFECT_OPTIMIZER_CONFIG,
+      randomEffectRegularizationContext)
+    val singleNodeGLMLossFunction = SingleNodeGLMLossFunction(
+      randomEffectOptimizationConfiguration,
+      LogisticLossFunction)
+    val value = singleNodeGLMLossFunction.value(
+      labeledPoints,
+      coefficients,
+      PhotonNonBroadcast(NORMALIZATION_CONTEXT))
+
+    // expectValue = log(1 + exp(3)) + log(1 + exp(2)) = 5.1755
+    assertEquals(value, 5.1755, EPSILON)
+  }
+
+  /**
+   * Verify the value of loss function with L2 regularization.
+   */
+  @Test()
+  def testValueWithL2Regularization(): Unit = {
+
+    val labeledPoints = Iterable(LABELED_POINT_1, LABELED_POINT_2)
+    val coefficients = COEFFICIENT_VECTOR
+
+    val randomEffectRegularizationContext = L2RegularizationContext
+    val randomEffectOptimizationConfiguration = RandomEffectOptimizationConfiguration(
+      RANDOM_EFFECT_OPTIMIZER_CONFIG,
+      randomEffectRegularizationContext,
+      RANDOM_EFFECT_REGULARIZATION_WEIGHT)
+    val singleNodeGLMLossFunction = SingleNodeGLMLossFunction(
+      randomEffectOptimizationConfiguration,
+      LogisticLossFunction)
+    val value = singleNodeGLMLossFunction.value(
+      labeledPoints,
+      coefficients,
+      PhotonNonBroadcast(NORMALIZATION_CONTEXT))
+
+    // expectedValue = log(1 + exp(3)) + log(1 + exp(2)) + 1 * ((-2)^2 + 3^2) / 2 = 11.6755
+    assertEquals(value, 11.6755, EPSILON)
+  }
+
+  /**
+   * Verify the value of loss function with elastic net regularization.
+   */
+  @Test()
+  def testValueWithElasticNetRegularization(): Unit = {
+
+    val labeledPoints = Iterable(LABELED_POINT_1, LABELED_POINT_2)
+    val coefficients = COEFFICIENT_VECTOR
+
+    val randomEffectRegularizationContext = ElasticNetRegularizationContext(ALPHA)
+    val randomEffectOptimizationConfiguration = RandomEffectOptimizationConfiguration(
+      RANDOM_EFFECT_OPTIMIZER_CONFIG,
+      randomEffectRegularizationContext,
+      RANDOM_EFFECT_REGULARIZATION_WEIGHT)
+    val singleNodeGLMLossFunction = SingleNodeGLMLossFunction(
+      randomEffectOptimizationConfiguration,
+      LogisticLossFunction)
+    val value = singleNodeGLMLossFunction.value(
+      labeledPoints,
+      coefficients,
+      PhotonNonBroadcast(NORMALIZATION_CONTEXT))
+
+    // L1 is computed by the optimizer.
+    // expectedValue = log(1 + exp(3)) + log(1 + exp(2)) + (1 - 0.4) * 1 * ((-2)^2 + 3^2) / 2 = 9.0755
+    assertEquals(value, 9.0755, EPSILON)
+  }
+}
+
+object SingleNodeGLMLossFunctionTest {
+
+  private val RANDOM_EFFECT_OPTIMIZER_CONFIG = mock(classOf[OptimizerConfig])
+  private val LABELED_POINT_1 = new LabeledPoint(0, DenseVector(0.0, 1.0))
+  private val LABELED_POINT_2 = new LabeledPoint(1, DenseVector(1.0, 0.0))
+  private val COEFFICIENT_VECTOR = DenseVector(-2.0, 3.0)
+  private val NORMALIZATION_CONTEXT = NoNormalization()
+  private val RANDOM_EFFECT_REGULARIZATION_WEIGHT = 1D
+  private val ALPHA = 0.4
+  private val EPSILON = 1e-3
+}

--- a/photon-api/src/test/scala/com/linkedin/photon/ml/function/svm/SingleNodeSmoothedHingeLossFunctionTest.scala
+++ b/photon-api/src/test/scala/com/linkedin/photon/ml/function/svm/SingleNodeSmoothedHingeLossFunctionTest.scala
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2019 LinkedIn Corp. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linkedin.photon.ml.function.svm
+
+import breeze.linalg.DenseVector
+import org.mockito.Mockito._
+import org.testng.Assert.assertEquals
+import org.testng.annotations.Test
+
+import com.linkedin.photon.ml.data.LabeledPoint
+import com.linkedin.photon.ml.normalization.NoNormalization
+import com.linkedin.photon.ml.optimization._
+import com.linkedin.photon.ml.optimization.game.RandomEffectOptimizationConfiguration
+import com.linkedin.photon.ml.util.PhotonNonBroadcast
+
+/**
+ * Unit tests for [[SingleNodeSmoothedHingeLossFunction]].
+ */
+class SingleNodeSmoothedHingeLossFunctionTest {
+
+  import SingleNodeSmoothedHingeLossFunctionTest._
+
+  /**
+   * Verify the value of loss function without regularization.
+   */
+  @Test()
+  def testValueNoRegularization(): Unit = {
+
+    val labeledPoints = Iterable(LABELED_POINT_1, LABELED_POINT_2)
+    val coefficients = COEFFICIENT_VECTOR
+
+    val randomEffectRegularizationContext = NoRegularizationContext
+    val randomEffectOptimizationConfiguration = RandomEffectOptimizationConfiguration(
+      RANDOM_EFFECT_OPTIMIZER_CONFIG,
+      randomEffectRegularizationContext)
+    val singleNodeSmoothedHingeLossFunction = SingleNodeSmoothedHingeLossFunction(randomEffectOptimizationConfiguration)
+    val value = singleNodeSmoothedHingeLossFunction.value(
+      labeledPoints,
+      coefficients,
+      PhotonNonBroadcast(NORMALIZATION_CONTEXT))
+
+    assertEquals(value, 6.0, EPSILON)
+  }
+
+  /**
+   * Verify the value of loss function with L2 regularization.
+   */
+  @Test()
+  def testValueWithL2Regularization(): Unit = {
+
+    val labeledPoints = Iterable(LABELED_POINT_1, LABELED_POINT_2)
+    val coefficients = COEFFICIENT_VECTOR
+
+    val randomEffectRegularizationContext = L2RegularizationContext
+    val randomEffectOptimizationConfiguration = RandomEffectOptimizationConfiguration(
+      RANDOM_EFFECT_OPTIMIZER_CONFIG,
+      randomEffectRegularizationContext,
+      RANDOM_EFFECT_REGULARIZATION_WEIGHT)
+    val singleNodeSmoothedHingeLossFunction = SingleNodeSmoothedHingeLossFunction(randomEffectOptimizationConfiguration)
+    val value = singleNodeSmoothedHingeLossFunction.value(
+      labeledPoints,
+      coefficients,
+      PhotonNonBroadcast(NORMALIZATION_CONTEXT))
+
+    // expectedValue = 6 + 1 * ((-2)^2 + 3^2) / 2 = 12.5
+    assertEquals(value, 12.5, EPSILON)
+  }
+
+  /**
+   * Verify the value of loss function with elastic net regularization.
+   */
+  @Test()
+  def testValueWithElasticNetRegularization(): Unit = {
+
+    val labeledPoints = Iterable(LABELED_POINT_1, LABELED_POINT_2)
+    val coefficients = COEFFICIENT_VECTOR
+
+    val randomEffectRegularizationContext = ElasticNetRegularizationContext(ALPHA)
+    val randomEffectOptimizationConfiguration = RandomEffectOptimizationConfiguration(
+      RANDOM_EFFECT_OPTIMIZER_CONFIG,
+      randomEffectRegularizationContext,
+      RANDOM_EFFECT_REGULARIZATION_WEIGHT)
+    val singleNodeSmoothedHingeLossFunction = SingleNodeSmoothedHingeLossFunction(randomEffectOptimizationConfiguration)
+    val value = singleNodeSmoothedHingeLossFunction.value(
+      labeledPoints,
+      coefficients,
+      PhotonNonBroadcast(NORMALIZATION_CONTEXT))
+
+    // L1 is computed by the optimizer.
+    // expectedValue = 6 + (1 - 0.4) * 1 * ((-2)^2 + 3^2) / 2 = 9.9
+    assertEquals(value, 9.9, EPSILON)
+  }
+}
+
+object SingleNodeSmoothedHingeLossFunctionTest {
+
+  private val RANDOM_EFFECT_OPTIMIZER_CONFIG = mock(classOf[OptimizerConfig])
+  private val LABELED_POINT_1 = new LabeledPoint(0, DenseVector(0.0, 1.0))
+  private val LABELED_POINT_2 = new LabeledPoint(1, DenseVector(1.0, 0.0))
+  private val COEFFICIENT_VECTOR = DenseVector(-2.0, 3.0)
+  private val NORMALIZATION_CONTEXT = NoNormalization()
+  private val RANDOM_EFFECT_REGULARIZATION_WEIGHT = 1D
+  private val ALPHA = 0.4
+  private val EPSILON = 1e-3
+}


### PR DESCRIPTION
This PR fixes the bug of elastic net regularization. Unit tests are added for GLM and smoothed hinge loss functions on a single node and distributed nodes.