### PR TITLE
Solve the Spark lineage problem by disabling warm start for autotuning

### DIFF
--- a/photon-client/src/test/scala/com/linkedin/photon/ml/cli/game/GameDriverTest.scala
+++ b/photon-client/src/test/scala/com/linkedin/photon/ml/cli/game/GameDriverTest.scala
@@ -167,7 +167,10 @@ class GameDriverTest {
    *
    * @param params A [[ParamMap]] with one or more flaws
    */
-  @Test(dataProvider = "invalidParamMaps", expectedExceptions = Array(classOf[IllegalArgumentException]))
+  @Test(
+    dataProvider = "invalidParamMaps",
+    expectedExceptions = Array(classOf[IllegalArgumentException]),
+    dependsOnMethods = Array("testGetRequiredParam"))
   def testValidateParams(params: ParamMap): Unit = {
 
     MockGameDriver.clear()


### PR DESCRIPTION
This PR solves the Spark lineage issue by disabling warm start for autotuning. Without this change, GAME training jobs with multiple number of iterations for hyperparameter search failed because of the limitation of Spark lineage. After applying the change, tests for grid search and autotuning ran stable.