### PR TITLE
Fix output stream writer to UTF-8 format

### DIFF
--- a/photon-client/src/main/scala/com/linkedin/photon/ml/util/IOUtils.scala
+++ b/photon-client/src/main/scala/com/linkedin/photon/ml/util/IOUtils.scala
@@ -222,7 +222,7 @@ object IOUtils {
     val stream = fs.create(outputPath, forceOverwrite)
     val writer = new PrintWriter(
       new BufferedWriter(
-        new OutputStreamWriter(stream)
+        new OutputStreamWriter(stream, "UTF-8")
       )
     )
     try {


### PR DESCRIPTION
Fix output stream writer to UTF-8 format to solve generating inconsistent feature list issue when running NameAndTermFeatureBagsDriver in photon-client