### PR TITLE
Make optimization state tracking mandatory

### DIFF
--- a/photon-api/src/integTest/scala/com/linkedin/photon/ml/algorithm/CoordinateFactoryIntegTest.scala
+++ b/photon-api/src/integTest/scala/com/linkedin/photon/ml/algorithm/CoordinateFactoryIntegTest.scala
@@ -56,8 +56,7 @@ class CoordinateFactoryIntegTest extends SparkTestUtils {
       GLM_CONSTRUCTOR,
       DOWN_SAMPLER_FACTORY,
       MOCK_NORMALIZATION,
-      VARIANCE_COMPUTATION_TYPE,
-      TRACK_STATE)
+      VARIANCE_COMPUTATION_TYPE)
 
     coordinate match {
       case _: FixedEffectCoordinate[DistributedObjectiveFunction] =>
@@ -96,8 +95,7 @@ class CoordinateFactoryIntegTest extends SparkTestUtils {
       GLM_CONSTRUCTOR,
       DOWN_SAMPLER_FACTORY,
       MOCK_NORMALIZATION,
-      VARIANCE_COMPUTATION_TYPE,
-      TRACK_STATE)
+      VARIANCE_COMPUTATION_TYPE)
 
     coordinate match {
       case _: RandomEffectCoordinate[SingleNodeObjectiveFunction] =>
@@ -123,8 +121,7 @@ class CoordinateFactoryIntegTest extends SparkTestUtils {
       GLM_CONSTRUCTOR,
       DOWN_SAMPLER_FACTORY,
       MOCK_NORMALIZATION,
-      VARIANCE_COMPUTATION_TYPE,
-      TRACK_STATE)
+      VARIANCE_COMPUTATION_TYPE)
   }
 }
 
@@ -136,7 +133,6 @@ object CoordinateFactoryIntegTest {
   private val TOLERANCE = 2E-2
   private val TREE_AGGREGATE_DEPTH = 1
   private val VARIANCE_COMPUTATION_TYPE = VarianceComputationType.NONE
-  private val TRACK_STATE = true
 
   private val OPTIMIZER_CONFIG = OptimizerConfig(OPTIMIZER_TYPE, MAX_ITER, TOLERANCE)
   private val MOCK_NORMALIZATION = mock(classOf[NormalizationContext])

--- a/photon-api/src/integTest/scala/com/linkedin/photon/ml/normalization/NormalizationContextIntegTest.scala
+++ b/photon-api/src/integTest/scala/com/linkedin/photon/ml/normalization/NormalizationContextIntegTest.scala
@@ -104,7 +104,6 @@ class NormalizationContextIntegTest extends SparkTestUtils with GameTestUtils {
       normalizationContext,
       NUM_ITER,
       CONVERGENCE_TOLERANCE,
-      enableOptimizationStateTracker = true,
       constraintMap = None,
       treeAggregateDepth = 1,
       useWarmStart = false)

--- a/photon-api/src/integTest/scala/com/linkedin/photon/ml/optimization/DistributedOptimizationProblemIntegTest.scala
+++ b/photon-api/src/integTest/scala/com/linkedin/photon/ml/optimization/DistributedOptimizationProblemIntegTest.scala
@@ -162,7 +162,7 @@ class DistributedOptimizationProblemIntegTest extends SparkTestUtils {
     val objectiveFunction = mock(classOf[DistributedSmoothedHingeLossFunction])
 
     doReturn(normalization).when(normalizationMock).value
-    doReturn(Some(statesTracker)).when(optimizer).getStateTracker
+    doReturn(statesTracker).when(optimizer).getStateTracker
 
     val optimizerL1 = new OWLQN(initL1Weight, normalizationMock)
     val objectiveFunctionL2 = new L2LossFunction(sc)
@@ -234,7 +234,7 @@ class DistributedOptimizationProblemIntegTest extends SparkTestUtils {
       regularizationWeight: Double,
       dataGenerationFunction: () => Seq[LabeledPoint],
       lossFunction: PointwiseLossFunction,
-      DzzLossFunction: (Vector[Double]) => (LabeledPoint) => Double): Unit = sparkTest("testComputeVariancesSimple") {
+      DzzLossFunction: Vector[Double] => (LabeledPoint => Double)): Unit = sparkTest("testComputeVariancesSimple") {
 
     val input = sc.parallelize(dataGenerationFunction())
     val coefficients = generateDenseVector(OptimizationProblemIntegTestUtils.DIMENSIONS)
@@ -244,7 +244,7 @@ class DistributedOptimizationProblemIntegTest extends SparkTestUtils {
     val regContext = mock(classOf[RegularizationContext])
     val optConfig = mock(classOf[FixedEffectOptimizationConfiguration])
 
-    doReturn(Some(statesTracker)).when(optimizer).getStateTracker
+    doReturn(statesTracker).when(optimizer).getStateTracker
     doReturn(regContext).when(optConfig).regularizationContext
     doReturn(regularizationWeight).when(optConfig).regularizationWeight
     doReturn(RegularizationType.L2).when(regContext).regularizationType
@@ -286,7 +286,7 @@ class DistributedOptimizationProblemIntegTest extends SparkTestUtils {
       regularizationWeight: Double,
       dataGenerationFunction: () => Seq[LabeledPoint],
       lossFunction: PointwiseLossFunction,
-      DzzLossFunction: (Vector[Double]) => (LabeledPoint) => Double): Unit = sparkTest("testComputeVariancesFull") {
+      DzzLossFunction: Vector[Double] => (LabeledPoint => Double)): Unit = sparkTest("testComputeVariancesFull") {
 
     val input = sc.parallelize(dataGenerationFunction())
     val dimensions = OptimizationProblemIntegTestUtils.DIMENSIONS
@@ -297,7 +297,7 @@ class DistributedOptimizationProblemIntegTest extends SparkTestUtils {
     val regContext = mock(classOf[RegularizationContext])
     val optConfig = mock(classOf[FixedEffectOptimizationConfiguration])
 
-    doReturn(Some(statesTracker)).when(optimizer).getStateTracker
+    doReturn(statesTracker).when(optimizer).getStateTracker
     doReturn(regContext).when(optConfig).regularizationContext
     doReturn(regularizationWeight).when(optConfig).regularizationWeight
     doReturn(RegularizationType.L2).when(regContext).regularizationType
@@ -350,7 +350,7 @@ class DistributedOptimizationProblemIntegTest extends SparkTestUtils {
     val regContext = mock(classOf[RegularizationContext])
     val optConfig = mock(classOf[FixedEffectOptimizationConfiguration])
 
-    doReturn(Some(statesTracker)).when(optimizer).getStateTracker
+    doReturn(statesTracker).when(optimizer).getStateTracker
     doReturn(regContext).when(optConfig).regularizationContext
     doReturn(RegularizationType.NONE).when(regContext).regularizationType
 

--- a/photon-api/src/integTest/scala/com/linkedin/photon/ml/optimization/SingleNodeOptimizationProblemIntegTest.scala
+++ b/photon-api/src/integTest/scala/com/linkedin/photon/ml/optimization/SingleNodeOptimizationProblemIntegTest.scala
@@ -152,7 +152,7 @@ class SingleNodeOptimizationProblemIntegTest extends SparkTestUtils {
       regularizationWeight: Double,
       inputData: Seq[LabeledPoint],
       lossFunction: PointwiseLossFunction,
-      DzzLossFunction: (Vector[Double]) => (LabeledPoint) => Double): Unit = {
+      DzzLossFunction: Vector[Double] => (LabeledPoint => Double)): Unit = {
 
     val coefficients = generateDenseVector(OptimizationProblemIntegTestUtils.DIMENSIONS)
 
@@ -161,7 +161,7 @@ class SingleNodeOptimizationProblemIntegTest extends SparkTestUtils {
     val regContext = mock(classOf[RegularizationContext])
     val optConfig = mock(classOf[FixedEffectOptimizationConfiguration])
 
-    doReturn(Some(statesTracker)).when(optimizer).getStateTracker
+    doReturn(statesTracker).when(optimizer).getStateTracker
     doReturn(regContext).when(optConfig).regularizationContext
     doReturn(regularizationWeight).when(optConfig).regularizationWeight
     doReturn(RegularizationType.L2).when(regContext).regularizationType
@@ -200,7 +200,7 @@ class SingleNodeOptimizationProblemIntegTest extends SparkTestUtils {
       regularizationWeight: Double,
       inputData: Seq[LabeledPoint],
       lossFunction: PointwiseLossFunction,
-      DzzLossFunction: (Vector[Double]) => (LabeledPoint) => Double): Unit = {
+      DzzLossFunction: Vector[Double] => (LabeledPoint => Double)): Unit = {
 
     val dimensions = OptimizationProblemIntegTestUtils.DIMENSIONS
     val coefficients = generateDenseVector(dimensions)
@@ -210,7 +210,7 @@ class SingleNodeOptimizationProblemIntegTest extends SparkTestUtils {
     val regContext = mock(classOf[RegularizationContext])
     val optConfig = mock(classOf[FixedEffectOptimizationConfiguration])
 
-    doReturn(Some(statesTracker)).when(optimizer).getStateTracker
+    doReturn(statesTracker).when(optimizer).getStateTracker
     doReturn(regContext).when(optConfig).regularizationContext
     doReturn(regularizationWeight).when(optConfig).regularizationWeight
     doReturn(RegularizationType.L2).when(regContext).regularizationType
@@ -258,7 +258,7 @@ class SingleNodeOptimizationProblemIntegTest extends SparkTestUtils {
     val regContext = mock(classOf[RegularizationContext])
     val optConfig = mock(classOf[FixedEffectOptimizationConfiguration])
 
-    doReturn(Some(statesTracker)).when(optimizer).getStateTracker
+    doReturn(statesTracker).when(optimizer).getStateTracker
     doReturn(regContext).when(optConfig).regularizationContext
     doReturn(RegularizationType.NONE).when(regContext).regularizationType
 

--- a/photon-api/src/integTest/scala/com/linkedin/photon/ml/supervised/BaseGLMIntegTest.scala
+++ b/photon-api/src/integTest/scala/com/linkedin/photon/ml/supervised/BaseGLMIntegTest.scala
@@ -121,8 +121,7 @@ class BaseGLMIntegTest extends SparkTestUtils {
             None,
             LinearRegressionModel.apply,
             normalizationContext,
-            BaseGLMIntegTest.VARIANCE_COMPUTATION_TYPE,
-            BaseGLMIntegTest.TRACK_STATES),
+            BaseGLMIntegTest.VARIANCE_COMPUTATION_TYPE),
         linearRegressionData,
         new CompositeModelValidator[LinearRegressionModel](
           new PredictionFiniteValidator(),
@@ -137,8 +136,7 @@ class BaseGLMIntegTest extends SparkTestUtils {
             None,
             PoissonRegressionModel.apply,
             normalizationContext,
-            BaseGLMIntegTest.VARIANCE_COMPUTATION_TYPE,
-            BaseGLMIntegTest.TRACK_STATES),
+            BaseGLMIntegTest.VARIANCE_COMPUTATION_TYPE),
         poissonRegressionData,
         new CompositeModelValidator[PoissonRegressionModel](
           new PredictionFiniteValidator,
@@ -155,8 +153,7 @@ class BaseGLMIntegTest extends SparkTestUtils {
             None,
             LogisticRegressionModel.apply,
             normalizationContext,
-            BaseGLMIntegTest.VARIANCE_COMPUTATION_TYPE,
-            BaseGLMIntegTest.TRACK_STATES),
+            BaseGLMIntegTest.VARIANCE_COMPUTATION_TYPE),
         logisticRegressionData,
         new CompositeModelValidator[LogisticRegressionModel](
           new PredictionFiniteValidator(),
@@ -173,8 +170,7 @@ class BaseGLMIntegTest extends SparkTestUtils {
   @Test(dataProvider = "getGeneralizedLinearOptimizationProblems")
   def runGeneralizedLinearOptimizationProblemScenario(
       desc: String,
-      optimizationProblemBuilder: (BroadcastWrapper[NormalizationContext]) =>
-        DistributedOptimizationProblem[DistributedGLMLossFunction],
+      optimizationProblemBuilder: BroadcastWrapper[NormalizationContext] => DistributedOptimizationProblem[DistributedGLMLossFunction],
       data: Seq[LabeledPoint],
       validator: ModelValidator[GeneralizedLinearModel]): Unit = sparkTest(desc) {
 
@@ -191,8 +187,7 @@ class BaseGLMIntegTest extends SparkTestUtils {
       val statesTracker = optimizationProblem.getStatesTracker
 
       // Step 3: Check convergence
-      assertTrue(statesTracker.isDefined, "State tracking was enabled")
-      BaseGLMIntegTest.checkConvergence(statesTracker.get)
+      BaseGLMIntegTest.checkConvergence(statesTracker)
 
       result
     }
@@ -225,7 +220,6 @@ object BaseGLMIntegTest {
   // (this corresponds to 10 sigma, i.e. events that should occur at most once in the lifespan of our solar system)
   private val MAXIMUM_ERROR_MAGNITUDE: Double = 10 * SparkTestUtils.INLIER_STANDARD_DEVIATION
   private val VARIANCE_COMPUTATION_TYPE = VarianceComputationType.NONE
-  private val TRACK_STATES = true
 
   /**
    * Check that the loss value of the states in the [[OptimizationStatesTracker]] is monotonically decreasing.

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/algorithm/CoordinateFactory.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/algorithm/CoordinateFactory.scala
@@ -43,7 +43,6 @@ object CoordinateFactory {
    * @param lossFunctionConstructor A constructor for the loss function used for training
    * @param glmConstructor A constructor for the type of [[GeneralizedLinearModel]] being trained
    * @param downSamplerFactory A factory function for the [[DownSampler]] (if down-sampling is enabled)
-   * @param trackState Should the internal optimization states be recorded?
    * @param normalizationContext The [[NormalizationContext]]
    * @param varianceComputationType Should the trained coefficient variances be computed in addition to the means?
    * @return A [[Coordinate]] for the [[Dataset]] of type [[D]]
@@ -52,11 +51,10 @@ object CoordinateFactory {
       dataset: D,
       coordinateOptConfig: CoordinateOptimizationConfiguration,
       lossFunctionConstructor: ObjectiveFunctionFactory,
-      glmConstructor: (Coefficients) => GeneralizedLinearModel,
+      glmConstructor: Coefficients => GeneralizedLinearModel,
       downSamplerFactory: DownSamplerFactory,
       normalizationContext: NormalizationContext,
-      varianceComputationType: VarianceComputationType,
-      trackState: Boolean): Coordinate[D] = {
+      varianceComputationType: VarianceComputationType): Coordinate[D] = {
 
     val lossFunction: ObjectiveFunction = lossFunctionConstructor(coordinateOptConfig)
 
@@ -81,8 +79,7 @@ object CoordinateFactory {
             downSamplerOpt,
             glmConstructor,
             normalizationPhotonBroadcast,
-            varianceComputationType,
-            trackState)).asInstanceOf[Coordinate[D]]
+            varianceComputationType)).asInstanceOf[Coordinate[D]]
 
       case (
           rEDataset: RandomEffectDataset,
@@ -95,8 +92,7 @@ object CoordinateFactory {
           singleNodeLossFunction,
           glmConstructor,
           normalizationContext,
-          varianceComputationType,
-          trackState).asInstanceOf[Coordinate[D]]
+          varianceComputationType).asInstanceOf[Coordinate[D]]
 
       case _ =>
         throw new UnsupportedOperationException(

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/algorithm/FixedEffectCoordinate.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/algorithm/FixedEffectCoordinate.scala
@@ -48,16 +48,16 @@ protected[ml] class FixedEffectCoordinate[Objective <: DistributedObjectiveFunct
   /**
    * Compute an optimized model (i.e. run the coordinate optimizer) for the current dataset.
    *
-   * @return A tuple of the updated model and the optimization states tracker
+   * @return A (updated model, optimization state tracking information) tuple
    */
-  override protected[algorithm] def trainModel(): (DatumScoringModel, Option[OptimizationTracker]) = {
+  override protected[algorithm] def trainModel(): (DatumScoringModel, OptimizationTracker) = {
 
     val updatedFixedEffectModel = FixedEffectCoordinate.trainModel(
       dataset.labeledPoints,
       optimizationProblem,
       dataset.featureShardId,
       None)
-    val optimizationTracker = optimizationProblem.getStatesTracker.map(new FixedEffectOptimizationTracker(_))
+    val optimizationTracker = new FixedEffectOptimizationTracker(optimizationProblem.getStatesTracker)
 
     (updatedFixedEffectModel, optimizationTracker)
   }
@@ -69,8 +69,7 @@ protected[ml] class FixedEffectCoordinate[Objective <: DistributedObjectiveFunct
    * @param model The model to use as a starting point
    * @return A (updated model, optional optimization tracking information) tuple
    */
-  override protected[algorithm] def trainModel(
-      model: DatumScoringModel): (DatumScoringModel, Option[OptimizationTracker]) =
+  override protected[algorithm] def trainModel(model: DatumScoringModel): (DatumScoringModel, OptimizationTracker) =
     model match {
       case fixedEffectModel: FixedEffectModel =>
         val updatedFixedEffectModel = FixedEffectCoordinate.trainModel(
@@ -78,7 +77,7 @@ protected[ml] class FixedEffectCoordinate[Objective <: DistributedObjectiveFunct
           optimizationProblem,
           dataset.featureShardId,
           Some(fixedEffectModel))
-        val optimizationTracker = optimizationProblem.getStatesTracker.map(new FixedEffectOptimizationTracker(_))
+        val optimizationTracker = new FixedEffectOptimizationTracker(optimizationProblem.getStatesTracker)
 
         (updatedFixedEffectModel, optimizationTracker)
 

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/algorithm/RandomEffectCoordinate.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/algorithm/RandomEffectCoordinate.scala
@@ -66,11 +66,11 @@ protected[ml] class RandomEffectCoordinate[Objective <: SingleNodeObjectiveFunct
    *
    * @return A (updated model, optional optimization tracking information) tuple
    */
-  override protected[algorithm] def trainModel(): (DatumScoringModel, Option[OptimizationTracker]) = {
+  override protected[algorithm] def trainModel(): (DatumScoringModel, OptimizationTracker) = {
 
-    val (newModel, optimizationTrackerOpt) = RandomEffectCoordinate.trainModel(dataset, optimizationProblem, None)
+    val (newModel, optimizationTracker) = RandomEffectCoordinate.trainModel(dataset, optimizationProblem, None)
 
-    (projectModelBackward(newModel), optimizationTrackerOpt)
+    (projectModelBackward(newModel), optimizationTracker)
   }
 
   /**
@@ -81,16 +81,16 @@ protected[ml] class RandomEffectCoordinate[Objective <: SingleNodeObjectiveFunct
    * @return A (updated model, optional optimization tracking information) tuple
    */
   override protected[algorithm] def trainModel(
-      model: DatumScoringModel): (DatumScoringModel, Option[OptimizationTracker]) =
+      model: DatumScoringModel): (DatumScoringModel, OptimizationTracker) =
 
     model match {
       case randomEffectModel: RandomEffectModel =>
-        val (newModel, optimizationTrackerOpt) = RandomEffectCoordinate.trainModel(
+        val (newModel, optimizationTracker) = RandomEffectCoordinate.trainModel(
           dataset,
           optimizationProblem,
           Some(projectModelForward(randomEffectModel)))
 
-        (projectModelBackward(newModel), optimizationTrackerOpt)
+        (projectModelBackward(newModel), optimizationTracker)
 
       case _ =>
         throw new UnsupportedOperationException(
@@ -190,8 +190,7 @@ object RandomEffectCoordinate {
    * @param glmConstructor The function to use for producing GLMs from trained coefficients
    * @param normalizationContext The normalization context
    * @param varianceComputationType If and how coefficient variances should be computed
-   * @param isTrackingState Should the optimization problem record the internal optimizer states?
-   * @return
+   * @return A new [[RandomEffectCoordinate]] object
    */
   protected[ml] def apply[RandomEffectObjective <: SingleNodeObjectiveFunction](
       randomEffectDataset: RandomEffectDataset,
@@ -199,8 +198,7 @@ object RandomEffectCoordinate {
       objectiveFunction: RandomEffectObjective,
       glmConstructor: Coefficients => GeneralizedLinearModel,
       normalizationContext: NormalizationContext,
-      varianceComputationType: VarianceComputationType = VarianceComputationType.NONE,
-      isTrackingState: Boolean = false): RandomEffectCoordinate[RandomEffectObjective] = {
+      varianceComputationType: VarianceComputationType = VarianceComputationType.NONE): RandomEffectCoordinate[RandomEffectObjective] = {
 
     // Generate parameters of ProjectedRandomEffectCoordinate
     val randomEffectOptimizationProblem = buildRandomEffectOptimizationProblem(
@@ -209,8 +207,7 @@ object RandomEffectCoordinate {
       objectiveFunction,
       glmConstructor,
       normalizationContext,
-      varianceComputationType,
-      isTrackingState)
+      varianceComputationType)
 
     new RandomEffectCoordinate(randomEffectDataset, randomEffectOptimizationProblem)
   }
@@ -227,7 +224,6 @@ object RandomEffectCoordinate {
    * @param glmConstructor The function to use for producing GLMs from trained coefficients
    * @param normalizationContext The normalization context
    * @param varianceComputationType If and how coefficient variances should be computed
-   * @param isTrackingState Should the optimization problem record the internal optimizer states?
    * @return
    */
   private def buildRandomEffectOptimizationProblem[RandomEffectObjective <: SingleNodeObjectiveFunction](
@@ -236,8 +232,7 @@ object RandomEffectCoordinate {
       objectiveFunction: RandomEffectObjective,
       glmConstructor: Coefficients => GeneralizedLinearModel,
       normalizationContext: NormalizationContext,
-      varianceComputationType: VarianceComputationType = VarianceComputationType.NONE,
-      isTrackingState: Boolean = false): RandomEffectOptimizationProblem[RandomEffectObjective] = {
+      varianceComputationType: VarianceComputationType = VarianceComputationType.NONE): RandomEffectOptimizationProblem[RandomEffectObjective] = {
 
     // Generate new NormalizationContext and SingleNodeOptimizationProblem objects
     val optimizationProblems = linearSubspaceProjectorsRDD
@@ -259,11 +254,10 @@ object RandomEffectCoordinate {
           objectiveFunction,
           glmConstructor,
           PhotonNonBroadcast(projectedNormalizationContext),
-          varianceComputationType,
-          isTrackingState)
+          varianceComputationType)
       }
 
-    new RandomEffectOptimizationProblem(optimizationProblems, glmConstructor, isTrackingState)
+    new RandomEffectOptimizationProblem(optimizationProblems, glmConstructor)
   }
 
   /**
@@ -279,8 +273,7 @@ object RandomEffectCoordinate {
   protected[algorithm] def trainModel[Function <: SingleNodeObjectiveFunction](
       randomEffectDataset: RandomEffectDataset,
       randomEffectOptimizationProblem: RandomEffectOptimizationProblem[Function],
-      initialRandomEffectModelOpt: Option[RandomEffectModel])
-    : (RandomEffectModel, Option[RandomEffectOptimizationTracker]) = {
+      initialRandomEffectModelOpt: Option[RandomEffectModel]): (RandomEffectModel, RandomEffectOptimizationTracker) = {
 
     // All 3 RDDs involved in these joins use the same partitioner
     val dataAndOptimizationProblems = randomEffectDataset
@@ -288,9 +281,9 @@ object RandomEffectCoordinate {
       .join(randomEffectOptimizationProblem.optimizationProblems)
 
     // Left join the models to data and optimization problems for cases where we have a prior model but no new data
-    val newModelsAndTrackers = initialRandomEffectModelOpt
+    val (newModels, randomEffectOptimizationTracker) = initialRandomEffectModelOpt
       .map { randomEffectModel =>
-        randomEffectModel
+        val modelsAndTrackers = randomEffectModel
           .modelsRDD
           .leftOuterJoin(dataAndOptimizationProblems)
           .mapValues {
@@ -299,40 +292,40 @@ object RandomEffectCoordinate {
               val updatedModel = optimizationProblem.run(trainingLabeledPoints, localModel)
               val stateTrackers = optimizationProblem.getStatesTracker
 
-              (updatedModel, stateTrackers)
+              (updatedModel, Some(stateTrackers))
 
             case (localModel, _) =>
               (localModel, None)
           }
+        modelsAndTrackers.persist(StorageLevel.MEMORY_ONLY_SER)
+
+        val models = modelsAndTrackers.mapValues(_._1)
+        val optimizationTracker = RandomEffectOptimizationTracker(modelsAndTrackers.flatMap(_._2._2))
+
+        (models, optimizationTracker)
       }
       .getOrElse {
-        dataAndOptimizationProblems.mapValues { case (localDataset, optimizationProblem) =>
+        val modelsAndTrackers = dataAndOptimizationProblems.mapValues { case (localDataset, optimizationProblem) =>
           val trainingLabeledPoints = localDataset.dataPoints.map(_._2)
           val newModel = optimizationProblem.run(trainingLabeledPoints)
           val stateTrackers = optimizationProblem.getStatesTracker
 
           (newModel, stateTrackers)
         }
+        modelsAndTrackers.persist(StorageLevel.MEMORY_ONLY_SER)
+
+        val models = modelsAndTrackers.mapValues(_._1)
+        val optimizationTracker = RandomEffectOptimizationTracker(modelsAndTrackers.map(_._2._2))
+
+        (models, optimizationTracker)
       }
-      .setName(s"Updated models and state trackers for random effect ${randomEffectDataset.randomEffectType}")
-      .persist(StorageLevel.MEMORY_ONLY)
 
     val newRandomEffectModel = new RandomEffectModel(
-      newModelsAndTrackers.mapValues(_._1),
+      newModels,
       randomEffectDataset.randomEffectType,
       randomEffectDataset.featureShardId)
 
-    val optimizationTracker: Option[RandomEffectOptimizationTracker] =
-      if (randomEffectOptimizationProblem.isTrackingState) {
-        val stateTrackers = newModelsAndTrackers.flatMap(_._2._2)
-
-        Some(RandomEffectOptimizationTracker(stateTrackers))
-
-      } else {
-        None
-      }
-
-    (newRandomEffectModel, optimizationTracker)
+    (newRandomEffectModel, randomEffectOptimizationTracker)
   }
 
   /**

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/estimators/GameEstimator.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/estimators/GameEstimator.scala
@@ -661,8 +661,7 @@ class GameEstimator(val sc: SparkContext, implicit val logger: Logger) extends P
               glmConstructor,
               downSamplerFactory,
               normalizationContexts.getOrElse(coordinateId, NoNormalization()),
-              variance,
-              TRACK_STATE)
+              variance)
           }
 
           (coordinateId, coordinate)
@@ -702,5 +701,4 @@ object GameEstimator {
   private val GAME_ESTIMATOR_PREFIX = "GameEstimator"
 
   val DEFAULT_TREE_AGGREGATE_DEPTH = 1
-  val TRACK_STATE = true
 }

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/optimization/DistributedOptimizationProblem.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/optimization/DistributedOptimizationProblem.scala
@@ -180,9 +180,8 @@ object DistributedOptimizationProblem {
    * @param samplerOption (Optional) A sampler to use for down-sampling the training data prior to optimization
    * @param glmConstructor The function to use for producing GLMs from trained coefficients
    * @param normalizationContext The normalization context
-   * @param isTrackingState Should the optimization problem record the internal optimizer states?
    * @param varianceComputation If and how coefficient variances should be computed
-   * @return A new DistributedOptimizationProblem
+   * @return A new [[DistributedOptimizationProblem]]
    */
   def apply[Function <: DistributedObjectiveFunction](
       configuration: GLMOptimizationConfiguration,
@@ -190,8 +189,7 @@ object DistributedOptimizationProblem {
       samplerOption: Option[DownSampler],
       glmConstructor: Coefficients => GeneralizedLinearModel,
       normalizationContext: BroadcastWrapper[NormalizationContext],
-      varianceComputation: VarianceComputationType,
-      isTrackingState: Boolean): DistributedOptimizationProblem[Function] = {
+      varianceComputation: VarianceComputationType): DistributedOptimizationProblem[Function] = {
 
     val optimizerConfig = configuration.optimizerConfig
     val regularizationContext = configuration.regularizationContext
@@ -199,7 +197,7 @@ object DistributedOptimizationProblem {
     // Will result in a runtime error if created Optimizer cannot be cast to an Optimizer that can handle the given
     // objective function.
     val optimizer = OptimizerFactory
-      .build(optimizerConfig, normalizationContext, regularizationContext, regularizationWeight, isTrackingState)
+      .build(optimizerConfig, normalizationContext, regularizationContext, regularizationWeight)
       .asInstanceOf[Optimizer[Function]]
 
     new DistributedOptimizationProblem(

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/optimization/GeneralizedLinearOptimizationProblem.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/optimization/GeneralizedLinearOptimizationProblem.scala
@@ -46,7 +46,7 @@ protected[ml] abstract class GeneralizedLinearOptimizationProblem[Objective <: O
    *
    * @return Some(OptimizationStatesTracker) if optimization states were tracked, otherwise None
    */
-  def getStatesTracker: Option[OptimizationStatesTracker] = optimizer.getStateTracker
+  def getStatesTracker: OptimizationStatesTracker = optimizer.getStateTracker
 
   /**
    * Create a default generalized linear model with 0-valued coefficients

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/optimization/OptimizerFactory.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/optimization/OptimizerFactory.scala
@@ -31,15 +31,13 @@ protected[ml] object OptimizerFactory {
    * @param normalizationContext The normalization context
    * @param regularizationContext The regularization context
    * @param regularizationWeight The regularization weight
-   * @param isTrackingState Should the Optimizer track intermediate states during optimization?
-   * @return A new Optimizer
+   * @return A new [[Optimizer]]
    */
   def build(
       config: OptimizerConfig,
       normalizationContext: BroadcastWrapper[NormalizationContext],
       regularizationContext: RegularizationContext,
-      regularizationWeight: Double = 0,
-      isTrackingState: Boolean = Optimizer.DEFAULT_TRACKING_STATE): Optimizer[TwiceDiffFunction] =
+      regularizationWeight: Double = 0): Optimizer[TwiceDiffFunction] =
 
     (config.optimizerType, regularizationContext.regularizationType) match {
       case (OptimizerType.LBFGS, RegularizationType.L1 | RegularizationType.ELASTIC_NET) =>
@@ -48,24 +46,21 @@ protected[ml] object OptimizerFactory {
           normalizationContext = normalizationContext,
           tolerance = config.tolerance,
           maxNumIterations = config.maximumIterations,
-          constraintMap = config.constraintMap,
-          isTrackingState = isTrackingState)
+          constraintMap = config.constraintMap)
 
       case (OptimizerType.LBFGS, RegularizationType.L2 | RegularizationType.NONE) =>
         new LBFGS(
           normalizationContext = normalizationContext,
           tolerance = config.tolerance,
           maxNumIterations = config.maximumIterations,
-          constraintMap = config.constraintMap,
-          isTrackingState = isTrackingState)
+          constraintMap = config.constraintMap)
 
       case (OptimizerType.TRON, RegularizationType.L2 | RegularizationType.NONE) =>
         new TRON(
           normalizationContext = normalizationContext,
           tolerance = config.tolerance,
           maxNumIterations = config.maximumIterations,
-          constraintMap = config.constraintMap,
-          isTrackingState = isTrackingState)
+          constraintMap = config.constraintMap)
 
       case (OptimizerType.TRON, RegularizationType.L1 | RegularizationType.ELASTIC_NET) =>
         throw new IllegalArgumentException("TRON optimizer incompatible with L1 regularization")

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/optimization/SingleNodeOptimizationProblem.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/optimization/SingleNodeOptimizationProblem.scala
@@ -109,16 +109,14 @@ object SingleNodeOptimizationProblem {
    * @param glmConstructor The function to use for producing GLMs from trained coefficients
    * @param normalizationContext The normalization context
    * @param varianceComputationType Whether to compute coefficient variances, and if so how
-   * @param isTrackingState Should the optimization problem record the internal optimizer states?
-   * @return A new SingleNodeOptimizationProblem
+   * @return A new [[SingleNodeOptimizationProblem]]
    */
   def apply[Function <: SingleNodeObjectiveFunction](
       configuration: GLMOptimizationConfiguration,
       objectiveFunction: Function,
       glmConstructor: Coefficients => GeneralizedLinearModel,
       normalizationContext: BroadcastWrapper[NormalizationContext],
-      varianceComputationType: VarianceComputationType,
-      isTrackingState: Boolean): SingleNodeOptimizationProblem[Function] = {
+      varianceComputationType: VarianceComputationType): SingleNodeOptimizationProblem[Function] = {
 
     val optimizerConfig = configuration.optimizerConfig
     val regularizationContext = configuration.regularizationContext
@@ -126,7 +124,7 @@ object SingleNodeOptimizationProblem {
     // Will result in a runtime error if created Optimizer cannot be cast to an Optimizer that can handle the given
     // objective function.
     val optimizer = OptimizerFactory
-      .build(optimizerConfig, normalizationContext, regularizationContext, regularizationWeight, isTrackingState)
+      .build(optimizerConfig, normalizationContext, regularizationContext, regularizationWeight)
       .asInstanceOf[Optimizer[Function]]
 
     new SingleNodeOptimizationProblem(

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/optimization/game/RandomEffectOptimizationProblem.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/optimization/game/RandomEffectOptimizationProblem.scala
@@ -35,14 +35,13 @@ import com.linkedin.photon.ml.supervised.model.GeneralizedLinearModel
  * @tparam Objective The objective function to optimize
  * @param optimizationProblems The component optimization problems (one per individual) for a random effect
  *                             optimization problem
+ * @param glmConstructor The function to use for producing [[GeneralizedLinearModel]] objects from trained
+ *                       [[Coefficients]]
  */
 protected[ml] class RandomEffectOptimizationProblem[Objective <: SingleNodeObjectiveFunction](
     val optimizationProblems: RDD[(REId, SingleNodeOptimizationProblem[Objective])],
-    glmConstructor: Coefficients => GeneralizedLinearModel,
-    val isTrackingState: Boolean)
+    glmConstructor: Coefficients => GeneralizedLinearModel)
   extends RDDLike {
-
-  // TODO: Need to refactor 'isTrackingState' out
 
   /**
    * Get the Spark context.

--- a/photon-api/src/test/scala/com/linkedin/photon/ml/algorithm/FixedEffectCoordinateTest.scala
+++ b/photon-api/src/test/scala/com/linkedin/photon/ml/algorithm/FixedEffectCoordinateTest.scala
@@ -90,7 +90,7 @@ class FixedEffectCoordinateTest {
     doReturn(featureShardId).when(dataset).featureShardId
 
     // Optimization problem
-    doReturn(Some(statesTracker)).when(optimizationProblem).getStatesTracker
+    doReturn(statesTracker).when(optimizationProblem).getStatesTracker
 
     // New model
     doReturn(TaskType.LOGISTIC_REGRESSION).when(updatedModel).modelType

--- a/photon-api/src/test/scala/com/linkedin/photon/ml/optimization/DistributedOptimizationProblemTest.scala
+++ b/photon-api/src/test/scala/com/linkedin/photon/ml/optimization/DistributedOptimizationProblemTest.scala
@@ -57,8 +57,8 @@ class DistributedOptimizationProblemTest {
     val hessianDiagonal = DenseVector(Array(1D, 0D, 2D))
     val hessianMatrix = DenseMatrix.eye[Double](DIMENSIONS)
 
-    doReturn(Some(mockStatesTracker)).when(mockOptimizerDiff).getStateTracker
-    doReturn(Some(mockStatesTracker)).when(mockOptimizerTwiceDiff).getStateTracker
+    doReturn(mockStatesTracker).when(mockOptimizerDiff).getStateTracker
+    doReturn(mockStatesTracker).when(mockOptimizerTwiceDiff).getStateTracker
     doReturn(hessianDiagonal)
       .when(mockTwiceDiffFunction)
       .hessianDiagonal(Matchers.any(), Matchers.any())
@@ -140,8 +140,7 @@ class DistributedOptimizationProblemTest {
     doReturn(broadcastNormalization).when(optimizer).getNormalizationContext
     doReturn(normalization).when(broadcastNormalization).value
     doReturn((means, None)).when(optimizer).optimize(objectiveFunction, means)(trainingData)
-    doReturn(true).when(optimizer).isTrackingState
-    doReturn(Some(statesTracker)).when(optimizer).getStateTracker
+    doReturn(statesTracker).when(optimizer).getStateTracker
     doReturn(Array(state)).when(statesTracker).getTrackedStates
     doReturn(means).when(state).coefficients
     doReturn(coefficients).when(initialModel).coefficients

--- a/photon-api/src/test/scala/com/linkedin/photon/ml/optimization/GeneralizedLinearOptimizationProblemTest.scala
+++ b/photon-api/src/test/scala/com/linkedin/photon/ml/optimization/GeneralizedLinearOptimizationProblemTest.scala
@@ -45,7 +45,7 @@ class GeneralizedLinearOptimizationProblemTest {
     val objective = mock(classOf[SingleNodeSmoothedHingeLossFunction])
     val regularization = NoRegularizationContext
 
-    doReturn(Some(statesTracker)).when(optimizer).getStateTracker
+    doReturn(statesTracker).when(optimizer).getStateTracker
 
     val logisticProblem = new MockOptimizationProblem(
       optimizer,
@@ -93,7 +93,7 @@ class GeneralizedLinearOptimizationProblemTest {
     val objective = mock(classOf[SingleNodeSmoothedHingeLossFunction])
     val regularization = NoRegularizationContext
 
-    doReturn(Some(statesTracker)).when(optimizer).getStateTracker
+    doReturn(statesTracker).when(optimizer).getStateTracker
 
     val logisticProblem = new MockOptimizationProblem(
       optimizer,
@@ -153,8 +153,8 @@ class GeneralizedLinearOptimizationProblemTest {
     val statesTracker = mock(classOf[OptimizationStatesTracker])
     val initialModel = mock(classOf[GeneralizedLinearModel])
 
-    doReturn(Some(statesTracker)).when(optimizerNoReg).getStateTracker
-    doReturn(Some(statesTracker)).when(optimizerL1Reg).getStateTracker
+    doReturn(statesTracker).when(optimizerNoReg).getStateTracker
+    doReturn(statesTracker).when(optimizerL1Reg).getStateTracker
 
     val problemNone = new MockOptimizationProblem(
       optimizerNoReg,

--- a/photon-api/src/test/scala/com/linkedin/photon/ml/optimization/SingleNodeOptimizationProblemTest.scala
+++ b/photon-api/src/test/scala/com/linkedin/photon/ml/optimization/SingleNodeOptimizationProblemTest.scala
@@ -15,9 +15,6 @@
 package com.linkedin.photon.ml.optimization
 
 import breeze.linalg.{DenseMatrix, DenseVector, Vector}
-import org.apache.spark.SparkContext
-import org.apache.spark.broadcast.Broadcast
-import org.apache.spark.rdd.RDD
 import org.mockito.Matchers
 import org.mockito.Mockito._
 import org.testng.Assert._
@@ -57,8 +54,8 @@ class SingleNodeOptimizationProblemTest {
     val hessianDiagonal = DenseVector(Array(1D, 0D, 2D))
     val hessianMatrix = DenseMatrix.eye[Double](DIMENSIONS)
 
-    doReturn(Some(mockStatesTracker)).when(mockOptimizerDiff).getStateTracker
-    doReturn(Some(mockStatesTracker)).when(mockOptimizerTwiceDiff).getStateTracker
+    doReturn(mockStatesTracker).when(mockOptimizerDiff).getStateTracker
+    doReturn(mockStatesTracker).when(mockOptimizerTwiceDiff).getStateTracker
     doReturn(hessianDiagonal)
       .when(mockTwiceDiffFunction)
       .hessianDiagonal(Matchers.any(), Matchers.any())
@@ -127,8 +124,7 @@ class SingleNodeOptimizationProblemTest {
     doReturn(broadcastNormalization).when(optimizer).getNormalizationContext
     doReturn(normalization).when(broadcastNormalization).value
     doReturn((means, None)).when(optimizer).optimize(objectiveFunction, means)(trainingData)
-    doReturn(true).when(optimizer).isTrackingState
-    doReturn(Some(statesTracker)).when(optimizer).getStateTracker
+    doReturn(statesTracker).when(optimizer).getStateTracker
     doReturn(Array(state)).when(statesTracker).getTrackedStates
     doReturn(means).when(state).coefficients
     doReturn(coefficients).when(initialModel).coefficients

--- a/photon-api/src/test/scala/com/linkedin/photon/ml/util/GameTestUtils.scala
+++ b/photon-api/src/test/scala/com/linkedin/photon/ml/util/GameTestUtils.scala
@@ -20,6 +20,7 @@ import org.apache.spark.{HashPartitioner, SparkConf}
 import breeze.linalg.DenseVector
 import org.testng.annotations.DataProvider
 
+import com.linkedin.photon.ml.TaskType.TaskType
 import com.linkedin.photon.ml.{SparkSessionConfiguration, TaskType}
 import com.linkedin.photon.ml.Types.{FeatureShardId, REId, REType, UniqueSampleId}
 import com.linkedin.photon.ml.algorithm.{FixedEffectCoordinate, RandomEffectCoordinate}
@@ -43,7 +44,7 @@ trait GameTestUtils extends SparkTestUtils {
   /**
    *
    */
-  val defaultTaskType = TaskType.LOGISTIC_REGRESSION
+  val defaultTaskType: TaskType = TaskType.LOGISTIC_REGRESSION
 
   /**
    * Default random seed
@@ -153,8 +154,7 @@ trait GameTestUtils extends SparkTestUtils {
       None,
       LogisticRegressionModel.apply,
       PhotonBroadcast(sc.broadcast(NoNormalization())),
-      VarianceComputationType.NONE,
-      isTrackingState = false)
+      VarianceComputationType.NONE)
   }
 
   /**
@@ -268,7 +268,6 @@ trait GameTestUtils extends SparkTestUtils {
   def generateRandomEffectOptimizationProblem(
       dataset: RandomEffectDataset): RandomEffectOptimizationProblem[SingleNodeGLMLossFunction] = {
 
-    val isTrackingState = false
     val configuration = RandomEffectOptimizationConfiguration(generateOptimizerConfig())
     val normalizationBroadcast = sc.broadcast(NoNormalization())
     val randomEffectOptimizationProblems = dataset
@@ -279,11 +278,10 @@ trait GameTestUtils extends SparkTestUtils {
           SingleNodeGLMLossFunction(configuration, LogisticLossFunction),
           LogisticRegressionModel.apply,
           PhotonBroadcast(normalizationBroadcast),
-          VarianceComputationType.NONE,
-          isTrackingState)
+          VarianceComputationType.NONE)
       }
 
-    new RandomEffectOptimizationProblem(randomEffectOptimizationProblems, LogisticRegressionModel.apply, isTrackingState)
+    new RandomEffectOptimizationProblem(randomEffectOptimizationProblems, LogisticRegressionModel.apply)
   }
 
   /**

--- a/photon-client/src/main/scala/com/linkedin/photon/ml/Driver.scala
+++ b/photon-client/src/main/scala/com/linkedin/photon/ml/Driver.scala
@@ -84,7 +84,7 @@ protected[ml] class Driver(
   private[this] var summaryOption: Option[FeatureDataStatistics] = None
   private[this] var normalizationContext: NormalizationContext = NoNormalization()
 
-  private[this] var lambdaModelAndTrackers: List[(Double, _ <: GeneralizedLinearModel, Option[OptimizationStatesTracker])] =
+  private[this] var lambdaModelAndTrackers: List[(Double, GeneralizedLinearModel, OptimizationStatesTracker)] =
     List.empty
 
   protected var perModelMetrics: Map[Double, Evaluation.MetricsMap] = Map()
@@ -169,8 +169,14 @@ protected[ml] class Driver(
         updateStage(DriverStage.VALIDATED)
 
       case _ =>
-        lambdaModelAndTrackers.foreach { case (regWeight, _, trackerOpt) =>
-            sendEvent(PhotonOptimizationLogEvent(regWeight, trackerOpt))
+        lambdaModelAndTrackers.foreach { case (regWeight, _, tracker) =>
+          val trackerOpt = if (params.enableOptimizationStateTracker) {
+            Some(tracker)
+          } else {
+            None
+          }
+
+          sendEvent(PhotonOptimizationLogEvent(regWeight, trackerOpt))
         }
     }
 
@@ -186,7 +192,11 @@ protected[ml] class Driver(
 
     Utils.createHDFSDir(params.outputDir, sc.hadoopConfiguration)
     val finalModelsDir = new Path(params.outputDir, LEARNED_MODELS_TEXT)
-    IOUtils.writeModelsInText(sc, lambdaModelAndTrackers, finalModelsDir.toString, inputDataFormat.indexMapLoader())
+
+    val lambdaAndModels = lambdaModelAndTrackers.map { case (lambda, model, _) =>
+      (lambda, model)
+    }
+    IOUtils.writeModelsInText(sc, lambdaAndModels, finalModelsDir.toString, inputDataFormat.indexMapLoader())
 
     logger.info(s"Final models are written to: $finalModelsDir")
 
@@ -322,7 +332,6 @@ protected[ml] class Driver(
       normalizationContext = normalizationContext,
       maxNumIter = params.maxNumIter,
       tolerance = params.tolerance,
-      enableOptimizationStateTracker = params.enableOptimizationStateTracker,
       constraintMap = inputDataFormat.constraintFeatureMap(),
       treeAggregateDepth = params.treeAggregateDepth,
       useWarmStart = params.useWarmStart)
@@ -333,8 +342,8 @@ protected[ml] class Driver(
     if (params.enableOptimizationStateTracker) {
       logger.info(s"optimization state tracker information:")
 
-      lambdaModelAndTrackers.foreach { abc =>
-        logger.info(s"model with regularization weight ${abc._1}: ${abc._3.get.toSummaryString}")
+      lambdaModelAndTrackers.foreach { case (lambda, _, tracker) =>
+        logger.info(s"model with regularization weight $lambda: ${tracker.toSummaryString}")
       }
     }
   }
@@ -344,58 +353,60 @@ protected[ml] class Driver(
    */
   protected def computeAndLogModelMetrics(): Unit =
     if (params.validatePerIteration) {
-      lambdaModelAndTrackers.foreach { case (regularizationWeight: Double, glm: GeneralizedLinearModel, optimizationStatesTrackerOpt: Option[OptimizationStatesTracker]) =>
-        require(
-          optimizationStatesTrackerOpt.isDefined,
-          s"Missing optimization state information for model with regularization weight $regularizationWeight")
+      lambdaModelAndTrackers.foreach {
+        case (regularizationWeight: Double, glm: GeneralizedLinearModel, optimizationStatesTracker: OptimizationStatesTracker) =>
 
-        logger.info(s"Model with lambda = $regularizationWeight:")
+          logger.info(s"Model with lambda = $regularizationWeight:")
 
-        val tracker = optimizationStatesTrackerOpt.get
-        val perIterationMetrics = tracker
-          .getTrackedStates
-          .map { optimizerState =>
-            val model = glm.updateCoefficients(Coefficients(optimizerState.coefficients, None))
-            val metrics = Evaluation.evaluate(model, validationData)
+          val perIterationMetrics = optimizationStatesTracker
+            .getTrackedStates
+            .map { optimizerState =>
+              val model = glm.updateCoefficients(Coefficients(optimizerState.coefficients, None))
+              val metrics = Evaluation.evaluate(model, validationData)
 
-            metrics
-              .keys
-              .toSeq
-              .sorted
-              .foreach { metric =>
-                logger.info(f"Iteration: [${optimizerState.iter}%6d] Metric: [$metric] value: ${metrics(metric)}")
-              }
+              metrics
+                .keys
+                .toSeq
+                .sorted
+                .foreach { metric =>
+                  logger.info(f"Iteration: [${optimizerState.iter}%6d] Metric: [$metric] value: ${metrics(metric)}")
+                }
 
-            (model, metrics)
-          }
+              (model, metrics)
+            }
 
-          val finalMetrics = perIterationMetrics.last._2
+            val finalMetrics = perIterationMetrics.last._2
 
-          perModelMetrics += (regularizationWeight -> finalMetrics)
-          sendEvent(
-            PhotonOptimizationLogEvent(
-              regularizationWeight,
-              optimizationStatesTrackerOpt,
-              Some(perIterationMetrics),
-              Some(finalMetrics)))
+            perModelMetrics += (regularizationWeight -> finalMetrics)
+            sendEvent(
+              PhotonOptimizationLogEvent(
+                regularizationWeight,
+                Some(optimizationStatesTracker),
+                Some(perIterationMetrics),
+                Some(finalMetrics)))
       }
     } else {
-      lambdaModelAndTrackers.foreach { case (regularizationWeight: Double, glm: GeneralizedLinearModel, optimizationStatesTrackerOpt: Option[OptimizationStatesTracker]) =>
-        logger.info(s"Model with lambda = $regularizationWeight:")
+      lambdaModelAndTrackers.foreach { case (lambda, model, tracker) =>
 
-        val finalMetrics = Evaluation.evaluate(glm, validationData)
+          logger.info(s"Model with lambda = $lambda:")
 
-        finalMetrics
-          .keys
-          .toSeq
-          .sorted
-          .foreach { metric =>
-            logger.info(f"Metric: [$metric] value: ${finalMetrics(metric)}")
+          val trackerOpt = if(params.enableOptimizationStateTracker) {
+            Some(tracker)
+          } else {
+            None
           }
+          val finalMetrics = Evaluation.evaluate(model, validationData)
 
-        perModelMetrics += (regularizationWeight -> finalMetrics)
-        sendEvent(
-          PhotonOptimizationLogEvent(regularizationWeight, optimizationStatesTrackerOpt, None, Some(finalMetrics)))
+          finalMetrics
+            .keys
+            .toSeq
+            .sorted
+            .foreach { metric =>
+              logger.info(f"Metric: [$metric] value: ${finalMetrics(metric)}")
+            }
+
+          perModelMetrics += (lambda -> finalMetrics)
+          sendEvent(PhotonOptimizationLogEvent(lambda, trackerOpt, None, Some(finalMetrics)))
       }
     }
 
@@ -425,7 +436,7 @@ protected[ml] class Driver(
 
     IOUtils.writeModelsInText(
       sc,
-      List((bestModelWeight, bestModel, None)),
+      List((bestModelWeight, bestModel)),
       bestModelDir.toString,
       inputDataFormat.indexMapLoader()
     )
@@ -457,7 +468,7 @@ protected[ml] class Driver(
    */
   protected def trainFunc(
       x: RDD[LabeledPoint],
-      y: Map[Double, GeneralizedLinearModel]): List[(Double, _ <: GeneralizedLinearModel, Option[OptimizationStatesTracker])] =
+      y: Map[Double, GeneralizedLinearModel]): List[(Double, _ <: GeneralizedLinearModel, OptimizationStatesTracker)] =
     ModelTraining.trainGeneralizedLinearModel(
       trainingData = x,
       taskType = params.taskType,
@@ -467,7 +478,6 @@ protected[ml] class Driver(
       normalizationContext = normalizationContext,
       maxNumIter = params.maxNumIter,
       tolerance = params.tolerance,
-      enableOptimizationStateTracker = params.enableOptimizationStateTracker,
       constraintMap = inputDataFormat.constraintFeatureMap(),
       warmStartModels = y,
       treeAggregateDepth = params.treeAggregateDepth,

--- a/photon-client/src/main/scala/com/linkedin/photon/ml/Params.scala
+++ b/photon-client/src/main/scala/com/linkedin/photon/ml/Params.scala
@@ -99,6 +99,7 @@ class Params extends PalDBIndexMapParams {
   /**
    * Whether to enable the optimization tracker, which stores the per-iteration log information of the running optimizer
    */
+  @Deprecated
   var enableOptimizationStateTracker: Boolean = true
 
   /**

--- a/photon-client/src/main/scala/com/linkedin/photon/ml/index/FeatureIndexingDriver.scala
+++ b/photon-client/src/main/scala/com/linkedin/photon/ml/index/FeatureIndexingDriver.scala
@@ -268,8 +268,7 @@ object FeatureIndexingDriver extends PhotonParams with Logging {
       // NOTE PalDB writer within the same JVM might stomp on each other and generate corrupted data, it's safer to
       // lock the write. This will only block writing operations within the same JVM
       PalDBIndexMapBuilder.WRITER_LOCK.synchronized {
-        val mapBuilder =
-          new PalDBIndexMapBuilder().init(outputDir, idx, featureShardId)
+        val mapBuilder = new PalDBIndexMapBuilder().init(outputDir, idx, featureShardId)
 
         while (iter.hasNext) {
           val tuple = iter.next()
@@ -282,6 +281,7 @@ object FeatureIndexingDriver extends PhotonParams with Logging {
 
         mapBuilder.close()
       }
+
       Array[Int](i).toIterator
     }
 

--- a/photon-client/src/main/scala/com/linkedin/photon/ml/util/IOUtils.scala
+++ b/photon-client/src/main/scala/com/linkedin/photon/ml/util/IOUtils.scala
@@ -27,7 +27,6 @@ import org.joda.time.{DateTimeZone, Days}
 import com.linkedin.photon.ml.Constants
 import com.linkedin.photon.ml.estimators.GameEstimator
 import com.linkedin.photon.ml.index.IndexMapLoader
-import com.linkedin.photon.ml.optimization.OptimizationStatesTracker
 import com.linkedin.photon.ml.optimization.game.{FixedEffectOptimizationConfiguration, RandomEffectOptimizationConfiguration}
 import com.linkedin.photon.ml.supervised.model.GeneralizedLinearModel
 
@@ -241,11 +240,11 @@ object IOUtils {
    */
   def writeModelsInText(
       sc: SparkContext,
-      models: Iterable[(Double, GeneralizedLinearModel, Option[OptimizationStatesTracker])],
+      models: Iterable[(Double, GeneralizedLinearModel)],
       modelDir: String,
       indexMapLoader: IndexMapLoader): Unit = {
 
-    models.foreach{ case (lambda, m, _) => println(lambda + ": " + m.toString)}
+    models.foreach{ case (lambda, m) => println(lambda + ": " + m.toString)}
 
     sc.parallelize(models.toSeq, models.size)
       .mapPartitions({ iter =>

--- a/photon-lib/src/integTest/scala/com/linkedin/photon/ml/algorithm/CoordinateDescentIntegTest.scala
+++ b/photon-lib/src/integTest/scala/com/linkedin/photon/ml/algorithm/CoordinateDescentIntegTest.scala
@@ -88,8 +88,8 @@ class CoordinateDescentIntegTest extends SparkTestUtils {
 
       // Coordinate mock setup
       doReturn(score).when(coordinate).score(model)
-      doReturn((model, Some(tracker))).when(coordinate).trainModel(model)
-      doReturn((model, Some(tracker))).when(coordinate).trainModel(model, score)
+      doReturn((model, tracker)).when(coordinate).trainModel(model)
+      doReturn((model, tracker)).when(coordinate).trainModel(model, score)
 
       doReturn(model).when(model).setName(Matchers.any(classOf[String]))
       doReturn(model).when(model).persistRDD(Matchers.any(classOf[StorageLevel]))
@@ -197,8 +197,8 @@ class CoordinateDescentIntegTest extends SparkTestUtils {
 
       // Coordinate mock setup
       doReturn(trainingScore).when(coordinate).score(model)
-      doReturn((model, Some(tracker))).when(coordinate).trainModel()
-      doReturn((model, Some(tracker))).when(coordinate).trainModel(trainingScore)
+      doReturn((model, tracker)).when(coordinate).trainModel()
+      doReturn((model, tracker)).when(coordinate).trainModel(trainingScore)
 
       // Model mock setup
       doReturn(model).when(model).setName(Matchers.any(classOf[String]))

--- a/photon-lib/src/integTest/scala/com/linkedin/photon/ml/optimization/OptimizerIntegTest.scala
+++ b/photon-lib/src/integTest/scala/com/linkedin/photon/ml/optimization/OptimizerIntegTest.scala
@@ -39,13 +39,11 @@ class OptimizerIntegTest extends SparkTestUtils with Logging {
       Array(new LBFGS(
         tolerance = CONVERGENCE_TOLERANCE,
         maxNumIterations = MAX_ITERATIONS,
-        normalizationContext = NORMALIZATION_MOCK,
-        isTrackingState = ENABLE_TRACKING)),
+        normalizationContext = NORMALIZATION_MOCK)),
       Array(new TRON(
         tolerance = CONVERGENCE_TOLERANCE,
         maxNumIterations = MAX_ITERATIONS,
-        normalizationContext = NORMALIZATION_MOCK,
-        isTrackingState = ENABLE_TRACKING)))
+        normalizationContext = NORMALIZATION_MOCK)))
   }
 
   @DataProvider(parallel = true)
@@ -54,13 +52,11 @@ class OptimizerIntegTest extends SparkTestUtils with Logging {
       Array(new LBFGS(
         tolerance = CONVERGENCE_TOLERANCE,
         maxNumIterations = MAX_ITERATIONS,
-        normalizationContext = NORMALIZATION_MOCK,
-        isTrackingState = ENABLE_TRACKING)),
+        normalizationContext = NORMALIZATION_MOCK)),
       Array(new TRON(
         tolerance = CONVERGENCE_TOLERANCE,
         maxNumIterations = MAX_ITERATIONS,
-        normalizationContext = NORMALIZATION_MOCK,
-        isTrackingState = ENABLE_TRACKING)))
+        normalizationContext = NORMALIZATION_MOCK)))
   }
 
   // TODO: Currently the test objective function used by this test ignores weights, so testing points with varying
@@ -77,13 +73,13 @@ class OptimizerIntegTest extends SparkTestUtils with Logging {
       val objective: IntegTestObjective = new IntegTestObjective(sc, treeAggregateDepth = 1)
       val zero = Vector.zeros[Double](objective.domainDimension(data))
       optimizer.optimize(objective, zero)(data)
-      easyOptimizationStatesChecks(optimizer.getStateTracker.get)
+      easyOptimizationStatesChecks(optimizer.getStateTracker)
 
       // Test weighted sample
       val pt2 = new LabeledPoint(label = 1, features, offset = 0, weight = 1.5)
       val data2 = sc.parallelize(Seq(pt2))
       optimizer.optimize(objective, zero)(data2)
-      easyOptimizationStatesChecks(optimizer.getStateTracker.get)
+      easyOptimizationStatesChecks(optimizer.getStateTracker)
     }
 
   @Test(dataProvider = "optimzersNotUsingInitialValue")
@@ -99,9 +95,8 @@ class OptimizerIntegTest extends SparkTestUtils with Logging {
         val initParam = DenseVector.fill[Double](PROBLEM_DIMENSION)(r.nextDouble())
         optimizer.optimize(new IntegTestObjective(sc, treeAggregateDepth = 1), initParam)(data)
 
-        assertTrue(optimizer.getStateTracker.isDefined)
         assertTrue(optimizer.isDone)
-        easyOptimizationStatesChecks(optimizer.getStateTracker.get)
+        easyOptimizationStatesChecks(optimizer.getStateTracker)
       }
 
     // Test weighted sample
@@ -111,7 +106,7 @@ class OptimizerIntegTest extends SparkTestUtils with Logging {
       val initParam = DenseVector.fill[Double](PROBLEM_DIMENSION)(r.nextDouble())
       optimizer.optimize(new IntegTestObjective(sc, treeAggregateDepth = 1), initParam)(data2)
 
-      easyOptimizationStatesChecks(optimizer.getStateTracker.get)
+      easyOptimizationStatesChecks(optimizer.getStateTracker)
     }
   }
 }
@@ -128,7 +123,6 @@ object OptimizerIntegTest extends Logging {
   private val PARAMETER_TOLERANCE: Double = 1e-4
   private val RANDOM_SEED: Long = 314159265359L
   private val RANDOM_SAMPLES: Int = 100
-  private val ENABLE_TRACKING: Boolean = true
   private val NORMALIZATION = NoNormalization()
   private val NORMALIZATION_MOCK = mock(classOf[BroadcastWrapper[NormalizationContext]])
 

--- a/photon-lib/src/main/scala/com/linkedin/photon/ml/algorithm/Coordinate.scala
+++ b/photon-lib/src/main/scala/com/linkedin/photon/ml/algorithm/Coordinate.scala
@@ -38,18 +38,18 @@ protected[ml] abstract class Coordinate[D <: Dataset[D]](protected val dataset: 
   /**
    * Compute an optimized model (i.e. run the coordinate optimizer) for the current dataset.
    *
-   * @return A tuple of the updated model and the optimization states tracker
+   * @return A (updated model, optimization state tracking information) tuple
    */
-  protected[algorithm] def trainModel(): (DatumScoringModel, Option[OptimizationTracker])
+  protected[algorithm] def trainModel(): (DatumScoringModel, OptimizationTracker)
 
   /**
    * Compute an optimized model (i.e. run the coordinate optimizer) for the current dataset with residuals from other
    * coordinates.
    *
    * @param score The combined scores for each record of the other coordinates
-   * @return A tuple of the updated model and the optimization states tracker
+   * @return A (updated model, optimization state tracking information) tuple
    */
-  protected[algorithm] def trainModel(score: CoordinateDataScores): (DatumScoringModel, Option[OptimizationTracker]) =
+  protected[algorithm] def trainModel(score: CoordinateDataScores): (DatumScoringModel, OptimizationTracker) =
     updateCoordinateWithDataset(dataset.addScoresToOffsets(score)).trainModel()
 
   /**
@@ -57,9 +57,9 @@ protected[ml] abstract class Coordinate[D <: Dataset[D]](protected val dataset: 
    * a starting point.
    *
    * @param model The model to use as a starting point
-   * @return A (updated model, optional optimization tracking information) tuple
+   * @return A (updated model, optimization state tracking information) tuple
    */
-  protected[algorithm] def trainModel(model: DatumScoringModel): (DatumScoringModel, Option[OptimizationTracker])
+  protected[algorithm] def trainModel(model: DatumScoringModel): (DatumScoringModel, OptimizationTracker)
 
   /**
    * Compute an optimized model (i.e. run the coordinate optimizer) for the current dataset using an existing model as
@@ -67,11 +67,11 @@ protected[ml] abstract class Coordinate[D <: Dataset[D]](protected val dataset: 
    *
    * @param model The existing model
    * @param score The combined scores for each record of the other coordinates
-   * @return A tuple of the updated model and the optimization states tracker
+   * @return A (updated model, optimization state tracking information) tuple
    */
   protected[algorithm] def trainModel(
       model: DatumScoringModel,
-      score: CoordinateDataScores): (DatumScoringModel, Option[OptimizationTracker]) =
+      score: CoordinateDataScores): (DatumScoringModel, OptimizationTracker) =
     updateCoordinateWithDataset(dataset.addScoresToOffsets(score)).trainModel(model)
 
   /**

--- a/photon-lib/src/main/scala/com/linkedin/photon/ml/algorithm/CoordinateDescent.scala
+++ b/photon-lib/src/main/scala/com/linkedin/photon/ml/algorithm/CoordinateDescent.scala
@@ -192,7 +192,7 @@ object CoordinateDescent {
 
       logger.debug(s"Updating coordinate of class ${coordinate.getClass}")
 
-      val (model, trackerOpt) = (initialModelOpt, residualsOpt) match {
+      val (model, tracker) = (initialModelOpt, residualsOpt) match {
         case (Some(initialModel), Some(residuals)) =>
           Timed(s"Train new model with residuals using existing model as starting point") {
             coordinate.trainModel(initialModel, residuals)
@@ -214,7 +214,7 @@ object CoordinateDescent {
           }
       }
 
-      logOptimizationSummary(logger, coordinateId, model, trackerOpt)
+      logOptimizationSummary(logger, coordinateId, model, tracker)
 
       model
   }
@@ -225,28 +225,25 @@ object CoordinateDescent {
    * @param logger The logger to which to send debug messages
    * @param coordinateId The ID of the coordinate for which to train a new model
    * @param datumScoringModel A newly trained model
-   * @param optimizationTrackerOpt An optional tracker of optimization states
+   * @param optimizationTracker Optimization state tracking information
    */
   protected[algorithm] def logOptimizationSummary(
       logger: Logger,
       coordinateId: CoordinateId,
       datumScoringModel: DatumScoringModel,
-      optimizationTrackerOpt: Option[OptimizationTracker]): Unit = if (logger.isDebugEnabled) {
+      optimizationTracker: OptimizationTracker): Unit = if (logger.isDebugEnabled) {
 
     logger.debug(s"Summary of coordinate optimization for coordinate $coordinateId:")
 
     logger.debug(s"Summary of the new model:")
     logger.debug(datumScoringModel.toSummaryString)
 
-    // If optimization tracking is enabled, log the optimization summary
-    optimizationTrackerOpt.foreach { optimizationTracker =>
-      logger.debug(s"Summary of optimization for the new model:")
-      logger.debug(optimizationTracker.toSummaryString)
+    logger.debug(s"Summary of optimization for the new model:")
+    logger.debug(optimizationTracker.toSummaryString)
 
-      optimizationTracker match {
-        case rddLike: RDDLike => rddLike.unpersistRDD()
-        case _ =>
-      }
+    optimizationTracker match {
+      case rddLike: RDDLike => rddLike.unpersistRDD()
+      case _ =>
     }
   }
 

--- a/photon-lib/src/main/scala/com/linkedin/photon/ml/algorithm/ModelCoordinate.scala
+++ b/photon-lib/src/main/scala/com/linkedin/photon/ml/algorithm/ModelCoordinate.scala
@@ -39,9 +39,9 @@ abstract class ModelCoordinate[D <: Dataset[D]](dataset: D) extends Coordinate(d
   /**
    * Compute an optimized model (i.e. run the coordinate optimizer) for the current dataset.
    *
-   * @return A tuple of the updated model and the optimization states tracker
+   * @return A (updated model, optimization state tracking information) tuple
    */
-  override protected[algorithm] def trainModel(): (DatumScoringModel, Option[OptimizationTracker]) =
+  override protected[algorithm] def trainModel(): (DatumScoringModel, OptimizationTracker) =
     throw new UnsupportedOperationException("Attempted to train model coordinate.")
 
   /**
@@ -49,9 +49,9 @@ abstract class ModelCoordinate[D <: Dataset[D]](dataset: D) extends Coordinate(d
    * a starting point.
    *
    * @param model The model to use as a starting point
-   * @return A tuple of the updated model and the optimization states tracker
+   * @return A (updated model, optimization state tracking information) tuple
    */
-  override protected[algorithm] def trainModel(model: DatumScoringModel): (DatumScoringModel, Option[OptimizationTracker]) =
+  override protected[algorithm] def trainModel(model: DatumScoringModel): (DatumScoringModel, OptimizationTracker) =
     throw new UnsupportedOperationException("Attempted to train model coordinate.")
 
   /**

--- a/photon-lib/src/main/scala/com/linkedin/photon/ml/optimization/LBFGS.scala
+++ b/photon-lib/src/main/scala/com/linkedin/photon/ml/optimization/LBFGS.scala
@@ -34,21 +34,18 @@ import com.linkedin.photon.ml.util.BroadcastWrapper
  *                       Recommended:  3 < numCorrections < 10
  *                       Restriction:  numCorrections > 0
  * @param constraintMap (Optional) The map of constraints on the feature coefficients
- * @param isTrackingState Whether to track intermediate states during optimization
  */
 class LBFGS(
     normalizationContext: BroadcastWrapper[NormalizationContext],
     numCorrections: Int = LBFGS.DEFAULT_NUM_CORRECTIONS,
     tolerance: Double = LBFGS.DEFAULT_TOLERANCE,
     maxNumIterations: Int = LBFGS.DEFAULT_MAX_ITER,
-    constraintMap: Option[Map[Int, (Double, Double)]] = Optimizer.DEFAULT_CONSTRAINT_MAP,
-    isTrackingState: Boolean = Optimizer.DEFAULT_TRACKING_STATE)
+    constraintMap: Option[Map[Int, (Double, Double)]] = Optimizer.DEFAULT_CONSTRAINT_MAP)
   extends Optimizer[DiffFunction](
     tolerance,
     maxNumIterations,
     normalizationContext,
-    constraintMap,
-    isTrackingState) {
+    constraintMap) {
 
   /**
    * Under the hood, this adaptor uses an LBFGS

--- a/photon-lib/src/main/scala/com/linkedin/photon/ml/optimization/LBFGSB.scala
+++ b/photon-lib/src/main/scala/com/linkedin/photon/ml/optimization/LBFGSB.scala
@@ -35,7 +35,6 @@ import com.linkedin.photon.ml.util.BroadcastWrapper
  *                       time.
  *                       Recommended:  3 < numCorrections < 10
  *                       Restriction:  numCorrections > 0
- * @param isTrackingState Whether to track intermediate states during optimization
  */
 class LBFGSB (
     lowerBounds: DenseVector[Double],
@@ -43,15 +42,13 @@ class LBFGSB (
     normalizationContext: BroadcastWrapper[NormalizationContext],
     numCorrections: Int = LBFGS.DEFAULT_NUM_CORRECTIONS,
     tolerance: Double = LBFGS.DEFAULT_TOLERANCE,
-    maxNumIterations: Int = LBFGS.DEFAULT_MAX_ITER,
-    isTrackingState: Boolean = Optimizer.DEFAULT_TRACKING_STATE)
+    maxNumIterations: Int = LBFGS.DEFAULT_MAX_ITER)
   extends LBFGS(
     normalizationContext,
     numCorrections,
     tolerance,
     maxNumIterations,
-    Optimizer.DEFAULT_CONSTRAINT_MAP,
-    isTrackingState) {
+    Optimizer.DEFAULT_CONSTRAINT_MAP) {
 
   /**
    * Under the hood, this adaptor uses an LBFGSB optimizer from Breeze to optimize functions.

--- a/photon-lib/src/main/scala/com/linkedin/photon/ml/optimization/OWLQN.scala
+++ b/photon-lib/src/main/scala/com/linkedin/photon/ml/optimization/OWLQN.scala
@@ -35,7 +35,6 @@ import com.linkedin.photon.ml.util.BroadcastWrapper
  * @param tolerance The tolerance threshold for improvement between iterations as a percentage of the initial loss
  * @param maxNumIterations The cut-off for number of optimization iterations to perform.
  * @param constraintMap (Optional) The map of constraints on the feature coefficients
- * @param isTrackingState Whether to track intermediate states during optimization
  */
 class OWLQN(
     l1RegWeight: Double,
@@ -43,15 +42,13 @@ class OWLQN(
     numCorrections: Int = LBFGS.DEFAULT_NUM_CORRECTIONS,
     tolerance: Double = LBFGS.DEFAULT_TOLERANCE,
     maxNumIterations: Int = LBFGS.DEFAULT_MAX_ITER,
-    constraintMap: Option[Map[Int, (Double, Double)]] = Optimizer.DEFAULT_CONSTRAINT_MAP,
-    isTrackingState: Boolean = Optimizer.DEFAULT_TRACKING_STATE)
+    constraintMap: Option[Map[Int, (Double, Double)]] = Optimizer.DEFAULT_CONSTRAINT_MAP)
   extends LBFGS(
     normalizationContext,
     numCorrections,
     tolerance,
     maxNumIterations,
-    constraintMap,
-    isTrackingState) {
+    constraintMap) {
 
   protected var regularizationWeight: Double = l1RegWeight
 

--- a/photon-lib/src/main/scala/com/linkedin/photon/ml/optimization/TRON.scala
+++ b/photon-lib/src/main/scala/com/linkedin/photon/ml/optimization/TRON.scala
@@ -52,7 +52,6 @@
 package com.linkedin.photon.ml.optimization
 
 import breeze.linalg.{Vector, norm}
-import org.apache.spark.broadcast.Broadcast
 
 import com.linkedin.photon.ml.function.TwiceDiffFunction
 import com.linkedin.photon.ml.normalization.NormalizationContext
@@ -75,21 +74,18 @@ import com.linkedin.photon.ml.util.{BroadcastWrapper, Logging, VectorUtils}
  * @param tolerance The tolerance threshold for improvement between iterations as a percentage of the initial loss
  * @param maxNumIterations The cut-off for number of optimization iterations to perform.
  * @param constraintMap (Optional) The map of constraints on the feature coefficients
- * @param isTrackingState Whether to track intermediate states during optimization
  */
 class TRON(
     normalizationContext: BroadcastWrapper[NormalizationContext],
     maxNumImprovementFailures: Int = TRON.DEFAULT_MAX_NUM_FAILURE,
     tolerance: Double = TRON.DEFAULT_TOLERANCE,
     maxNumIterations: Int = TRON.DEFAULT_MAX_ITER,
-    constraintMap: Option[Map[Int, (Double, Double)]] = Optimizer.DEFAULT_CONSTRAINT_MAP,
-    isTrackingState: Boolean = Optimizer.DEFAULT_TRACKING_STATE)
+    constraintMap: Option[Map[Int, (Double, Double)]] = Optimizer.DEFAULT_CONSTRAINT_MAP)
   extends Optimizer[TwiceDiffFunction](
     tolerance,
     maxNumIterations,
     normalizationContext,
-    constraintMap,
-    isTrackingState) {
+    constraintMap) {
 
   /**
    * Initialize the hyperparameters for TRON (see Reference 2 for more details).

--- a/photon-lib/src/test/scala/com/linkedin/photon/ml/algorithm/CoordinateDescentTest.scala
+++ b/photon-lib/src/test/scala/com/linkedin/photon/ml/algorithm/CoordinateDescentTest.scala
@@ -26,6 +26,7 @@ import com.linkedin.photon.ml.data._
 import com.linkedin.photon.ml.data.scoring.CoordinateDataScores
 import com.linkedin.photon.ml.evaluation.{EvaluationResults, EvaluationSuite, EvaluatorType}
 import com.linkedin.photon.ml.model.DatumScoringModel
+import com.linkedin.photon.ml.optimization.OptimizationTracker
 import com.linkedin.photon.ml.spark.{BroadcastLike, RDDLike}
 import com.linkedin.photon.ml.util.PhotonLogger
 
@@ -119,7 +120,7 @@ class CoordinateDescentTest {
    *
    * @param coordinateDescent A pre-built [[CoordinateDescent]] object to attempt to run
    * @param coordinates A map of optimization problem coordinates (optimization sub-problems)
-   * @param initialModelsOpt
+   * @param initialModelsOpt An optional [[Map]] of existing prior models
    */
   @Test(dataProvider = "invalidRunInput", expectedExceptions = Array(classOf[IllegalArgumentException]))
   def testInvalidRun(
@@ -134,16 +135,17 @@ class CoordinateDescentTest {
     val mockCoordinate = mock(classOf[CoordinateType])
     val mockInitialModel = mock(classOf[DatumScoringModel])
     val mockResiduals = mock(classOf[CoordinateDataScores])
+    val mockStatesTracker = mock(classOf[OptimizationTracker])
 
     val mockNewModel1 = mock(classOf[DatumScoringModel])
     val mockNewModel2 = mock(classOf[DatumScoringModel])
     val mockNewModel3 = mock(classOf[DatumScoringModel])
     val mockNewModel4 = mock(classOf[DatumScoringModel])
 
-    doReturn((mockNewModel1, None)).when(mockCoordinate).trainModel(mockInitialModel, mockResiduals)
-    doReturn((mockNewModel2, None)).when(mockCoordinate).trainModel(mockInitialModel)
-    doReturn((mockNewModel3, None)).when(mockCoordinate).trainModel(mockResiduals)
-    doReturn((mockNewModel4, None)).when(mockCoordinate).trainModel()
+    doReturn((mockNewModel1, mockStatesTracker)).when(mockCoordinate).trainModel(mockInitialModel, mockResiduals)
+    doReturn((mockNewModel2, mockStatesTracker)).when(mockCoordinate).trainModel(mockInitialModel)
+    doReturn((mockNewModel3, mockStatesTracker)).when(mockCoordinate).trainModel(mockResiduals)
+    doReturn((mockNewModel4, mockStatesTracker)).when(mockCoordinate).trainModel()
 
     Array(
       Array(mockCoordinate, Some(mockInitialModel), Some(mockResiduals), mockNewModel1),
@@ -190,13 +192,13 @@ class CoordinateDescentTest {
     val mockCoordinate = mock(classOf[CoordinateType])
     val mockInitialModel = mock(classOf[DatumScoringModel])
     val mockNewModel = mock(classOf[DatumScoringModel])
+    val mockStatesTracker = mock(classOf[OptimizationTracker])
 
     val trainingCoordinateId = "trainingCoordinateId"
     val lockedCoordinateId = "lockedCoordinateId"
     val coordinatesToTrain = Seq(trainingCoordinateId)
-    val iteration = 1
 
-    doReturn((mockNewModel, None)).when(mockCoordinate).trainModel(mockInitialModel)
+    doReturn((mockNewModel, mockStatesTracker)).when(mockCoordinate).trainModel(mockInitialModel)
 
     val newModel = CoordinateDescent.trainOrFetchCoordinateModel(
       trainingCoordinateId,

--- a/photon-lib/src/test/scala/com/linkedin/photon/ml/optimization/OptimizerTest.scala
+++ b/photon-lib/src/test/scala/com/linkedin/photon/ml/optimization/OptimizerTest.scala
@@ -39,13 +39,11 @@ class OptimizerTest extends Logging {
       Array(new LBFGS(
         tolerance = CONVERGENCE_TOLERANCE,
         maxNumIterations = MAX_ITERATIONS,
-        normalizationContext = NORMALIZATION_MOCK,
-        isTrackingState = ENABLE_TRACKING)),
+        normalizationContext = NORMALIZATION_MOCK)),
       Array(new TRON(
         tolerance = CONVERGENCE_TOLERANCE,
         maxNumIterations = MAX_ITERATIONS,
-        normalizationContext = NORMALIZATION_MOCK,
-        isTrackingState = ENABLE_TRACKING)))
+        normalizationContext = NORMALIZATION_MOCK)))
   }
 
   @DataProvider(parallel = true)
@@ -54,13 +52,11 @@ class OptimizerTest extends Logging {
       Array(new LBFGS(
         tolerance = CONVERGENCE_TOLERANCE,
         maxNumIterations = MAX_ITERATIONS,
-        normalizationContext = NORMALIZATION_MOCK,
-        isTrackingState = ENABLE_TRACKING)),
+        normalizationContext = NORMALIZATION_MOCK)),
       Array(new TRON(
         tolerance = CONVERGENCE_TOLERANCE,
         maxNumIterations = MAX_ITERATIONS,
-        normalizationContext = NORMALIZATION_MOCK,
-        isTrackingState = ENABLE_TRACKING)))
+        normalizationContext = NORMALIZATION_MOCK)))
   }
 
   // TODO: Currently the test objective function used by this test ignores weights, so testing points with varying
@@ -75,12 +71,12 @@ class OptimizerTest extends Logging {
     val pt1 = Seq(new LabeledPoint(label = 1, features, offset = 0, weight = 1))
     val zero = Vector.zeros[Double](objective.domainDimension(pt1))
     optimizer.optimize(objective, zero)(pt1)
-    easyOptimizationStatesChecks(optimizer.getStateTracker.get)
+    easyOptimizationStatesChecks(optimizer.getStateTracker)
 
     // Test weighted sample
     val pt2 = new LabeledPoint(label = 1, features, offset = 0, weight = 1.5)
     optimizer.optimize(objective, zero)(Seq(pt2))
-    easyOptimizationStatesChecks(optimizer.getStateTracker.get)
+    easyOptimizationStatesChecks(optimizer.getStateTracker)
   }
 
   @Test(dataProvider = "optimizersNotUsingInitialValue")
@@ -96,9 +92,8 @@ class OptimizerTest extends Logging {
       val initParam = DenseVector.fill[Double](PROBLEM_DIMENSION)(r.nextDouble())
       optimizer.optimize(objective, initParam)(Seq(pt))
 
-      assertTrue(optimizer.getStateTracker.isDefined)
       assertTrue(optimizer.isDone)
-      easyOptimizationStatesChecks(optimizer.getStateTracker.get)
+      easyOptimizationStatesChecks(optimizer.getStateTracker)
     }
 
     // Test weighted sample
@@ -106,7 +101,7 @@ class OptimizerTest extends Logging {
       val initParam = DenseVector.fill[Double](PROBLEM_DIMENSION)(r.nextDouble())
       optimizer.optimize(objective, initParam)(Seq(pt2))
 
-      easyOptimizationStatesChecks(optimizer.getStateTracker.get)
+      easyOptimizationStatesChecks(optimizer.getStateTracker)
     }
   }
 }
@@ -121,7 +116,6 @@ object OptimizerTest extends Logging {
   private val PARAMETER_TOLERANCE: Double = 1e-4
   private val RANDOM_SEED: Long = 314159265359L
   private val RANDOM_SAMPLES: Int = 100
-  private val ENABLE_TRACKING: Boolean = true
   private val NORMALIZATION = NoNormalization()
   private val NORMALIZATION_MOCK = mock(classOf[BroadcastWrapper[NormalizationContext]])
 


### PR DESCRIPTION
When using GAME, optimization state tracking already did not have the option of being disabled. When using the legacy driver (i.e. `Driver`), in practice LinkedIn users were always keeping the option enabled. There is no performance penalty for enabling optimization state tracking. Thus, to simplify the code this PR seeks to make it always enabled.