### PR TITLE
Remove 'materializeOnce' function from RDDLike trait 

### DIFF
--- a/photon-api/src/main/scala/com/linkedin/photon/ml/data/FixedEffectDataset.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/data/FixedEffectDataset.scala
@@ -107,7 +107,7 @@ protected[ml] class FixedEffectDataset(
    */
   override def materialize(): FixedEffectDataset = {
 
-    materializeOnce(labeledPoints)
+    labeledPoints.count()
 
     this
   }

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/data/RandomEffectDataset.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/data/RandomEffectDataset.scala
@@ -148,7 +148,9 @@ protected[ml] class RandomEffectDataset(
    */
   override def materialize(): RandomEffectDataset = {
 
-    materializeOnce(activeData, uniqueIdToRandomEffectIds, passiveData)
+    activeData.count()
+    uniqueIdToRandomEffectIds.count()
+    passiveData.count()
 
     this
   }

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/data/RandomEffectDatasetInProjectedSpace.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/data/RandomEffectDatasetInProjectedSpace.scala
@@ -84,11 +84,14 @@ class RandomEffectDatasetInProjectedSpace(
    * @return This object with all its RDDs materialized
    */
   override def materialize(): this.type = {
+
     super.materialize()
+
     randomEffectProjector match {
       case rddLike: RDDLike => rddLike.materialize()
       case _ =>
     }
+
     this
   }
 }

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/model/RandomEffectModel.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/model/RandomEffectModel.scala
@@ -180,7 +180,7 @@ class RandomEffectModel(
    */
   override protected[ml] def materialize(): RandomEffectModel = {
 
-    materializeOnce(modelsRDD)
+    modelsRDD.count()
 
     this
   }

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/model/RandomEffectModelInProjectedSpace.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/model/RandomEffectModelInProjectedSpace.scala
@@ -144,7 +144,7 @@ protected[ml] class RandomEffectModelInProjectedSpace(
   override def materialize(): RandomEffectModelInProjectedSpace = {
 
     super.materialize()
-    materializeOnce(modelsInProjectedSpaceRDD)
+    modelsInProjectedSpaceRDD.count()
 
     this
   }

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/optimization/RandomEffectOptimizationTracker.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/optimization/RandomEffectOptimizationTracker.scala
@@ -87,7 +87,7 @@ protected[ml] class RandomEffectOptimizationTracker(val optimizationStatesTracke
    */
   override def materialize(): RandomEffectOptimizationTracker = {
 
-    materializeOnce(optimizationStatesTrackers)
+    optimizationStatesTrackers.count()
 
     this
   }

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/optimization/game/RandomEffectOptimizationProblem.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/optimization/game/RandomEffectOptimizationProblem.scala
@@ -99,7 +99,7 @@ protected[ml] class RandomEffectOptimizationProblem[Objective <: SingleNodeObjec
    */
   override def materialize(): this.type = {
 
-    materializeOnce(optimizationProblems)
+    optimizationProblems.count()
 
     this
   }

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/projector/IndexMapProjectorRDD.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/projector/IndexMapProjectorRDD.scala
@@ -201,7 +201,7 @@ protected[ml] class IndexMapProjectorRDD private (indexMapProjectorRDD: RDD[(Str
    */
   override def materialize(): IndexMapProjectorRDD = {
 
-    materializeOnce(indexMapProjectorRDD)
+    indexMapProjectorRDD.count()
 
     this
   }
@@ -238,9 +238,9 @@ object IndexMapProjectorRDD {
     val passiveIndices = randomEffectDataset
       .passiveData
       .map { case (_, (reId, labeledPoint)) =>
-        (reId, VectorUtils.getActiveIndices(labeledPoint.features))
+        (reId, labeledPoint.features)
       }
-      .partitionBy(randomEffectDataset.randomEffectIdPartitioner)
+      .mapValues(VectorUtils.getActiveIndices)
 
     // Union them, and fold the results into (reId, indices) tuples
     val indices = if (!passiveIndices.isEmpty()) {

--- a/photon-lib/src/main/scala/com/linkedin/photon/ml/data/scoring/DataScores.scala
+++ b/photon-lib/src/main/scala/com/linkedin/photon/ml/data/scoring/DataScores.scala
@@ -103,7 +103,7 @@ abstract protected[ml] class DataScores[T : ClassTag, D <: DataScores[T, D]](
    */
   override def materialize(): RDDLike = {
 
-    materializeOnce(scores)
+    scores.count()
 
     this
   }

--- a/photon-lib/src/main/scala/com/linkedin/photon/ml/evaluation/EvaluationSuite.scala
+++ b/photon-lib/src/main/scala/com/linkedin/photon/ml/evaluation/EvaluationSuite.scala
@@ -143,7 +143,7 @@ class EvaluationSuite(
    */
   protected[ml] def materialize(): EvaluationSuite = {
 
-    materializeOnce(labelAndOffsetAndWeights)
+    labelAndOffsetAndWeights.count()
 
     this
   }

--- a/photon-lib/src/main/scala/com/linkedin/photon/ml/spark/RDDLike.scala
+++ b/photon-lib/src/main/scala/com/linkedin/photon/ml/spark/RDDLike.scala
@@ -14,11 +14,9 @@
  */
 package com.linkedin.photon.ml.spark
 
-import scala.reflect.ClassTag
-
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
-import org.apache.spark.storage.{RDDInfo, StorageLevel}
+import org.apache.spark.storage.StorageLevel
 
 /**
  * A trait containing simple operations on [[RDD]]s.
@@ -63,19 +61,4 @@ protected[ml] trait RDDLike {
    * @return This object with all of its [[RDD]]s materialized
    */
   protected[ml] def materialize(): RDDLike
-
-  /**
-   * Materialize the given [[RDD]]s, if they are not already materialized and cached. Forcing an [[RDD]] to be evaluated
-   * is a waste of resources if it is already materialized.
-   *
-   * @tparam T Generic type to handle any [[RDD]]
-   * @param rdds The [[RDD]]s to materialize
-   */
-  protected def materializeOnce[T <: RDD[_] : ClassTag](rdds: T*): Unit = {
-    val idSet = sparkContext.getRDDStorageInfo.map(_.id).toSet
-
-    rdds.foreach { rdd =>
-      if (!idSet.contains(rdd.id)) rdd.count()
-    }
-  }
 }


### PR DESCRIPTION
Change made in preparation for projection refactor (it was not working correctly anyway). After persistence refactor, this function will likely be completely removed.