### PR TITLE
Fix a bug in calculating RMSE off by sqrt(2)

### DIFF
--- a/photon-api/src/main/scala/com/linkedin/photon/ml/evaluation/SquaredLossEvaluator.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/evaluation/SquaredLossEvaluator.scala
@@ -34,7 +34,9 @@ object SquaredLossEvaluator extends SingleEvaluator {
   override def evaluate(scoresAndLabelsAndWeights: RDD[(Double, Double, Double)]): Double =
     scoresAndLabelsAndWeights
       .map { case (score, label, weight) =>
-        weight * SquaredLossFunction.lossAndDzLoss(score, label)._1
+        // Squared loss function is calculated as (score - label)^2.
+        // lossAndDzLoss uses (score - label)^2 / 2 for mathematical convenience.
+        2 * weight * SquaredLossFunction.lossAndDzLoss(score, label)._1
       }
       .reduce(_ + _)
 }

--- a/photon-client/src/integTest/scala/com/linkedin/photon/ml/cli/game/training/GameTrainingDriverIntegTest.scala
+++ b/photon-client/src/integTest/scala/com/linkedin/photon/ml/cli/game/training/GameTrainingDriverIntegTest.scala
@@ -433,7 +433,7 @@ class GameTrainingDriverIntegTest extends SparkTestUtils with GameTestUtils with
 
     runDriver(args.put(GameTrainingDriver.rootOutputDirectory, outputDir))
 
-    compareModelEvaluation(new Path(outputDir, "best"), trainedMixedModelPath, 0.007)
+    compareModelEvaluation(new Path(outputDir, "best"), trainedMixedModelPath, 0.005)
   }
 
   /**

--- a/photon-client/src/integTest/scala/com/linkedin/photon/ml/cli/game/training/GameTrainingDriverIntegTest.scala
+++ b/photon-client/src/integTest/scala/com/linkedin/photon/ml/cli/game/training/GameTrainingDriverIntegTest.scala
@@ -76,7 +76,7 @@ class GameTrainingDriverIntegTest extends SparkTestUtils with GameTestUtils with
   def testFixedEffectsWithIntercept(): Unit = sparkTest("testFixedEffectsWithIntercept") {
 
     // This is a baseline RMSE capture from an assumed-correct implementation on 01/24/2018
-    val errorThreshold = 1.2
+    val errorThreshold = 1.697
     val outputDir = new Path(getTmpDir, "fixedEffects")
 
     runDriver(
@@ -112,7 +112,7 @@ class GameTrainingDriverIntegTest extends SparkTestUtils with GameTestUtils with
   def testFixedEffectsWithAdditionalOpts(): Unit = sparkTest("testFixedEffectsWithIntercept") {
 
     // This is a baseline RMSE capture from an assumed-correct implementation on 01/24/2018
-    val errorThreshold = 1.2
+    val errorThreshold = 1.697
     val outputDir = new Path(getTmpDir, "fixedEffectsAdditionalOpts")
     val newArgs = fixedEffectSeriousRunArgs
       .copy
@@ -145,7 +145,7 @@ class GameTrainingDriverIntegTest extends SparkTestUtils with GameTestUtils with
   def testFixedEffectsWithoutIntercept(): Unit = sparkTest("testFixedEffectsWithoutIntercept") {
 
     // This is a baseline RMSE capture from an assumed-correct implementation on 01/24/2018
-    val errorThreshold = 1.2
+    val errorThreshold = 1.697
     val outputDir = new Path(getTmpDir, "fixedEffectsNoIntercept")
     val modifiedFeatureShardConfigs = fixedEffectFeatureShardConfigs
       .mapValues(_.copy(hasIntercept = false))
@@ -243,7 +243,7 @@ class GameTrainingDriverIntegTest extends SparkTestUtils with GameTestUtils with
   def testRandomEffectsWithIntercept(): Unit = sparkTest("testRandomEffectsWithIntercept") {
 
     // This is a baseline RMSE capture from an assumed-correct implementation on 01/24/2018
-    val errorThreshold = 2.34
+    val errorThreshold = 3.309
     val outputDir = new Path(getTmpDir, "randomEffects")
 
     runDriver(randomEffectSeriousRunArgs
@@ -269,7 +269,7 @@ class GameTrainingDriverIntegTest extends SparkTestUtils with GameTestUtils with
   def testRandomEffectsWithoutAnyIntercept(): Unit = sparkTest("testRandomEffectsWithoutAnyIntercept") {
 
     // This is a baseline RMSE capture from an assumed-correct implementation on 01/24/2018
-    val errorThreshold = 2.34
+    val errorThreshold = 3.309
     val outputDir = new Path(getTmpDir, "randomEffectsNoIntercept")
     val modifiedFeatureShardConfigs = randomEffectFeatureShardConfigs
       .mapValues(_.copy(hasIntercept = false))
@@ -299,7 +299,7 @@ class GameTrainingDriverIntegTest extends SparkTestUtils with GameTestUtils with
   def testRandomEffectWithNormalization(): Unit = sparkTest("testRandomEffectsWithoutAnyIntercept") {
 
     // This is a baseline RMSE capture from an assumed-correct implementation on 01/24/2018
-    val errorThreshold = 2.34
+    val errorThreshold = 3.309
     val outputDir = new Path(getTmpDir, "randomEffectsNormalization")
     runDriver(
       randomEffectSeriousRunArgs
@@ -325,7 +325,7 @@ class GameTrainingDriverIntegTest extends SparkTestUtils with GameTestUtils with
   def testFixedAndRandomEffects(): Unit = sparkTest("fixedAndRandomEffects") {
 
     // This is a baseline RMSE capture from an assumed-correct implementation on 03/29/2019
-    val errorThreshold = 1.05
+    val errorThreshold = 1.485
     val outputDir = new Path(getTmpDir, "fixedAndRandomEffects")
 
     runDriver(mixedEffectSeriousRunArgs.put(GameTrainingDriver.rootOutputDirectory, outputDir))
@@ -433,7 +433,7 @@ class GameTrainingDriverIntegTest extends SparkTestUtils with GameTestUtils with
 
     runDriver(args.put(GameTrainingDriver.rootOutputDirectory, outputDir))
 
-    compareModelEvaluation(new Path(outputDir, "best"), trainedMixedModelPath, 0.005)
+    compareModelEvaluation(new Path(outputDir, "best"), trainedMixedModelPath, 0.007)
   }
 
   /**


### PR DESCRIPTION
Changes:
1. Add correct calculation of squared loss, which will be used to compute Rooted Mean Squared Error (RMSE) by taking average and squared root. 
2. Multiply the error threshold by sqrt(2) since RMSE calculation has been changed.