### PR TITLE
Minor refactor to DatumScoringModel modelType

### DIFF
--- a/photon-api/src/main/scala/com/linkedin/photon/ml/model/RandomEffectModelInProjectedSpace.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/model/RandomEffectModelInProjectedSpace.scala
@@ -17,7 +17,6 @@ package com.linkedin.photon.ml.model
 import org.apache.spark.rdd.RDD
 import org.apache.spark.storage.StorageLevel
 
-import com.linkedin.photon.ml.TaskType.TaskType
 import com.linkedin.photon.ml.Types.{FeatureShardId, REType, REId}
 import com.linkedin.photon.ml.projector.RandomEffectProjector
 import com.linkedin.photon.ml.supervised.model.GeneralizedLinearModel
@@ -45,39 +44,18 @@ protected[ml] class RandomEffectModelInProjectedSpace(
    *
    * @return A [[RandomEffectModel]]
    */
-  def toRandomEffectModel: RandomEffectModel = {
-
-    val currType = this.modelType
-
-    new RandomEffectModel(modelsInProjectedSpaceRDD, randomEffectType, featureShardId) {
-
-      // TODO: The model types don't necessarily match, but checking each time is slow so copy the type for now
-      override lazy val modelType: TaskType = currType
-    }
-  }
+  def toRandomEffectModel: RandomEffectModel =
+    new RandomEffectModel(modelsInProjectedSpaceRDD, randomEffectType, featureShardId)
 
   /**
    * Update the random effect model in projected space with new sub-models (one per random effect ID).
    *
-   * @param updatedModelsRDDInProjectedSpace The new sub-models with coefficients in projected space, one per random
+   * @param updatedModelsRdd The new sub-models with coefficients in projected space, one per random
    *                                         effect ID
    * @return The updated random effect model in projected space
    */
-  override def update(
-      updatedModelsRDDInProjectedSpace: RDD[(REId, GeneralizedLinearModel)]): RandomEffectModelInProjectedSpace = {
-
-    val currType = this.modelType
-
-    new RandomEffectModelInProjectedSpace(
-        updatedModelsRDDInProjectedSpace,
-        randomEffectProjector,
-        randomEffectType,
-        featureShardId) {
-
-      // TODO: The model types don't necessarily match, but checking each time is slow so copy the type for now
-      override lazy val modelType: TaskType = currType
-    }
-  }
+  override def update(updatedModelsRdd: RDD[(REId, GeneralizedLinearModel)]): RandomEffectModelInProjectedSpace =
+    new RandomEffectModelInProjectedSpace(updatedModelsRdd, randomEffectProjector, randomEffectType, featureShardId)
 
   /**
    * Summarize this model in text format.

--- a/photon-client/src/integTest/scala/com/linkedin/photon/ml/data/avro/ModelProcessingUtilsIntegTest.scala
+++ b/photon-client/src/integTest/scala/com/linkedin/photon/ml/data/avro/ModelProcessingUtilsIntegTest.scala
@@ -559,12 +559,12 @@ object ModelProcessingUtilsIntegTest {
     gameModel
       .toMap
       .map {
-        case (fixedEffect: String, model: FixedEffectModel) =>
+        case (coordinate: CoordinateId, model: FixedEffectModel) =>
           val featureIndex = featureIndexLoaders(model.featureShardId).indexMapForDriver()
 
-          (fixedEffect, Map((fixedEffect, extractGLMFeatures(model.model, featureIndex))))
+          (coordinate, Map((coordinate, extractGLMFeatures(model.model, featureIndex))))
 
-        case (randomEffect: String, model: RandomEffectModel) =>
+        case (coordinate: CoordinateId, model: RandomEffectModel) =>
           // Each random effect has a feature space, referred to by a shard id
           val featureShardId = model.featureShardId
           val featureIndexLoader = featureIndexLoaders(featureShardId)
@@ -577,10 +577,10 @@ object ModelProcessingUtilsIntegTest {
             }
           }
 
-        (randomEffect, featuresMapRDD.collect().toMap)
+        (coordinate, featuresMapRDD.collect().toMap)
 
-        case (modelType, _) =>
-          throw new RuntimeException(s"Unknown model type: $modelType")
+        case (coordinate, _) =>
+          throw new RuntimeException(s"Unknown model type for coordinate '$coordinate'")
       }
 
   /**


### PR DESCRIPTION
This change is made in preparation for the projection refactor, after which `RandomEffectModelInProjectedSpace` will no longer exist and the number of calls to `determineModelType` should no longer cause noticeable performance impact (allowing us to simplify the code)