### PR TITLE
Lock Travis CI to 'trusty' distribution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ scala:
 sudo: required
 jdk:
   - oraclejdk8
+dist: trusty
 before_cache:
   - rm -f $HOME/.gradle/caches/modules-2/modules-2.lock
 cache:


### PR DESCRIPTION
For some reason, using 'xenial' has started causing test failures. This is a known issue:
https://travis-ci.community/t/error-installing-oraclejdk8-expected-feature-release-number-in-range-of-9-to-14-but-got-8/3766/5
https://travis-ci.community/t/install-jdk-sh-failing-for-openjdk9-and-10/3998/27