### PR TITLE
Improve RandomEffectDataset Performance

### DIFF
--- a/photon-api/src/integTest/scala/com/linkedin/photon/ml/estimators/GameEstimatorIntegTest.scala
+++ b/photon-api/src/integTest/scala/com/linkedin/photon/ml/estimators/GameEstimatorIntegTest.scala
@@ -221,7 +221,7 @@ class GameEstimatorIntegTest extends SparkTestUtils with GameTestUtils {
       case ds: RandomEffectDataset =>
         assertEquals(ds.activeData.count(), 33110)
 
-        val featureStats = ds.activeData.values.map(_.numActiveFeatures).stats()
+        val featureStats = ds.activeData.values.map(_.numFeatures).stats()
         assertEquals(featureStats.count, 33110)
         assertEquals(featureStats.mean, 24.12999093, CommonTestUtils.LOW_PRECISION_TOLERANCE)
         assertEquals(featureStats.stdev, 0.61119425, CommonTestUtils.LOW_PRECISION_TOLERANCE)
@@ -236,7 +236,7 @@ class GameEstimatorIntegTest extends SparkTestUtils with GameTestUtils {
       case ds: RandomEffectDataset =>
         assertEquals(ds.activeData.count(), 23167)
 
-        val featureStats = ds.activeData.values.map(_.numActiveFeatures).stats()
+        val featureStats = ds.activeData.values.map(_.numFeatures).stats()
         assertEquals(featureStats.count, 23167)
         assertEquals(featureStats.mean, 21.0, CommonTestUtils.LOW_PRECISION_TOLERANCE)
         assertEquals(featureStats.stdev, 0.0, CommonTestUtils.LOW_PRECISION_TOLERANCE)
@@ -251,7 +251,7 @@ class GameEstimatorIntegTest extends SparkTestUtils with GameTestUtils {
       case ds: RandomEffectDataset =>
         assertEquals(ds.activeData.count(), 4471)
 
-        val featureStats = ds.activeData.values.map(_.numActiveFeatures).stats()
+        val featureStats = ds.activeData.values.map(_.numFeatures).stats()
         assertEquals(featureStats.count, 4471)
         assertEquals(featureStats.mean, 3.0, CommonTestUtils.LOW_PRECISION_TOLERANCE)
         assertEquals(featureStats.stdev, 0.0, CommonTestUtils.LOW_PRECISION_TOLERANCE)

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/data/LocalDataset.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/data/LocalDataset.scala
@@ -40,7 +40,6 @@ protected[ml] case class LocalDataset(dataPoints: Array[(UniqueSampleId, Labeled
 
   val numDataPoints: Int = dataPoints.length
   val numFeatures: Int = dataPoints.head._2.features.length
-  val numActiveFeatures: Int = dataPoints.flatMap(_._2.features.activeKeysIterator).toSet.size
 
   /**
    *
@@ -108,7 +107,10 @@ protected[ml] case class LocalDataset(dataPoints: Array[(UniqueSampleId, Labeled
    * @param numFeaturesToKeep The number of features to keep
    * @return The filtered dataset
    */
-  def filterFeaturesByPearsonCorrelationScore(numFeaturesToKeep: Int): LocalDataset =
+  def filterFeaturesByPearsonCorrelationScore(numFeaturesToKeep: Int): LocalDataset = {
+
+    val numActiveFeatures: Int = dataPoints.flatMap(_._2.features.activeKeysIterator).toSet.size
+
     if (numFeaturesToKeep < numActiveFeatures) {
 
       val labelAndFeatures = dataPoints.map { case (_, labeledPoint) => (labeledPoint.label, labeledPoint.features) }
@@ -133,6 +135,7 @@ protected[ml] case class LocalDataset(dataPoints: Array[(UniqueSampleId, Labeled
     } else {
       this
     }
+  }
 }
 
 object LocalDataset {

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/data/RandomEffectDataset.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/data/RandomEffectDataset.scala
@@ -209,7 +209,7 @@ protected[ml] class RandomEffectDataset(
     val numAllSamples = numActiveSamples + numPassiveSamples
     val numActiveSamplesStats = activeData.values.map(_.numDataPoints).stats()
     val activeSamplerResponseSumStats = activeData.values.map(_.getLabels.map(_._2).sum).stats()
-    val numFeaturesStats = activeData.values.map(_.numActiveFeatures).stats()
+    val numFeaturesStats = activeData.values.map(_.numFeatures).stats()
     val numIdsWithPassiveData =
       if (passiveDataRandomEffectIdsOption.isDefined) passiveDataRandomEffectIdsOption.get.value.size else 0
 

--- a/photon-lib/src/main/scala/com/linkedin/photon/ml/util/VectorUtils.scala
+++ b/photon-lib/src/main/scala/com/linkedin/photon/ml/util/VectorUtils.scala
@@ -260,15 +260,28 @@ object VectorUtils {
    * @param vector the input vector
    * @return the set of indices
    */
-  def getActiveIndices(vector: Vector[Double]): Set[Int] = vector match {
-    case vector: DenseVector[Double] => vector
+  def getActiveIndices(vector: Vector[Double]): mutable.Set[Int] = vector match {
+    case dense: DenseVector[Double] =>
+      val set: mutable.Set[Int] = mutable.Set.empty[Int]
+      var index: Int = 0
+
+      dense
         .valuesIterator
-        .zipWithIndex
-        .filter(x => !MathUtils.isAlmostZero(x._1))
-        .map(_._2)
-        .toSet
+        .foreach { value =>
+          if (!MathUtils.isAlmostZero(value)) {
+            set += index
+          }
 
-    case _ => vector.activeKeysIterator.toSet
+          index += 1
+        }
+
+      set
+
+    case sparse: SparseVector[Double] =>
+      val set: mutable.Set[Int] = mutable.Set.empty[Int]
+
+      sparse.activeKeysIterator.foreach(set += _)
+
+      set
   }
-
 }


### PR DESCRIPTION
`numActiveFeatures` should only be used in one place, and is expensive to compute, so remove it as a member of `LocalDataset`.

`VectorUtils.getActiveIndices` uses immutable `Set` objects which cause too much latency when dealing with large random effects due to inefficient Scala construction algorithm - replace with mutable `Set` objects.