### PR TITLE
Loosen permissions on Evaluator.evaluate method

### DIFF
--- a/photon-api/src/integTest/scala/com/linkedin/photon/ml/evaluation/MultiEvaluatorIntegTest.scala
+++ b/photon-api/src/integTest/scala/com/linkedin/photon/ml/evaluation/MultiEvaluatorIntegTest.scala
@@ -74,7 +74,7 @@ class MultiEvaluatorIntegTest extends SparkTestUtils {
 object MultiEvaluatorIntegTest {
 
   class MockLocalEvaluator extends LocalEvaluator {
-    override protected[ml] def evaluate(scoreLabelAndWeight: Array[(Double, Double, Double)]): Double =
+    override def evaluate(scoreLabelAndWeight: Array[(Double, Double, Double)]): Double =
       math.pow(scoreLabelAndWeight.map(_._1).sum, 2)
   }
 

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/evaluation/AreaUnderPRCurveEvaluator.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/evaluation/AreaUnderPRCurveEvaluator.scala
@@ -30,7 +30,7 @@ object AreaUnderPRCurveEvaluator extends SingleEvaluator {
    * @param scoresAndLabelsAndWeights A [[RDD]] of scored data
    * @return The AUPR
    */
-  override protected[ml] def evaluate(scoresAndLabelsAndWeights: RDD[(Double, Double, Double)]): Double = {
+  override def evaluate(scoresAndLabelsAndWeights: RDD[(Double, Double, Double)]): Double = {
 
     val scoreAndLabels = scoresAndLabelsAndWeights.map { case (score, label, _) => (score, label) }
 

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/evaluation/AreaUnderROCCurveEvaluator.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/evaluation/AreaUnderROCCurveEvaluator.scala
@@ -30,7 +30,7 @@ object AreaUnderROCCurveEvaluator extends SingleEvaluator {
    * @param scoresAndLabelsAndWeights A [[RDD]] of scored data
    * @return The AUROC
    */
-  override protected[ml] def evaluate(scoresAndLabelsAndWeights: RDD[(Double, Double, Double)]): Double = {
+  override def evaluate(scoresAndLabelsAndWeights: RDD[(Double, Double, Double)]): Double = {
 
     val scoreAndLabels = scoresAndLabelsAndWeights.map { case (score, label, _) => (score, label) }
 

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/evaluation/AreaUnderROCCurveLocalEvaluator.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/evaluation/AreaUnderROCCurveLocalEvaluator.scala
@@ -30,7 +30,7 @@ protected[evaluation] object AreaUnderROCCurveLocalEvaluator extends LocalEvalua
    * @param scoresAndLabelsAndWeights An [[Array]] of (score, label, weight) tuples
    * @return The AUROC
    */
-  protected[evaluation] override def evaluate(scoresAndLabelsAndWeights: Array[(Double, Double, Double)]): Double = {
+  override def evaluate(scoresAndLabelsAndWeights: Array[(Double, Double, Double)]): Double = {
 
     //Directly calling scoresAndLabelAndWeight.sort would cause some performance issue with large arrays
     val comparator = new JComparator[(Double, Double, Double)]() {

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/evaluation/LogisticLossEvaluator.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/evaluation/LogisticLossEvaluator.scala
@@ -31,7 +31,7 @@ object LogisticLossEvaluator extends SingleEvaluator {
    * @param scoresAndLabelsAndWeights A [[RDD]] of scored data
    * @return The logistic loss
    */
-  override protected[ml] def evaluate(scoresAndLabelsAndWeights: RDD[(Double, Double, Double)]): Double =
+  override def evaluate(scoresAndLabelsAndWeights: RDD[(Double, Double, Double)]): Double =
     scoresAndLabelsAndWeights
       .map { case (score, label, weight) =>
         weight * LogisticLossFunction.lossAndDzLoss(score, label)._1

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/evaluation/PoissonLossEvaluator.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/evaluation/PoissonLossEvaluator.scala
@@ -31,7 +31,7 @@ object PoissonLossEvaluator extends SingleEvaluator {
    * @param scoresAndLabelsAndWeights A [[RDD]] of scored data
    * @return The Poisson loss
    */
-  override protected[ml] def evaluate(scoresAndLabelsAndWeights: RDD[(Double, Double, Double)]): Double =
+  override def evaluate(scoresAndLabelsAndWeights: RDD[(Double, Double, Double)]): Double =
     scoresAndLabelsAndWeights
       .map { case (score, label, weight) =>
         weight * PoissonLossFunction.lossAndDzLoss(score, label)._1

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/evaluation/PrecisionAtKLocalEvaluator.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/evaluation/PrecisionAtKLocalEvaluator.scala
@@ -36,7 +36,7 @@ protected[evaluation] class PrecisionAtKLocalEvaluator(protected val k: Int) ext
    * @param scoresAndLabelsAndWeights An [[Array]] of (score, label, weight) tuples
    * @return The precision @ k
    */
-  protected[evaluation] override def evaluate(scoresAndLabelsAndWeights: Array[(Double, Double, Double)]): Double = {
+  override def evaluate(scoresAndLabelsAndWeights: Array[(Double, Double, Double)]): Double = {
 
     // Directly calling scoresAndLabelAndWeight.sort in Scala would cause some performance issue with large arrays
     val comparator = new JComparator[(Double, Double, Double)]() {

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/evaluation/RMSEEvaluator.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/evaluation/RMSEEvaluator.scala
@@ -29,7 +29,7 @@ object RMSEEvaluator extends SingleEvaluator {
    * @param scoresAndLabelsAndWeights A [[RDD]] of scored data
    * @return The RMSE
    */
-  override protected[ml] def evaluate(scoresAndLabelsAndWeights: RDD[(Double, Double, Double)]): Double = {
+  override def evaluate(scoresAndLabelsAndWeights: RDD[(Double, Double, Double)]): Double = {
 
     val squaredLoss = SquaredLossEvaluator.evaluate(scoresAndLabelsAndWeights)
 

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/evaluation/SmoothedHingeLossEvaluator.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/evaluation/SmoothedHingeLossEvaluator.scala
@@ -31,7 +31,7 @@ object SmoothedHingeLossEvaluator extends SingleEvaluator {
    * @param scoresAndLabelsAndWeights A [[RDD]] of scored data
    * @return The smoothed hinge loss
    */
-  override protected[ml] def evaluate(scoresAndLabelsAndWeights: RDD[(Double, Double, Double)]): Double =
+  override def evaluate(scoresAndLabelsAndWeights: RDD[(Double, Double, Double)]): Double =
     scoresAndLabelsAndWeights
       .map { case (score, label, weight) =>
         weight * SmoothedHingeLossFunction.lossAndDzLoss(score, label)._1

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/evaluation/SquaredLossEvaluator.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/evaluation/SquaredLossEvaluator.scala
@@ -31,7 +31,7 @@ object SquaredLossEvaluator extends SingleEvaluator {
    * @param scoresAndLabelsAndWeights A [[RDD]] of scored data
    * @return The squared loss
    */
-  override protected[ml] def evaluate(scoresAndLabelsAndWeights: RDD[(Double, Double, Double)]): Double =
+  override def evaluate(scoresAndLabelsAndWeights: RDD[(Double, Double, Double)]): Double =
     scoresAndLabelsAndWeights
       .map { case (score, label, weight) =>
         weight * SquaredLossFunction.lossAndDzLoss(score, label)._1

--- a/photon-api/src/test/scala/com/linkedin/photon/ml/evaluation/PrecisionAtKLocalEvaluatorTest.scala
+++ b/photon-api/src/test/scala/com/linkedin/photon/ml/evaluation/PrecisionAtKLocalEvaluatorTest.scala
@@ -55,26 +55,42 @@ class PrecisionAtKLocalEvaluatorTest {
     // Two case adopted from Metronome
     val labelsM1 = Array[Double](0, 0, 1, 0)
     val scoresM1 = Array(1, 0.75, 0.5, 0.25)
+    val scoresAndLabelsAndWeightsM1 = getScoreLabelAndWeights(scoresM1, labelsM1)
     val metronomeCase1 = Array(
-      Array (1, getScoreLabelAndWeights(scoresM1, labelsM1), 0.0),
-      Array (2, getScoreLabelAndWeights(scoresM1, labelsM1), 0.0),
-      Array (3, getScoreLabelAndWeights(scoresM1, labelsM1), 1.0 / 3),
-      Array (4, getScoreLabelAndWeights(scoresM1, labelsM1), 1.0 / 4),
-      Array (10, getScoreLabelAndWeights(scoresM1, labelsM1), 1.0 / 10)
+      Array(1, scoresAndLabelsAndWeightsM1, 0.0),
+      Array(2, scoresAndLabelsAndWeightsM1, 0.0),
+      Array(3, scoresAndLabelsAndWeightsM1, 1.0 / 3),
+      Array(4, scoresAndLabelsAndWeightsM1, 1.0 / 4),
+      Array(10, scoresAndLabelsAndWeightsM1, 1.0 / 10)
     )
 
     val labelsM2 = Array[Double](1, 0, 0, 1, 1, 0)
     val scoresM2 = Array(1, 0.75, 0.5, 0.25, 0.2, 0.1)
+    val scoresAndLabelsAndWeightsM2 = getScoreLabelAndWeights(scoresM2, labelsM2)
     val metronomeCase2 = Array(
-      Array (1, getScoreLabelAndWeights(scoresM2, labelsM2), 1.0),
-      Array (2, getScoreLabelAndWeights(scoresM2, labelsM2), 1.0 / 2),
-      Array (3, getScoreLabelAndWeights(scoresM2, labelsM2), 1.0 / 3),
-      Array (4, getScoreLabelAndWeights(scoresM2, labelsM2), 2.0 / 4),
-      Array (5, getScoreLabelAndWeights(scoresM2, labelsM2), 3.0 / 5),
-      Array (100, getScoreLabelAndWeights(scoresM2, labelsM2), 3.0 / 100)
+      Array(1, scoresAndLabelsAndWeightsM2, 1.0),
+      Array(2, scoresAndLabelsAndWeightsM2, 1.0 / 2),
+      Array(3, scoresAndLabelsAndWeightsM2, 1.0 / 3),
+      Array(4, scoresAndLabelsAndWeightsM2, 2.0 / 4),
+      Array(5, scoresAndLabelsAndWeightsM2, 3.0 / 5),
+      Array(100, scoresAndLabelsAndWeightsM2, 3.0 / 100)
     )
 
-    trivialCase1 ++ trivialCase2 ++ trivialCase3 ++ trivialCase4 ++ metronomeCase1 ++ metronomeCase2
+    // Identical to the second Metronome test, but the order of the scores and labels is shifted (this tests that the
+    // evaluator correctly sorts by score)
+    val labelsM3 = Array[Double](1, 0, 1, 0, 1, 0)
+    val scoresM3 = Array(0.2, 0.1, 1, 0.5, 0.25, 0.75)
+    val scoresAndLabelsAndWeightsM3 = getScoreLabelAndWeights(scoresM3, labelsM3)
+    val metronomeCase3 = Array(
+      Array(1, scoresAndLabelsAndWeightsM3, 1.0),
+      Array(2, scoresAndLabelsAndWeightsM3, 1.0 / 2),
+      Array(3, scoresAndLabelsAndWeightsM3, 1.0 / 3),
+      Array(4, scoresAndLabelsAndWeightsM3, 2.0 / 4),
+      Array(5, scoresAndLabelsAndWeightsM3, 3.0 / 5),
+      Array(100, scoresAndLabelsAndWeightsM3, 3.0 / 100)
+    )
+
+    trivialCase1 ++ trivialCase2 ++ trivialCase3 ++ trivialCase4 ++ metronomeCase1 ++ metronomeCase2 ++ metronomeCase3
   }
 
   /**

--- a/photon-lib/src/main/scala/com/linkedin/photon/ml/evaluation/Evaluator.scala
+++ b/photon-lib/src/main/scala/com/linkedin/photon/ml/evaluation/Evaluator.scala
@@ -42,7 +42,7 @@ trait Evaluator {
    * @param scoresAndLabelsAndWeights A [[RDD]] of scored data
    * @return The evaluation metric
    */
-  protected[ml] def evaluate(scoresAndLabelsAndWeights: RDD[ScoredData]): Double
+  def evaluate(scoresAndLabelsAndWeights: RDD[ScoredData]): Double
 
   //
   // Object functions

--- a/photon-lib/src/main/scala/com/linkedin/photon/ml/evaluation/LocalEvaluator.scala
+++ b/photon-lib/src/main/scala/com/linkedin/photon/ml/evaluation/LocalEvaluator.scala
@@ -25,5 +25,5 @@ trait LocalEvaluator extends Serializable {
    * @param scoresAndLabelsAndWeights An [[Array]] of (score, label, weight) tuples
    * @return The evaluation metric
    */
-  protected[evaluation] def evaluate(scoresAndLabelsAndWeights: Array[(Double, Double, Double)]): Double
+  def evaluate(scoresAndLabelsAndWeights: Array[(Double, Double, Double)]): Double
 }

--- a/photon-lib/src/main/scala/com/linkedin/photon/ml/evaluation/MultiEvaluator.scala
+++ b/photon-lib/src/main/scala/com/linkedin/photon/ml/evaluation/MultiEvaluator.scala
@@ -46,7 +46,7 @@ abstract class MultiEvaluator(
    * @param scoresAndLabelsAndWeights A [[RDD]] of pairs (uniqueId, (score, label, weight))
    * @return Evaluation metric value
    */
-  override protected[ml] def evaluate(
+  override def evaluate(
       scoresAndLabelsAndWeights: RDD[(UniqueSampleId, (Double, Double, Double))]): Double = {
 
     // Create a local copy of the localEvaluator, so that the underlying object won't get shipped to the executor nodes

--- a/photon-lib/src/test/scala/com/linkedin/photon/ml/evaluation/EvaluationSuiteTest.scala
+++ b/photon-lib/src/test/scala/com/linkedin/photon/ml/evaluation/EvaluationSuiteTest.scala
@@ -100,7 +100,7 @@ object EvaluationSuiteTest {
 
     type ScoredData = Double
 
-    override protected[ml] def evaluate(scoresAndLabelsAndWeights: RDD[Double]): Double =
+    override def evaluate(scoresAndLabelsAndWeights: RDD[Double]): Double =
       scoresAndLabelsAndWeights.sum()
   }
 }


### PR DESCRIPTION
- Change permissions of Evaluator.evaluate and all derived classes to public
- Add PrecisionAtKLocalEvaluator unit tests