### PR TITLE
Disable L2 Regularization on Intercept

### DIFF
--- a/photon-api/src/integTest/scala/com/linkedin/photon/ml/algorithm/CoordinateFactoryIntegTest.scala
+++ b/photon-api/src/integTest/scala/com/linkedin/photon/ml/algorithm/CoordinateFactoryIntegTest.scala
@@ -56,7 +56,8 @@ class CoordinateFactoryIntegTest extends SparkTestUtils {
       GLM_CONSTRUCTOR,
       DOWN_SAMPLER_FACTORY,
       MOCK_NORMALIZATION,
-      VARIANCE_COMPUTATION_TYPE)
+      VARIANCE_COMPUTATION_TYPE,
+      INTERCEPT_INDEX)
 
     coordinate match {
       case _: FixedEffectCoordinate[DistributedObjectiveFunction] =>
@@ -95,7 +96,8 @@ class CoordinateFactoryIntegTest extends SparkTestUtils {
       GLM_CONSTRUCTOR,
       DOWN_SAMPLER_FACTORY,
       MOCK_NORMALIZATION,
-      VARIANCE_COMPUTATION_TYPE)
+      VARIANCE_COMPUTATION_TYPE,
+      INTERCEPT_INDEX)
 
     coordinate match {
       case _: RandomEffectCoordinate[SingleNodeObjectiveFunction] =>
@@ -121,7 +123,8 @@ class CoordinateFactoryIntegTest extends SparkTestUtils {
       GLM_CONSTRUCTOR,
       DOWN_SAMPLER_FACTORY,
       MOCK_NORMALIZATION,
-      VARIANCE_COMPUTATION_TYPE)
+      VARIANCE_COMPUTATION_TYPE,
+      INTERCEPT_INDEX)
   }
 }
 
@@ -133,6 +136,7 @@ object CoordinateFactoryIntegTest {
   private val TOLERANCE = 2E-2
   private val TREE_AGGREGATE_DEPTH = 1
   private val VARIANCE_COMPUTATION_TYPE = VarianceComputationType.NONE
+  private val INTERCEPT_INDEX = None
 
   private val OPTIMIZER_CONFIG = OptimizerConfig(OPTIMIZER_TYPE, MAX_ITER, TOLERANCE)
   private val MOCK_NORMALIZATION = mock(classOf[NormalizationContext])

--- a/photon-api/src/integTest/scala/com/linkedin/photon/ml/supervised/BaseGLMIntegTest.scala
+++ b/photon-api/src/integTest/scala/com/linkedin/photon/ml/supervised/BaseGLMIntegTest.scala
@@ -170,7 +170,8 @@ class BaseGLMIntegTest extends SparkTestUtils {
   @Test(dataProvider = "getGeneralizedLinearOptimizationProblems")
   def runGeneralizedLinearOptimizationProblemScenario(
       desc: String,
-      optimizationProblemBuilder: BroadcastWrapper[NormalizationContext] => DistributedOptimizationProblem[DistributedGLMLossFunction],
+      optimizationProblemBuilder: BroadcastWrapper[NormalizationContext] =>
+        DistributedOptimizationProblem[DistributedGLMLossFunction],
       data: Seq[LabeledPoint],
       validator: ModelValidator[GeneralizedLinearModel]): Unit = sparkTest(desc) {
 

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/algorithm/CoordinateFactory.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/algorithm/CoordinateFactory.scala
@@ -15,8 +15,8 @@
 package com.linkedin.photon.ml.algorithm
 
 import com.linkedin.photon.ml.data.{Dataset, FixedEffectDataset, RandomEffectDataset}
-import com.linkedin.photon.ml.function.ObjectiveFunctionHelper.ObjectiveFunctionFactory
-import com.linkedin.photon.ml.function.{DistributedObjectiveFunction, ObjectiveFunction, SingleNodeObjectiveFunction}
+import com.linkedin.photon.ml.function.ObjectiveFunctionHelper.{DistributedObjectiveFunctionFactory, ObjectiveFunctionFactoryFactory, SingleNodeObjectiveFunctionFactory}
+import com.linkedin.photon.ml.function.ObjectiveFunction
 import com.linkedin.photon.ml.model.Coefficients
 import com.linkedin.photon.ml.normalization.NormalizationContext
 import com.linkedin.photon.ml.optimization.DistributedOptimizationProblem
@@ -40,29 +40,31 @@ object CoordinateFactory {
    * @tparam D Some type of [[Dataset]]
    * @param dataset The input data to use for training
    * @param coordinateOptConfig The optimization settings for training
-   * @param lossFunctionConstructor A constructor for the loss function used for training
+   * @param lossFunctionFactoryConstructor A constructor for the loss function factory function
    * @param glmConstructor A constructor for the type of [[GeneralizedLinearModel]] being trained
    * @param downSamplerFactory A factory function for the [[DownSampler]] (if down-sampling is enabled)
    * @param normalizationContext The [[NormalizationContext]]
    * @param varianceComputationType Should the trained coefficient variances be computed in addition to the means?
+   * @param interceptIndexOpt The index of the intercept, if one is present
    * @return A [[Coordinate]] for the [[Dataset]] of type [[D]]
    */
   def build[D <: Dataset[D]](
       dataset: D,
       coordinateOptConfig: CoordinateOptimizationConfiguration,
-      lossFunctionConstructor: ObjectiveFunctionFactory,
+      lossFunctionFactoryConstructor: ObjectiveFunctionFactoryFactory,
       glmConstructor: Coefficients => GeneralizedLinearModel,
       downSamplerFactory: DownSamplerFactory,
       normalizationContext: NormalizationContext,
-      varianceComputationType: VarianceComputationType): Coordinate[D] = {
+      varianceComputationType: VarianceComputationType,
+      interceptIndexOpt: Option[Int]): Coordinate[D] = {
 
-    val lossFunction: ObjectiveFunction = lossFunctionConstructor(coordinateOptConfig)
+    val lossFunctionFactory = lossFunctionFactoryConstructor(coordinateOptConfig)
 
-    (dataset, coordinateOptConfig, lossFunction) match {
+    (dataset, coordinateOptConfig, lossFunctionFactory) match {
       case (
           fEDataset: FixedEffectDataset,
           fEOptConfig: FixedEffectOptimizationConfiguration,
-          distributedLossFunction: DistributedObjectiveFunction) =>
+          distributedLossFunctionFactory: DistributedObjectiveFunctionFactory) =>
 
         val downSamplerOpt = if (DownSampler.isValidDownSamplingRate(fEOptConfig.downSamplingRate)) {
           Some(downSamplerFactory(fEOptConfig.downSamplingRate))
@@ -75,7 +77,7 @@ object CoordinateFactory {
           fEDataset,
           DistributedOptimizationProblem(
             fEOptConfig,
-            distributedLossFunction,
+            distributedLossFunctionFactory(interceptIndexOpt),
             downSamplerOpt,
             glmConstructor,
             normalizationPhotonBroadcast,
@@ -84,22 +86,23 @@ object CoordinateFactory {
       case (
           rEDataset: RandomEffectDataset,
           rEOptConfig: RandomEffectOptimizationConfiguration,
-          singleNodeLossFunction: SingleNodeObjectiveFunction) =>
+          singleNodeLossFunctionFactory: SingleNodeObjectiveFunctionFactory) =>
 
         RandomEffectCoordinate(
           rEDataset,
           rEOptConfig,
-          singleNodeLossFunction,
+          singleNodeLossFunctionFactory,
           glmConstructor,
           normalizationContext,
-          varianceComputationType).asInstanceOf[Coordinate[D]]
+          varianceComputationType,
+          interceptIndexOpt).asInstanceOf[Coordinate[D]]
 
       case _ =>
         throw new UnsupportedOperationException(
           s"""Cannot build coordinate for the following input class combination:
           |  ${dataset.getClass.getName}
           |  ${coordinateOptConfig.getClass.getName}
-          |  ${lossFunction.getClass.getName}""".stripMargin)
+          |  ${lossFunctionFactory.getClass.getName}""".stripMargin)
     }
   }
 }

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/function/ObjectiveFunctionHelper.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/function/ObjectiveFunctionHelper.scala
@@ -26,7 +26,9 @@ import com.linkedin.photon.ml.optimization.game.CoordinateOptimizationConfigurat
  */
 object ObjectiveFunctionHelper {
 
-  type ObjectiveFunctionFactory = (CoordinateOptimizationConfiguration) => ObjectiveFunction
+  type ObjectiveFunctionFactoryFactory = CoordinateOptimizationConfiguration => Option[Int] => ObjectiveFunction
+  type DistributedObjectiveFunctionFactory = Option[Int] => DistributedObjectiveFunction
+  type SingleNodeObjectiveFunctionFactory = Option[Int] => SingleNodeObjectiveFunction
 
   /**
    * Construct a factory function for building [[ObjectiveFunction]] objects.
@@ -36,7 +38,7 @@ object ObjectiveFunctionHelper {
    * @return A function which builds the appropriate type of [[ObjectiveFunction]] for a given [[Coordinate]] type and
    *         optimization settings.
    */
-  def buildFactory(taskType: TaskType, treeAggregateDepth: Int): ObjectiveFunctionFactory =
+  def buildFactory(taskType: TaskType, treeAggregateDepth: Int): ObjectiveFunctionFactoryFactory =
     taskType match {
       case TaskType.LOGISTIC_REGRESSION => GLMLossFunction.buildFactory(LogisticLossFunction, treeAggregateDepth)
       case TaskType.LINEAR_REGRESSION => GLMLossFunction.buildFactory(SquaredLossFunction, treeAggregateDepth)

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/function/glm/DistributedGLMLossFunction.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/function/glm/DistributedGLMLossFunction.scala
@@ -155,22 +155,24 @@ object DistributedGLMLossFunction {
    * @param configuration The optimization problem configuration
    * @param singleLossFunction The PointwiseLossFunction providing functionality for l(z, y)
    * @param treeAggregateDepth The tree aggregation depth
+   * @param interceptIndexOpt The index of the intercept, if there is one
    * @return A new DistributedGLMLossFunction
    */
   def apply(
       configuration: GLMOptimizationConfiguration,
       singleLossFunction: PointwiseLossFunction,
-      treeAggregateDepth: Int): DistributedGLMLossFunction = {
+      treeAggregateDepth: Int,
+      interceptIndexOpt: Option[Int] = None): DistributedGLMLossFunction = {
 
     val regularizationContext = configuration.regularizationContext
     val regularizationWeight = configuration.regularizationWeight
 
     regularizationContext.regularizationType match {
       case RegularizationType.L2 | RegularizationType.ELASTIC_NET =>
-        new DistributedGLMLossFunction(singleLossFunction, treeAggregateDepth)
-          with L2RegularizationTwiceDiff {
-
+        new DistributedGLMLossFunction(singleLossFunction, treeAggregateDepth) with L2RegularizationTwiceDiff {
           l2RegWeight = regularizationContext.getL2RegularizationWeight(regularizationWeight)
+
+          override def interceptOpt: Option[Int] = interceptIndexOpt
         }
 
       case _ => new DistributedGLMLossFunction(singleLossFunction, treeAggregateDepth)

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/function/glm/GLMLossFunction.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/function/glm/GLMLossFunction.scala
@@ -31,20 +31,21 @@ object GLMLossFunction {
    * @return A function which builds the appropriate type of [[ObjectiveFunction]] for a given [[Coordinate]] type and
    *         optimization settings.
    */
-  def buildFactory(
-      lossFunction: PointwiseLossFunction,
-      treeAggregateDepth: Int): (CoordinateOptimizationConfiguration) => ObjectiveFunction =
-    (config: CoordinateOptimizationConfiguration) => {
-      config match {
-        case fEOptConfig: FixedEffectOptimizationConfiguration =>
-          DistributedGLMLossFunction(fEOptConfig, lossFunction, treeAggregateDepth)
+  def buildFactory
+      (lossFunction: PointwiseLossFunction, treeAggregateDepth: Int)
+      (config: CoordinateOptimizationConfiguration): Option[Int] => ObjectiveFunction =
 
-        case rEOptConfig: RandomEffectOptimizationConfiguration =>
-          SingleNodeGLMLossFunction(rEOptConfig, lossFunction)
+    config match {
+      case fEOptConfig: FixedEffectOptimizationConfiguration =>
+        (interceptIndexOpt: Option[Int]) =>
+          DistributedGLMLossFunction(fEOptConfig, lossFunction, treeAggregateDepth, interceptIndexOpt)
 
-        case _ =>
-          throw new UnsupportedOperationException(
-            s"Cannot create a GLM loss function from a coordinate configuration with class '${config.getClass.getName}'")
-      }
+      case rEOptConfig: RandomEffectOptimizationConfiguration =>
+        (interceptIndexOpt: Option[Int]) =>
+          SingleNodeGLMLossFunction(rEOptConfig, lossFunction, interceptIndexOpt)
+
+      case _ =>
+        throw new UnsupportedOperationException(
+          s"Cannot create a GLM loss function from a coordinate configuration with class '${config.getClass.getName}'")
     }
 }

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/function/glm/SingleNodeGLMLossFunction.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/function/glm/SingleNodeGLMLossFunction.scala
@@ -144,11 +144,13 @@ object SingleNodeGLMLossFunction {
    *
    * @param configuration The optimization problem configuration
    * @param singleLossFunction The PointwiseLossFunction providing functionality for l(z, y)
+   * @param interceptIndexOpt The index of the intercept, if there is one
    * @return A new SingleNodeGLMLossFunction
    */
   def apply(
       configuration: GLMOptimizationConfiguration,
-      singleLossFunction: PointwiseLossFunction): SingleNodeGLMLossFunction = {
+      singleLossFunction: PointwiseLossFunction,
+      interceptIndexOpt: Option[Int] = None): SingleNodeGLMLossFunction = {
 
     val regularizationContext = configuration.regularizationContext
     val regularizationWeight = configuration.regularizationWeight
@@ -157,6 +159,8 @@ object SingleNodeGLMLossFunction {
       case RegularizationType.L2 | RegularizationType.ELASTIC_NET =>
         new SingleNodeGLMLossFunction(singleLossFunction) with L2RegularizationTwiceDiff {
           l2RegWeight = regularizationContext.getL2RegularizationWeight(regularizationWeight)
+
+          override def interceptOpt: Option[Int] = interceptIndexOpt
         }
 
       case _ => new SingleNodeGLMLossFunction(singleLossFunction)

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/function/svm/DistributedSmoothedHingeLossFunction.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/function/svm/DistributedSmoothedHingeLossFunction.scala
@@ -109,11 +109,13 @@ object DistributedSmoothedHingeLossFunction {
    *
    * @param configuration The optimization problem configuration
    * @param treeAggregateDepth The tree aggregation depth
+   * @param interceptIndexOpt The index of the intercept, if there is one
    * @return A new DistributedSmoothedHingeLossFunction
    */
   def apply(
       configuration: GLMOptimizationConfiguration,
-      treeAggregateDepth: Int): DistributedSmoothedHingeLossFunction = {
+      treeAggregateDepth: Int,
+      interceptIndexOpt: Option[Int] = None): DistributedSmoothedHingeLossFunction = {
 
     val regularizationContext = configuration.regularizationContext
 
@@ -121,10 +123,11 @@ object DistributedSmoothedHingeLossFunction {
       case RegularizationType.L2 | RegularizationType.ELASTIC_NET =>
         new DistributedSmoothedHingeLossFunction(treeAggregateDepth) with L2RegularizationDiff {
           l2RegWeight = regularizationContext.getL2RegularizationWeight(configuration.regularizationWeight)
+
+          override def interceptOpt: Option[Int] = interceptIndexOpt
         }
 
-      case _ =>
-        new DistributedSmoothedHingeLossFunction(treeAggregateDepth)
+      case _ => new DistributedSmoothedHingeLossFunction(treeAggregateDepth)
     }
   }
 }

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/function/svm/SingleNodeSmoothedHingeLossFunction.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/function/svm/SingleNodeSmoothedHingeLossFunction.scala
@@ -97,9 +97,12 @@ object SingleNodeSmoothedHingeLossFunction {
    * function.
    *
    * @param configuration The optimization problem configuration
+   * @param interceptIndexOpt The index of the intercept, if there is one
    * @return A new SingleNodeSmoothedHingeLossFunction
    */
-  def apply(configuration: GLMOptimizationConfiguration): SingleNodeSmoothedHingeLossFunction = {
+  def apply(
+      configuration: GLMOptimizationConfiguration,
+      interceptIndexOpt: Option[Int] = None): SingleNodeSmoothedHingeLossFunction = {
 
     val regularizationContext = configuration.regularizationContext
     val regularizationWeight = configuration.regularizationWeight
@@ -108,6 +111,8 @@ object SingleNodeSmoothedHingeLossFunction {
       case RegularizationType.L2 | RegularizationType.ELASTIC_NET =>
         new SingleNodeSmoothedHingeLossFunction with L2RegularizationDiff {
           l2RegWeight = regularizationContext.getL2RegularizationWeight(regularizationWeight)
+
+          override def interceptOpt: Option[Int] = interceptIndexOpt
         }
 
       case _ => new SingleNodeSmoothedHingeLossFunction

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/function/svm/SmoothedHingeLossFunction.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/function/svm/SmoothedHingeLossFunction.scala
@@ -94,19 +94,22 @@ object SmoothedHingeLossFunction {
    * @return A function which builds the appropriate type of [[ObjectiveFunction]] for a given [[Coordinate]] type and
    *         optimization settings.
    */
-  def buildFactory(treeAggregateDepth: Int): (CoordinateOptimizationConfiguration) => ObjectiveFunction =
-    (config: CoordinateOptimizationConfiguration) => {
-      config match {
-        case fEOptConfig: FixedEffectOptimizationConfiguration =>
+  def buildFactory
+      (treeAggregateDepth: Int)
+      (config: CoordinateOptimizationConfiguration): Option[Int] => ObjectiveFunction =
+
+    config match {
+      case fEOptConfig: FixedEffectOptimizationConfiguration =>
+        (interceptIndexOpt: Option[Int]) =>
           DistributedSmoothedHingeLossFunction(fEOptConfig, treeAggregateDepth)
 
-        case rEOptConfig: RandomEffectOptimizationConfiguration =>
+      case rEOptConfig: RandomEffectOptimizationConfiguration =>
+        (interceptIndexOpt: Option[Int]) =>
           SingleNodeSmoothedHingeLossFunction(rEOptConfig)
 
-        case _ =>
-          throw new UnsupportedOperationException(
-            s"Cannot create a smoothed hinge loss linear SVM loss function from a coordinate configuration with class " +
-              s"'${config.getClass.getName}'")
-      }
+      case _ =>
+        throw new UnsupportedOperationException(
+          s"Cannot create a smoothed hinge loss linear SVM loss function from a coordinate configuration with class " +
+            s"'${config.getClass.getName}'")
     }
 }

--- a/photon-api/src/test/scala/com/linkedin/photon/ml/function/DistributedObjectiveFunctionTest.scala
+++ b/photon-api/src/test/scala/com/linkedin/photon/ml/function/DistributedObjectiveFunctionTest.scala
@@ -36,12 +36,12 @@ class DistributedObjectiveFunctionTest {
    */
   @Test(dataProvider = "invalidInput", expectedExceptions = Array(classOf[IllegalArgumentException]))
   def testSetupWithInvalidInput(treeAggregateDepth: Int): Unit =
-    new MockDistributedObjectiveFunction(treeAggregateDepth)
+    new MockDistributedObjectiveFunctionFactory(treeAggregateDepth)
 }
 
 object DistributedObjectiveFunctionTest {
 
-  class MockDistributedObjectiveFunction(treeAggregateDepth: Int)
+  class MockDistributedObjectiveFunctionFactory(treeAggregateDepth: Int)
     extends DistributedObjectiveFunction(treeAggregateDepth) {
 
     override protected[ml] def value(

--- a/photon-api/src/test/scala/com/linkedin/photon/ml/function/ObjectiveFunctionHelperTest.scala
+++ b/photon-api/src/test/scala/com/linkedin/photon/ml/function/ObjectiveFunctionHelperTest.scala
@@ -53,10 +53,10 @@ class ObjectiveFunctionHelperTest {
 
     trainingTask match {
       case TaskType.LOGISTIC_REGRESSION | TaskType.LINEAR_REGRESSION | TaskType.POISSON_REGRESSION =>
-        assertTrue(objectiveFunction.isInstanceOf[DistributedGLMLossFunction])
+        assertTrue(objectiveFunction.isInstanceOf[Option[Int] => DistributedGLMLossFunction])
 
       case TaskType.SMOOTHED_HINGE_LOSS_LINEAR_SVM =>
-        assertTrue(objectiveFunction.isInstanceOf[DistributedSmoothedHingeLossFunction])
+        assertTrue(objectiveFunction.isInstanceOf[Option[Int] => DistributedSmoothedHingeLossFunction])
     }
   }
 }

--- a/photon-api/src/test/scala/com/linkedin/photon/ml/function/glm/GLMLossFunctionTest.scala
+++ b/photon-api/src/test/scala/com/linkedin/photon/ml/function/glm/GLMLossFunctionTest.scala
@@ -52,10 +52,10 @@ class GLMLossFunctionTest {
 
     coordinateOptConfig match {
       case _: FixedEffectOptimizationConfiguration =>
-        assertTrue(objectiveFunction.isInstanceOf[DistributedGLMLossFunction])
+        assertTrue(objectiveFunction.isInstanceOf[Option[Int] => DistributedGLMLossFunction])
 
       case _: RandomEffectOptimizationConfiguration =>
-        assertTrue(objectiveFunction.isInstanceOf[SingleNodeGLMLossFunction])
+        assertTrue(objectiveFunction.isInstanceOf[Option[Int] => SingleNodeGLMLossFunction])
 
       case _ =>
         assertTrue(false)

--- a/photon-api/src/test/scala/com/linkedin/photon/ml/function/svm/SmoothedHingeLossFunctionTest.scala
+++ b/photon-api/src/test/scala/com/linkedin/photon/ml/function/svm/SmoothedHingeLossFunctionTest.scala
@@ -47,14 +47,14 @@ class SmoothedHingeLossFunctionTest {
   @Test(dataProvider = "coordinateOptimizationProblemProvider")
   def testBuildFactory(coordinateOptConfig: CoordinateOptimizationConfiguration): Unit = {
 
-    val objectiveFunction = SmoothedHingeLossFunction.buildFactory(TREE_AGGREGATE_DEPTH)(coordinateOptConfig)
+    val objectiveFunctionFactory = SmoothedHingeLossFunction.buildFactory(TREE_AGGREGATE_DEPTH)(coordinateOptConfig)
 
     coordinateOptConfig match {
       case _: FixedEffectOptimizationConfiguration =>
-        assertTrue(objectiveFunction.isInstanceOf[DistributedSmoothedHingeLossFunction])
+        assertTrue(objectiveFunctionFactory.isInstanceOf[Option[Int] => DistributedSmoothedHingeLossFunction])
 
       case _: RandomEffectOptimizationConfiguration =>
-        assertTrue(objectiveFunction.isInstanceOf[SingleNodeSmoothedHingeLossFunction])
+        assertTrue(objectiveFunctionFactory.isInstanceOf[Option[Int] => SingleNodeSmoothedHingeLossFunction])
 
       case _ =>
         assertTrue(false)

--- a/photon-client/src/main/scala/com/linkedin/photon/ml/cli/game/training/GameTrainingDriver.scala
+++ b/photon-client/src/main/scala/com/linkedin/photon/ml/cli/game/training/GameTrainingDriver.scala
@@ -33,7 +33,7 @@ import com.linkedin.photon.ml.data.avro.{AvroDataReader, ModelProcessingUtils}
 import com.linkedin.photon.ml.estimators.GameEstimator.GameOptimizationConfiguration
 import com.linkedin.photon.ml.estimators.{GameEstimator, GameEstimatorEvaluationFunction}
 import com.linkedin.photon.ml.hyperparameter.tuner.HyperparameterTunerFactory
-import com.linkedin.photon.ml.index.IndexMapLoader
+import com.linkedin.photon.ml.index.{IndexMap, IndexMapLoader}
 import com.linkedin.photon.ml.io.{CoordinateConfiguration, ModelOutputMode, RandomEffectCoordinateConfiguration}
 import com.linkedin.photon.ml.io.ModelOutputMode.ModelOutputMode
 import com.linkedin.photon.ml.io.scopt.game.ScoptGameTrainingParametersParser
@@ -363,6 +363,14 @@ object GameTrainingDriver extends GameDriver {
       readValidationData(avroDataReader, featureIndexMapLoaders)
     }
 
+    val interceptIndices = featureIndexMapLoaders.flatMap { case (coordinateId, indexMap) =>
+      indexMap.indexMapForDriver().getIndex(Constants.INTERCEPT_KEY) match {
+        case IndexMap.NULL_KEY => None
+        case i if i >= 0 => Some(coordinateId, i)
+        case _ => throw new IndexOutOfBoundsException("Intercept Index should not be negative.")
+      }
+    }
+
     trainingData.persist(StorageLevel.DISK_ONLY)
     validationData.map(_.persist(StorageLevel.DISK_ONLY))
 
@@ -446,6 +454,7 @@ object GameTrainingDriver extends GameDriver {
         .setCoordinateDataConfigurations(coordinateDataConfigs)
         .setCoordinateUpdateSequence(getRequiredParam(coordinateUpdateSequence))
         .setCoordinateDescentIterations(getRequiredParam(coordinateDescentIterations))
+        .setCoordinateInterceptIndices(interceptIndices)
         .setVarianceComputation(getOrDefault(varianceComputationType))
         .setIgnoreThresholdForNewModels(getOrDefault(ignoreThresholdForNewModels))
         .setUseWarmStart(true)

--- a/photon-client/src/main/scala/com/linkedin/photon/ml/util/IOUtils.scala
+++ b/photon-client/src/main/scala/com/linkedin/photon/ml/util/IOUtils.scala
@@ -101,15 +101,15 @@ object IOUtils {
   }
 
   /**
-    * Returns file paths matching the given date range. This method filters out invalid paths by default, but this
-    * behavior can be changed with the "errorOnMissing" parameter.
-    *
-    * @param inputDirs The base paths for input files
-    * @param dateRange Date range for finding input files
-    * @param configuration Hadoop configuration
-    * @param errorOnMissing If true, the method will throw when a date has no corresponding input file
-    * @return A sequence of matching file paths
-    */
+   * Returns file paths matching the given date range. This method filters out invalid paths by default, but this
+   * behavior can be changed with the "errorOnMissing" parameter.
+   *
+   * @param inputDirs The base paths for input files
+   * @param dateRange Date range for finding input files
+   * @param configuration Hadoop configuration
+   * @param errorOnMissing If true, the method will throw when a date has no corresponding input file
+   * @return A sequence of matching file paths
+   */
   def getInputPathsWithinDateRange(
       inputDirs: Set[Path],
       dateRange: DateRange,

--- a/photon-lib/src/test/scala/com/linkedin/photon/ml/function/L2RegularizationTest.scala
+++ b/photon-lib/src/test/scala/com/linkedin/photon/ml/function/L2RegularizationTest.scala
@@ -40,13 +40,21 @@ class L2RegularizationTest {
     val regularizationWeight = 10D
     val coefficients = DenseVector.ones[Double](DIMENSION)
     val multiplyVector = coefficients * 2D
+    val mockInterceptIndexOpt = Some(INTERCEPT_INDEX)
 
     val mockObjectiveFunction = new MockObjectiveFunction with L2RegularizationTwiceDiff {
       l2RegWeight = regularizationWeight
     }
 
+    val mockObjectiveFunctionWithInterceptIndex = new MockObjectiveFunction with L2Regularization {
+      l2RegWeight = regularizationWeight
+
+      override def interceptOpt: Option[Int] = mockInterceptIndexOpt
+    }
+
     // Assume that coefficients = 1-vector, multiply = 2-vector for all expected values below
     val expectedValue = MockObjectiveFunction.VALUE + (regularizationWeight * DIMENSION / 2)
+    val expectedValueWithoutIntercept = MockObjectiveFunction.VALUE + (regularizationWeight * (DIMENSION - 1) / 2)
     val expectedGradient = DenseVector(Array.fill(DIMENSION)(MockObjectiveFunction.GRADIENT + regularizationWeight))
     val expectedVector =
       DenseVector(Array.fill(DIMENSION)(MockObjectiveFunction.HESSIAN_VECTOR + (2D * regularizationWeight)))
@@ -56,6 +64,9 @@ class L2RegularizationTest {
       diag(DenseVector(Array.fill(DIMENSION)(MockObjectiveFunction.HESSIAN_MATRIX + regularizationWeight)))
 
     assertEquals(mockObjectiveFunction.value(Unit, coefficients, mockNormalization), expectedValue)
+    assertEquals(
+      mockObjectiveFunctionWithInterceptIndex.value(Unit, coefficients, mockNormalization),
+      expectedValueWithoutIntercept)
     assertEquals(mockObjectiveFunction.gradient(Unit, coefficients, mockNormalization), expectedGradient)
     assertEquals(
       mockObjectiveFunction.hessianVector(Unit, coefficients, multiplyVector, mockNormalization),
@@ -68,6 +79,7 @@ class L2RegularizationTest {
 object L2RegularizationTest {
 
   private val DIMENSION = 4
+  private val INTERCEPT_INDEX = 1
 
   /**
    * Mock [[ObjectiveFunction]] for testing [[L2Regularization]].


### PR DESCRIPTION
This is continuation of the work started by @biyan-linkedin in PR #439. Thank you for your work Bill!

Previously, Photon would regularize the entire coefficient vector, including the intercept coefficient if one was present. One of our users had this to say:
```
Penalizing intercept makes the behavior of L2 regularization depends
on the pos/neg ratio, and often leads to hard-to-interpret intercept.
Especially when we have a lot of training data and most of the features
are extremely sparse.
```