### PR TITLE
Add incremental training and related unit tests

### DIFF
--- a/photon-api/src/integTest/scala/com/linkedin/photon/ml/algorithm/CoordinateFactoryIntegTest.scala
+++ b/photon-api/src/integTest/scala/com/linkedin/photon/ml/algorithm/CoordinateFactoryIntegTest.scala
@@ -23,6 +23,7 @@ import com.linkedin.photon.ml.TaskType
 import com.linkedin.photon.ml.Types.REId
 import com.linkedin.photon.ml.data.{FixedEffectDataset, LocalDataset, RandomEffectDataset}
 import com.linkedin.photon.ml.function.{DistributedObjectiveFunction, ObjectiveFunctionHelper, SingleNodeObjectiveFunction}
+import com.linkedin.photon.ml.model.{FixedEffectModel, RandomEffectModel}
 import com.linkedin.photon.ml.normalization.NormalizationContext
 import com.linkedin.photon.ml.optimization.game.{FixedEffectOptimizationConfiguration, RandomEffectOptimizationConfiguration}
 import com.linkedin.photon.ml.optimization.{OptimizerConfig, OptimizerType, SingleNodeOptimizationProblem, VarianceComputationType}
@@ -46,6 +47,7 @@ class CoordinateFactoryIntegTest extends SparkTestUtils {
 
     val mockDataset = mock(classOf[FixedEffectDataset])
     val optimizationConfiguration = FixedEffectOptimizationConfiguration(OPTIMIZER_CONFIG)
+    val priorModelOpt: Option[FixedEffectModel] = None
 
     doReturn(sc).when(mockDataset).sparkContext
 
@@ -57,6 +59,7 @@ class CoordinateFactoryIntegTest extends SparkTestUtils {
       DOWN_SAMPLER_FACTORY,
       MOCK_NORMALIZATION,
       VARIANCE_COMPUTATION_TYPE,
+      priorModelOpt,
       INTERCEPT_INDEX)
 
     coordinate match {
@@ -78,8 +81,10 @@ class CoordinateFactoryIntegTest extends SparkTestUtils {
     val mockProjectorsRDD = mock(classOf[RDD[(REId, LinearSubspaceProjector)]])
     val mockProblemsRDD = mock(classOf[RDD[(REId, SingleNodeOptimizationProblem[SingleNodeObjectiveFunction])]])
     val optimizationConfiguration = RandomEffectOptimizationConfiguration(OPTIMIZER_CONFIG)
+    val priorModelOpt: Option[RandomEffectModel] = None
 
     doReturn(sc).when(mockDataset).sparkContext
+    doReturn(sc).when(mockProjectorsRDD).sparkContext
     doReturn(mockDataRDD).when(mockDataset).activeData
     doReturn(mockDataRDD)
       .when(mockDataRDD)
@@ -97,6 +102,7 @@ class CoordinateFactoryIntegTest extends SparkTestUtils {
       DOWN_SAMPLER_FACTORY,
       MOCK_NORMALIZATION,
       VARIANCE_COMPUTATION_TYPE,
+      priorModelOpt,
       INTERCEPT_INDEX)
 
     coordinate match {
@@ -124,6 +130,7 @@ class CoordinateFactoryIntegTest extends SparkTestUtils {
       DOWN_SAMPLER_FACTORY,
       MOCK_NORMALIZATION,
       VARIANCE_COMPUTATION_TYPE,
+      None,
       INTERCEPT_INDEX)
   }
 }
@@ -139,7 +146,7 @@ object CoordinateFactoryIntegTest {
   private val INTERCEPT_INDEX = None
 
   private val OPTIMIZER_CONFIG = OptimizerConfig(OPTIMIZER_TYPE, MAX_ITER, TOLERANCE)
-  private val MOCK_NORMALIZATION = mock(classOf[NormalizationContext])
+  private val MOCK_NORMALIZATION = mock(classOf[NormalizationContext], withSettings().serializable())
   private val GLM_CONSTRUCTOR = LogisticRegressionModel.apply _
   private val LOSS_FUNCTION_FACTORY = ObjectiveFunctionHelper.buildFactory(TRAINING_TASK, TREE_AGGREGATE_DEPTH)
   private val DOWN_SAMPLER_FACTORY = DownSamplerHelper.buildFactory(TRAINING_TASK)

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/algorithm/RandomEffectCoordinate.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/algorithm/RandomEffectCoordinate.scala
@@ -264,7 +264,7 @@ object RandomEffectCoordinate {
             case _ =>
               throw new IllegalStateException("Either a initial random effect model or data should be present!")
           }
-        modelsAndTrackers.persist(StorageLevel.MEMORY_AND_DISK_SER)
+        modelsAndTrackers.persist(StorageLevel.MEMORY_ONLY_SER)
 
         val models = modelsAndTrackers.mapValues(_._1)
         val optimizationTracker = RandomEffectOptimizationTracker(modelsAndTrackers.flatMap(_._2._2))
@@ -279,7 +279,7 @@ object RandomEffectCoordinate {
 
           (newModel, stateTrackers)
         }
-        modelsAndTrackers.persist(StorageLevel.MEMORY_AND_DISK_SER)
+        modelsAndTrackers.persist(StorageLevel.MEMORY_ONLY_SER)
 
         val models = modelsAndTrackers.mapValues(_._1)
         val optimizationTracker = RandomEffectOptimizationTracker(modelsAndTrackers.map(_._2._2))

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/estimators/GameEstimator.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/estimators/GameEstimator.scala
@@ -254,7 +254,11 @@ class GameEstimator(val sc: SparkContext, implicit val logger: Logger) extends P
       !ignoreThreshold || initialModelOpt.isDefined,
       "'Ignore threshold for new models' flag set but no initial model provided for warm-start")
 
-    // Warm-start, partial re-training, and incremental training are mutually exclusive.
+    // Warm-start, partial re-training, and incremental training require the same initial GAME model to be provided as
+    // input. Partial re-training requires some coordinates to be locked. These locked coordinates and the coordinates
+    // to be trained are mutually exclusive. For those coordinates to be trained, warm start will be enabled if any
+    // initial model is present. Moreover, if incremental training is enabled, this initial model will be used to
+    // construct a prior distribution.
     val coordinatesToTrain = (isIncrementalTraining, lockedModelCoordsOpt, initialModelOpt) match {
       case (true, None, None) =>
         throw new InvalidParameterException(s"'${incrementalTraining.name}' is enabled but no initial model provided.")

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/function/ObjectiveFunctionHelper.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/function/ObjectiveFunctionHelper.scala
@@ -20,15 +20,16 @@ import com.linkedin.photon.ml.algorithm.Coordinate
 import com.linkedin.photon.ml.function.glm.{GLMLossFunction, LogisticLossFunction, PoissonLossFunction, SquaredLossFunction}
 import com.linkedin.photon.ml.function.svm.SmoothedHingeLossFunction
 import com.linkedin.photon.ml.optimization.game.CoordinateOptimizationConfiguration
+import com.linkedin.photon.ml.supervised.model.GeneralizedLinearModel
 
 /**
  * Helper for [[ObjectiveFunction]] related tasks.
  */
 object ObjectiveFunctionHelper {
 
-  type ObjectiveFunctionFactoryFactory = CoordinateOptimizationConfiguration => Option[Int] => ObjectiveFunction
-  type DistributedObjectiveFunctionFactory = Option[Int] => DistributedObjectiveFunction
-  type SingleNodeObjectiveFunctionFactory = Option[Int] => SingleNodeObjectiveFunction
+  type ObjectiveFunctionFactoryFactory = CoordinateOptimizationConfiguration => (Option[GeneralizedLinearModel], Option[Int]) => ObjectiveFunction
+  type DistributedObjectiveFunctionFactory = (Option[GeneralizedLinearModel], Option[Int]) => DistributedObjectiveFunction
+  type SingleNodeObjectiveFunctionFactory = (Option[GeneralizedLinearModel], Option[Int]) => SingleNodeObjectiveFunction
 
   /**
    * Construct a factory function for building [[ObjectiveFunction]] objects.

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/function/glm/GLMLossFunction.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/function/glm/GLMLossFunction.scala
@@ -17,6 +17,7 @@ package com.linkedin.photon.ml.function.glm
 import com.linkedin.photon.ml.algorithm.Coordinate
 import com.linkedin.photon.ml.function.ObjectiveFunction
 import com.linkedin.photon.ml.optimization.game.{CoordinateOptimizationConfiguration, FixedEffectOptimizationConfiguration, RandomEffectOptimizationConfiguration}
+import com.linkedin.photon.ml.supervised.model.GeneralizedLinearModel
 
 /**
  * Helper for generalized linear model loss function related tasks.
@@ -28,21 +29,32 @@ object GLMLossFunction {
    *
    * @param lossFunction A [[PointwiseLossFunction]] for training a generalized linear model
    * @param treeAggregateDepth The tree-aggregate depth to use during aggregation
+   * @param config Optimization problem configuration
+   * @param isIncrementalTraining Is this an objective function for incremental training?
    * @return A function which builds the appropriate type of [[ObjectiveFunction]] for a given [[Coordinate]] type and
    *         optimization settings.
    */
-  def buildFactory
-      (lossFunction: PointwiseLossFunction, treeAggregateDepth: Int)
-      (config: CoordinateOptimizationConfiguration): Option[Int] => ObjectiveFunction =
-
+  def buildFactory(
+      lossFunction: PointwiseLossFunction,
+      treeAggregateDepth: Int)(
+      config: CoordinateOptimizationConfiguration): (Option[GeneralizedLinearModel], Option[Int]) => ObjectiveFunction =
     config match {
       case fEOptConfig: FixedEffectOptimizationConfiguration =>
-        (interceptIndexOpt: Option[Int]) =>
-          DistributedGLMLossFunction(fEOptConfig, lossFunction, treeAggregateDepth, interceptIndexOpt)
+        (generalizedLinearModelOpt: Option[GeneralizedLinearModel], interceptIndexOpt: Option[Int]) =>
+          DistributedGLMLossFunction(
+            fEOptConfig,
+            lossFunction,
+            treeAggregateDepth,
+            generalizedLinearModelOpt,
+            interceptIndexOpt)
 
       case rEOptConfig: RandomEffectOptimizationConfiguration =>
-        (interceptIndexOpt: Option[Int]) =>
-          SingleNodeGLMLossFunction(rEOptConfig, lossFunction, interceptIndexOpt)
+        (generalizedLinearModelOpt: Option[GeneralizedLinearModel], interceptIndexOpt: Option[Int]) =>
+          SingleNodeGLMLossFunction(
+            rEOptConfig,
+            lossFunction,
+            generalizedLinearModelOpt,
+            interceptIndexOpt)
 
       case _ =>
         throw new UnsupportedOperationException(

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/function/svm/SmoothedHingeLossFunction.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/function/svm/SmoothedHingeLossFunction.scala
@@ -21,6 +21,7 @@ import com.linkedin.photon.ml.constants.MathConst
 import com.linkedin.photon.ml.data.LabeledPoint
 import com.linkedin.photon.ml.function.ObjectiveFunction
 import com.linkedin.photon.ml.optimization.game.{CoordinateOptimizationConfiguration, FixedEffectOptimizationConfiguration, RandomEffectOptimizationConfiguration}
+import com.linkedin.photon.ml.supervised.model.GeneralizedLinearModel
 
 /**
  * Implement Rennie's smoothed hinge loss function (http://qwone.com/~jason/writing/smoothHinge.pdf) as an
@@ -91,20 +92,20 @@ object SmoothedHingeLossFunction {
    * Construct a factory function for building distributed and non-distributed smoothed hinge loss functions.
    *
    * @param treeAggregateDepth The tree-aggregate depth to use during aggregation
+   * @param config Optimization problem configuration
    * @return A function which builds the appropriate type of [[ObjectiveFunction]] for a given [[Coordinate]] type and
    *         optimization settings.
    */
-  def buildFactory
-      (treeAggregateDepth: Int)
-      (config: CoordinateOptimizationConfiguration): Option[Int] => ObjectiveFunction =
-
+  def buildFactory(
+      treeAggregateDepth: Int)(
+      config: CoordinateOptimizationConfiguration): (Option[GeneralizedLinearModel], Option[Int]) => ObjectiveFunction =
     config match {
       case fEOptConfig: FixedEffectOptimizationConfiguration =>
-        (interceptIndexOpt: Option[Int]) =>
+        (_: Option[GeneralizedLinearModel], _: Option[Int]) =>
           DistributedSmoothedHingeLossFunction(fEOptConfig, treeAggregateDepth)
 
       case rEOptConfig: RandomEffectOptimizationConfiguration =>
-        (interceptIndexOpt: Option[Int]) =>
+        (_: Option[GeneralizedLinearModel], _: Option[Int]) =>
           SingleNodeSmoothedHingeLossFunction(rEOptConfig)
 
       case _ =>

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/optimization/DistributedOptimizationProblem.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/optimization/DistributedOptimizationProblem.scala
@@ -28,7 +28,7 @@ import com.linkedin.photon.ml.optimization.VarianceComputationType.VarianceCompu
 import com.linkedin.photon.ml.optimization.game.GLMOptimizationConfiguration
 import com.linkedin.photon.ml.sampling.DownSampler
 import com.linkedin.photon.ml.supervised.model.GeneralizedLinearModel
-import com.linkedin.photon.ml.util.BroadcastWrapper
+import com.linkedin.photon.ml.util.{BroadcastWrapper, VectorUtils}
 import com.linkedin.photon.ml.util.Linalg.choleskyInverse
 
 /**
@@ -43,7 +43,7 @@ import com.linkedin.photon.ml.util.Linalg.choleskyInverse
  * @param regularizationContext The regularization context
  * @param varianceComputation If an how to compute coefficient variances
  */
-protected[ml] class DistributedOptimizationProblem[Objective <: DistributedObjectiveFunction] protected[optimization] (
+protected[ml] class DistributedOptimizationProblem[Objective <: DistributedObjectiveFunction] protected[optimization](
     optimizer: Optimizer[Objective],
     objectiveFunction: Objective,
     samplerOption: Option[DownSampler],
@@ -62,11 +62,13 @@ protected[ml] class DistributedOptimizationProblem[Objective <: DistributedObjec
    * @param regularizationWeight The new regularization weight
    */
   def updateRegularizationWeight(regularizationWeight: Double): Unit = {
+
     optimizer match {
       case owlqn: OWLQN =>
         owlqn.l1RegularizationWeight = regularizationContext.getL1RegularizationWeight(regularizationWeight)
       case _ =>
     }
+
     objectiveFunction match {
       case l2RegFunc: DistributedObjectiveFunction with L2Regularization =>
         l2RegFunc.l2RegularizationWeight = regularizationContext.getL2RegularizationWeight(regularizationWeight)
@@ -85,10 +87,7 @@ protected[ml] class DistributedOptimizationProblem[Objective <: DistributedObjec
 
     val result = (objectiveFunction, varianceComputation) match {
       case (twiceDiffFunc: TwiceDiffFunction, VarianceComputationType.SIMPLE) =>
-        Some(
-          twiceDiffFunc
-            .hessianDiagonal(input, coefficients)
-            .map(v => 1.0 / math.max(v, MathConst.EPSILON)))
+        Some(VectorUtils.invertVectorWithZeroHandler(twiceDiffFunc.hessianDiagonal(input, coefficients), 1.0 / MathConst.EPSILON))
 
       case (twiceDiffFunc: TwiceDiffFunction, VarianceComputationType.FULL) =>
         val hessianMatrix = twiceDiffFunc.hessianMatrix(input, coefficients)

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/optimization/SingleNodeOptimizationProblem.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/optimization/SingleNodeOptimizationProblem.scala
@@ -24,7 +24,7 @@ import com.linkedin.photon.ml.normalization.NormalizationContext
 import com.linkedin.photon.ml.optimization.VarianceComputationType.VarianceComputationType
 import com.linkedin.photon.ml.optimization.game.GLMOptimizationConfiguration
 import com.linkedin.photon.ml.supervised.model.GeneralizedLinearModel
-import com.linkedin.photon.ml.util.BroadcastWrapper
+import com.linkedin.photon.ml.util.{BroadcastWrapper, VectorUtils}
 import com.linkedin.photon.ml.util.Linalg.choleskyInverse
 
 /**
@@ -37,7 +37,7 @@ import com.linkedin.photon.ml.util.Linalg.choleskyInverse
  * @param glmConstructor The function to use for producing GLMs from trained coefficients
  * @param varianceComputationType If an how to compute coefficient variances
  */
-protected[ml] class SingleNodeOptimizationProblem[Objective <: SingleNodeObjectiveFunction] protected[optimization] (
+protected[ml] class SingleNodeOptimizationProblem[Objective <: SingleNodeObjectiveFunction] protected[optimization](
     optimizer: Optimizer[Objective],
     objectiveFunction: Objective,
     glmConstructor: Coefficients => GeneralizedLinearModel,
@@ -59,9 +59,7 @@ protected[ml] class SingleNodeOptimizationProblem[Objective <: SingleNodeObjecti
   override def computeVariances(input: Iterable[LabeledPoint], coefficients: Vector[Double]): Option[Vector[Double]] =
     (objectiveFunction, varianceComputationType) match {
       case (twiceDiffFunc: TwiceDiffFunction, VarianceComputationType.SIMPLE) =>
-        Some(twiceDiffFunc
-          .hessianDiagonal(input, coefficients)
-          .map(v => 1.0 / math.max(v, MathConst.EPSILON)))
+        Some(VectorUtils.invertVectorWithZeroHandler(twiceDiffFunc.hessianDiagonal(input, coefficients), 1.0 / MathConst.EPSILON))
 
       case (twiceDiffFunc: TwiceDiffFunction, VarianceComputationType.FULL) =>
         val hessianMatrix = twiceDiffFunc.hessianMatrix(input, coefficients)

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/optimization/game/RandomEffectOptimizationProblem.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/optimization/game/RandomEffectOptimizationProblem.scala
@@ -20,10 +20,10 @@ import org.apache.spark.storage.StorageLevel
 
 import com.linkedin.photon.ml.Types.REId
 import com.linkedin.photon.ml.function.SingleNodeObjectiveFunction
-import com.linkedin.photon.ml.model.Coefficients
+import com.linkedin.photon.ml.model.{Coefficients, RandomEffectModel}
 import com.linkedin.photon.ml.normalization.NormalizationContext
-import com.linkedin.photon.ml.optimization.{SingleNodeOptimizationProblem, VarianceComputationType}
 import com.linkedin.photon.ml.optimization.VarianceComputationType.VarianceComputationType
+import com.linkedin.photon.ml.optimization.{SingleNodeOptimizationProblem, VarianceComputationType}
 import com.linkedin.photon.ml.projector.LinearSubspaceProjector
 import com.linkedin.photon.ml.spark.RDDLike
 import com.linkedin.photon.ml.supervised.model.GeneralizedLinearModel
@@ -120,34 +120,43 @@ protected[ml] class RandomEffectOptimizationProblem[Objective <: SingleNodeObjec
 object RandomEffectOptimizationProblem {
 
   /**
-   * Build a new [[RandomEffectOptimizationProblem]].
+   * Build a new [[RandomEffectOptimizationProblem]] to optimize.
    *
    * @tparam RandomEffectObjective The type of objective function used to solve individual random effect optimization
    *                               problems
    * @param linearSubspaceProjectorsRDD The per-entity [[LinearSubspaceProjector]] objects used to compress the
    *                                    per-entity feature spaces
    * @param configuration The optimization problem configuration
-   * @param objectiveFunctionFactory The objective function to optimize
+   * @param objectiveFunctionFactory Factory for the objective function
    * @param glmConstructor The function to use for producing GLMs from trained coefficients
    * @param normalizationContext The normalization context
    * @param varianceComputationType If and how coefficient variances should be computed
    * @param interceptIndexOpt The option of intercept index
-   * @return A new [[RandomEffectOptimizationProblem]] object
+   * @return A new [[RandomEffectOptimizationProblem]]
    */
-  def apply[RandomEffectObjective <: SingleNodeObjectiveFunction](
+  protected[ml] def apply[RandomEffectObjective <: SingleNodeObjectiveFunction](
       linearSubspaceProjectorsRDD: RDD[(REId, LinearSubspaceProjector)],
       configuration: RandomEffectOptimizationConfiguration,
-      objectiveFunctionFactory: Option[Int] => RandomEffectObjective,
+      objectiveFunctionFactory: (Option[GeneralizedLinearModel], Option[Int]) => RandomEffectObjective,
+      priorRandomEffectModelOpt: Option[RandomEffectModel],
       glmConstructor: Coefficients => GeneralizedLinearModel,
       normalizationContext: NormalizationContext,
       varianceComputationType: VarianceComputationType = VarianceComputationType.NONE,
       interceptIndexOpt: Option[Int]): RandomEffectOptimizationProblem[RandomEffectObjective] = {
 
+    val sc = linearSubspaceProjectorsRDD.sparkContext
+    val configurationBroadcast = sc.broadcast(configuration)
+    val objectiveFunctionBuilderBroadcast = sc.broadcast(objectiveFunctionFactory)
+    val glmConstructorBroadcast = sc.broadcast(glmConstructor)
+    val normalizationContextBroadcast = sc.broadcast(normalizationContext)
+
     // Generate new NormalizationContext and SingleNodeOptimizationProblem objects
     val optimizationProblems = linearSubspaceProjectorsRDD
-      .mapValues { projector =>
-        val factors = normalizationContext.factorsOpt.map(factors => projector.projectForward(factors))
-        val shiftsAndIntercept = normalizationContext
+      .leftOuterJoin(priorRandomEffectModelOpt.map(_.modelsRDD).getOrElse(sc.emptyRDD[(REId, GeneralizedLinearModel)]))
+      .mapValues { case (projector: LinearSubspaceProjector, priorModelOpt: Option[GeneralizedLinearModel]) =>
+        val normContext = normalizationContextBroadcast.value
+        val factors = normContext.factorsOpt.map(factors => projector.projectForward(factors))
+        val shiftsAndIntercept = normContext
           .shiftsAndInterceptOpt
           .map { case (shifts, intercept) =>
             val newShifts = projector.projectForward(shifts)
@@ -156,18 +165,34 @@ object RandomEffectOptimizationProblem {
             (newShifts, newIntercept)
           }
         val projectedNormalizationContext = new NormalizationContext(factors, shiftsAndIntercept)
+        val objectiveFunctionBuilder = objectiveFunctionBuilderBroadcast.value
         val projectedInterceptOpt = interceptIndexOpt.map { interceptIndex =>
           projector.originalToProjectedSpaceMap(interceptIndex)
         }
 
-        // TODO: Broadcast arguments to SingleNodeOptimizationProblem?
+        // Project prior model coefficients
+        val projectedPriorModelOpt = priorModelOpt.map{
+          model =>
+            val oldCoefficients = model.coefficients
+            val newCoefficients = Coefficients(
+              projector.projectForward(oldCoefficients.means),
+              oldCoefficients.variancesOption.map(projector.projectForward))
+
+            model.updateCoefficients(newCoefficients)
+        }
+
         SingleNodeOptimizationProblem(
-          configuration,
-          objectiveFunctionFactory(projectedInterceptOpt),
-          glmConstructor,
+          configurationBroadcast.value,
+          objectiveFunctionBuilder(projectedPriorModelOpt, projectedInterceptOpt),
+          glmConstructorBroadcast.value,
           PhotonNonBroadcast(projectedNormalizationContext),
           varianceComputationType)
       }
+
+    configurationBroadcast.unpersist()
+    objectiveFunctionBuilderBroadcast.unpersist()
+    glmConstructorBroadcast.unpersist()
+    normalizationContextBroadcast.unpersist()
 
     new RandomEffectOptimizationProblem(optimizationProblems, glmConstructor)
   }

--- a/photon-api/src/test/scala/com/linkedin/photon/ml/function/ObjectiveFunctionHelperTest.scala
+++ b/photon-api/src/test/scala/com/linkedin/photon/ml/function/ObjectiveFunctionHelperTest.scala
@@ -23,6 +23,7 @@ import com.linkedin.photon.ml.function.glm.DistributedGLMLossFunction
 import com.linkedin.photon.ml.function.svm.DistributedSmoothedHingeLossFunction
 import com.linkedin.photon.ml.optimization.game.FixedEffectOptimizationConfiguration
 import com.linkedin.photon.ml.optimization.{OptimizerConfig, OptimizerType}
+import com.linkedin.photon.ml.supervised.model.GeneralizedLinearModel
 
 /**
  * Unit tests for [[ObjectiveFunctionHelper]].
@@ -48,15 +49,19 @@ class ObjectiveFunctionHelperTest {
   @Test(dataProvider = "trainingTaskProvider")
   def testBuildFactory(trainingTask: TaskType): Unit = {
 
-    val objectiveFunction =
-      ObjectiveFunctionHelper.buildFactory(trainingTask, TREE_AGGREGATE_DEPTH)(COORDINATE_OPT_CONFIG)
+    val objectiveFunction = ObjectiveFunctionHelper.buildFactory(
+      trainingTask,
+      TREE_AGGREGATE_DEPTH)(COORDINATE_OPT_CONFIG)
 
     trainingTask match {
       case TaskType.LOGISTIC_REGRESSION | TaskType.LINEAR_REGRESSION | TaskType.POISSON_REGRESSION =>
-        assertTrue(objectiveFunction.isInstanceOf[Option[Int] => DistributedGLMLossFunction])
+        assertTrue(
+          objectiveFunction.isInstanceOf[(Option[GeneralizedLinearModel], Option[Int]) => DistributedGLMLossFunction])
 
       case TaskType.SMOOTHED_HINGE_LOSS_LINEAR_SVM =>
-        assertTrue(objectiveFunction.isInstanceOf[Option[Int] => DistributedSmoothedHingeLossFunction])
+        assertTrue(
+          objectiveFunction
+            .isInstanceOf[(Option[GeneralizedLinearModel], Option[Int]) => DistributedSmoothedHingeLossFunction])
     }
   }
 }
@@ -64,6 +69,7 @@ class ObjectiveFunctionHelperTest {
 object ObjectiveFunctionHelperTest {
 
   val COORDINATE_OPT_CONFIG = FixedEffectOptimizationConfiguration(OptimizerConfig(OptimizerType.LBFGS, 1, 2e-2))
+  val ENABLE_INCREMENTAL_TRAINING = false
   val MAXIMUM_ITERATIONS = 1
   val TOLERANCE = 2e-2
   val TREE_AGGREGATE_DEPTH = 3

--- a/photon-api/src/test/scala/com/linkedin/photon/ml/function/glm/GLMLossFunctionTest.scala
+++ b/photon-api/src/test/scala/com/linkedin/photon/ml/function/glm/GLMLossFunctionTest.scala
@@ -20,6 +20,7 @@ import org.testng.annotations.{DataProvider, Test}
 import com.linkedin.photon.ml.function.ObjectiveFunction
 import com.linkedin.photon.ml.optimization.{OptimizerConfig, OptimizerType}
 import com.linkedin.photon.ml.optimization.game.{CoordinateOptimizationConfiguration, FixedEffectOptimizationConfiguration, RandomEffectOptimizationConfiguration}
+import com.linkedin.photon.ml.supervised.model.GeneralizedLinearModel
 
 /**
  * Unit tests for [[GLMLossFunction]].
@@ -47,15 +48,16 @@ class GLMLossFunctionTest {
   @Test(dataProvider = "coordinateOptimizationProblemProvider")
   def testBuildFactory(coordinateOptConfig: CoordinateOptimizationConfiguration): Unit = {
 
-    val objectiveFunction =
-      GLMLossFunction.buildFactory(LOSS_FUNCTION, TREE_AGGREGATE_DEPTH)(coordinateOptConfig)
+    val objectiveFunction = GLMLossFunction.buildFactory(LOSS_FUNCTION, TREE_AGGREGATE_DEPTH)(coordinateOptConfig)
 
     coordinateOptConfig match {
       case _: FixedEffectOptimizationConfiguration =>
-        assertTrue(objectiveFunction.isInstanceOf[Option[Int] => DistributedGLMLossFunction])
+        assertTrue(
+          objectiveFunction.isInstanceOf[(Option[GeneralizedLinearModel], Option[Int]) => DistributedGLMLossFunction])
 
       case _: RandomEffectOptimizationConfiguration =>
-        assertTrue(objectiveFunction.isInstanceOf[Option[Int] => SingleNodeGLMLossFunction])
+        assertTrue(
+          objectiveFunction.isInstanceOf[(Option[GeneralizedLinearModel], Option[Int]) => SingleNodeGLMLossFunction])
 
       case _ =>
         assertTrue(false)

--- a/photon-api/src/test/scala/com/linkedin/photon/ml/function/svm/SmoothedHingeLossFunctionTest.scala
+++ b/photon-api/src/test/scala/com/linkedin/photon/ml/function/svm/SmoothedHingeLossFunctionTest.scala
@@ -20,6 +20,7 @@ import org.testng.annotations.{DataProvider, Test}
 import com.linkedin.photon.ml.function.ObjectiveFunction
 import com.linkedin.photon.ml.optimization.{OptimizerConfig, OptimizerType}
 import com.linkedin.photon.ml.optimization.game.{CoordinateOptimizationConfiguration, FixedEffectOptimizationConfiguration, RandomEffectOptimizationConfiguration}
+import com.linkedin.photon.ml.supervised.model.GeneralizedLinearModel
 
 /**
  * Unit tests for [[SmoothedHingeLossFunction]].
@@ -51,10 +52,14 @@ class SmoothedHingeLossFunctionTest {
 
     coordinateOptConfig match {
       case _: FixedEffectOptimizationConfiguration =>
-        assertTrue(objectiveFunctionFactory.isInstanceOf[Option[Int] => DistributedSmoothedHingeLossFunction])
+        assertTrue(
+          objectiveFunctionFactory
+            .isInstanceOf[(Option[GeneralizedLinearModel], Option[Int]) => DistributedSmoothedHingeLossFunction])
 
       case _: RandomEffectOptimizationConfiguration =>
-        assertTrue(objectiveFunctionFactory.isInstanceOf[Option[Int] => SingleNodeSmoothedHingeLossFunction])
+        assertTrue(
+          objectiveFunctionFactory
+            .isInstanceOf[(Option[GeneralizedLinearModel], Option[Int]) => SingleNodeSmoothedHingeLossFunction])
 
       case _ =>
         assertTrue(false)

--- a/photon-api/src/test/scala/com/linkedin/photon/ml/optimization/game/CoordinateOptimizationConfigurationTest.scala
+++ b/photon-api/src/test/scala/com/linkedin/photon/ml/optimization/game/CoordinateOptimizationConfigurationTest.scala
@@ -24,12 +24,13 @@ class CoordinateOptimizationConfigurationTest {
 
   @DataProvider
   def invalidInput(): Array[Array[Any]] = Array(
-    Array(-1D, 1D, None, None),
-    Array(1D, -1D, None, None),
-    Array(1D, 0D, None, None),
-    Array(1D, 2D, None, None),
-    Array(1D, 1D, Some(DoubleRange(-1D, 10D)), None),
-    Array(1D, 1D, None, Some(DoubleRange(0D, 1.1))))
+    Array(-1D, 1D, None, None, None),
+    Array(1D, -1D, None, None, None),
+    Array(1D, 0D, None, None, None),
+    Array(1D, 2D, None, None, None),
+    Array(1D, 1D, Some(DoubleRange(-1D, 10D)), None, None),
+    Array(1D, 1D, None, Some(DoubleRange(0D, 1.1)), None),
+    Array(-1D, 1D, None, None, Some(-1D)))
 
   /**
    * Test that [[FixedEffectOptimizationConfiguration]] will reject invalid input.
@@ -42,7 +43,8 @@ class CoordinateOptimizationConfigurationTest {
       regularizationWeight: Double,
       downSamplingRate: Double,
       regularizationWeightRange: Option[DoubleRange],
-      elasticNetParamRange: Option[DoubleRange]): Unit = {
+      elasticNetParamRange: Option[DoubleRange],
+      incrementalWeight: Option[Double]): Unit = {
 
     val mockOptimizerConfig = mock(classOf[OptimizerConfig])
     val mockRegularizationContext = mock(classOf[RegularizationContext])
@@ -53,6 +55,7 @@ class CoordinateOptimizationConfigurationTest {
       regularizationWeight,
       regularizationWeightRange,
       elasticNetParamRange,
+      incrementalWeight,
       downSamplingRate)
   }
 }

--- a/photon-api/src/test/scala/com/linkedin/photon/ml/util/GameTestUtils.scala
+++ b/photon-api/src/test/scala/com/linkedin/photon/ml/util/GameTestUtils.scala
@@ -314,7 +314,7 @@ trait GameTestUtils extends SparkTestUtils {
       seed)
 
     val optimizationProblem = generateRandomEffectOptimizationProblem(randomEffectDataset)
-    val coordinate = new RandomEffectCoordinate[SingleNodeGLMLossFunction](randomEffectDataset, optimizationProblem)
+    val coordinate = new RandomEffectCoordinate(randomEffectDataset, optimizationProblem)
     val models = sc.parallelize(generateLinearModelsForRandomEffects(randomEffectIds, dimensions))
     val model = new RandomEffectModel(
       models,

--- a/photon-client/src/main/scala/com/linkedin/photon/ml/data/avro/AvroUtils.scala
+++ b/photon-client/src/main/scala/com/linkedin/photon/ml/data/avro/AvroUtils.scala
@@ -68,7 +68,7 @@ object AvroUtils {
 
     val minPartitionsPerPath = math.ceil(1.0 * minPartitions / inputPaths.length).toInt
 
-    sc.union(inputPaths.map { path => readAvroFilesInDir[GenericRecord](sc, path, minPartitionsPerPath) } )
+    sc.union(inputPaths.map { path => readAvroFilesInDir[GenericRecord](sc, path, minPartitionsPerPath) })
   }
 
   /**
@@ -251,8 +251,10 @@ object AvroUtils {
    * @return The nameAndTerm parsed from the Avro record
    */
   protected[avro] def readNameAndTermFromGenericRecord(record: GenericRecord): NameAndTerm = {
+
     val name = Utils.getStringAvro(record, AvroFieldNames.NAME)
     val term = Utils.getStringAvro(record, AvroFieldNames.TERM, isNullOK = true)
+
     NameAndTerm(name, term)
   }
 
@@ -269,6 +271,7 @@ object AvroUtils {
     genericRecords
       .flatMap {
         _.get(featureSectionKey) match {
+
           case recordList: JList[_] =>
             recordList.asScala.map {
               case record: GenericRecord =>
@@ -278,8 +281,8 @@ object AvroUtils {
                 throw new IllegalArgumentException(
                   s"$any in features list is not a record. It needs to be an Avro record containingg a name and term for " +
                     s"each feature.")
-
             }
+
           case _ =>
             throw new IllegalArgumentException(
               s"$featureSectionKey is not a list (and might be null). It needs to be a list of Avro records containing a " +
@@ -364,26 +367,16 @@ object AvroUtils {
       featureMap: IndexMap): GeneralizedLinearModel = {
 
     val meansAvros = bayesianLinearModelAvro.getMeans
+    val variancesAvros = bayesianLinearModelAvro.getVariances
     val modelClass = bayesianLinearModelAvro.getModelClass.toString
-    val indexAndValueArrayBuffer = new mutable.ArrayBuffer[(Int, Double)]
 
-    val iterator = meansAvros.iterator()
-    while (iterator.hasNext) {
-      val feature = iterator.next()
-      val name = feature.getName.toString
-      val term = feature.getTerm.toString
-      val featureKey = Utils.getFeatureKey(name, term)
-      if (featureMap.contains(featureKey)) {
-        val value = feature.getValue
-        val index = featureMap.getOrElse(featureKey,
-          throw new NoSuchElementException(s"nameAndTerm $featureKey not found in the feature map"))
-        indexAndValueArrayBuffer += ((index, value))
-      }
+    val means = convertNameTermValueAvroList(meansAvros, featureMap)
+    val coefficients = if (variancesAvros == null) {
+      Coefficients(means)
+    } else {
+      val variances = convertNameTermValueAvroList(variancesAvros, featureMap)
+      Coefficients(means, Some(variances))
     }
-
-    val length = featureMap.featureDimension
-    val coefficients = Coefficients(
-      VectorUtils.toVector(indexAndValueArrayBuffer.toArray, length))
 
     // Load and instantiate the model
     try {
@@ -397,6 +390,36 @@ object AvroUtils {
         throw new IllegalArgumentException(
           s"Error loading model: model class $modelClass couldn't be loaded. You may need to retrain the model.", e)
     }
+  }
+
+  /**
+   * Convert the NameTermValueAvro List of the type [[JList[NameTermValue]]] to Breeze vector of type [[Vector[Double]]].
+   *
+   * @param nameTermValueAvroList List of the type [[JList[NameTermValue]]]
+   * @param featureMap The map from feature name of type [[NameAndTerm]] to feature index of type [[Int]]
+   * @return Breeze vector of type [[Vector[Double]]]
+   */
+  protected[avro] def convertNameTermValueAvroList(
+      nameTermValueAvroList: JList[NameTermValueAvro],
+      featureMap: IndexMap): Vector[Double] = {
+
+    val iterator = nameTermValueAvroList.iterator()
+    val indexAndValueArrayBuffer = new mutable.ArrayBuffer[(Int, Double)]
+    val length = featureMap.featureDimension
+
+    while (iterator.hasNext) {
+      val feature = iterator.next()
+      val name = feature.getName.toString
+      val term = feature.getTerm.toString
+      val featureKey = Utils.getFeatureKey(name, term)
+      if (featureMap.contains(featureKey)) {
+        val value = feature.getValue
+        val index = featureMap.getOrElse(featureKey,
+          throw new NoSuchElementException(s"nameAndTerm $featureKey not found in the feature map"))
+        indexAndValueArrayBuffer += ((index, value))
+      }
+    }
+    VectorUtils.toVector(indexAndValueArrayBuffer.toArray, length)
   }
 
   /**

--- a/photon-client/src/main/scala/com/linkedin/photon/ml/data/avro/ModelProcessingUtils.scala
+++ b/photon-client/src/main/scala/com/linkedin/photon/ml/data/avro/ModelProcessingUtils.scala
@@ -323,8 +323,6 @@ object ModelProcessingUtils {
   /**
    * Load a single GLM from HDFS.
    *
-   * TODO: Currently only the means of the coefficients are loaded, the variances are discarded
-   *
    * @param inputDir The directory from which to load the model
    * @param indexMap A feature to index map
    * @param sc The Spark Context

--- a/photon-client/src/main/scala/com/linkedin/photon/ml/io/scopt/ScoptParserHelpers.scala
+++ b/photon-client/src/main/scala/com/linkedin/photon/ml/io/scopt/ScoptParserHelpers.scala
@@ -71,6 +71,7 @@ object ScoptParserHelpers extends Logging {
   val COORDINATE_OPT_CONFIG_REG_ALPHA_RANGE = "reg.alpha.range"
   val COORDINATE_OPT_CONFIG_REG_WEIGHTS = "reg.weights"
   val COORDINATE_OPT_CONFIG_REG_WEIGHT_RANGE = "reg.weight.range"
+  val COORDINATE_OPT_CONFIG_INCREMENTAL_WEIGHT = "incremental.weight"
   val COORDINATE_OPT_CONFIG_DOWN_SAMPLING_RATE = "down.sampling.rate"
 
   val COORDINATE_CONFIG_REQUIRED_ARGS = Map(
@@ -87,7 +88,8 @@ object ScoptParserHelpers extends Logging {
     (COORDINATE_OPT_CONFIG_REG_ALPHA, "<value>"),
     (COORDINATE_OPT_CONFIG_REG_ALPHA_RANGE, "<start>-<end>"),
     (COORDINATE_OPT_CONFIG_REG_WEIGHTS, "<list of values>"),
-    (COORDINATE_OPT_CONFIG_REG_WEIGHT_RANGE, "<start>-<end>"))
+    (COORDINATE_OPT_CONFIG_REG_WEIGHT_RANGE, "<start>-<end>"),
+    (COORDINATE_OPT_CONFIG_INCREMENTAL_WEIGHT, "<value>"))
   val COORDINATE_CONFIG_FIXED_EFFECT_OPTIONAL_ARGS = Map(
     (COORDINATE_OPT_CONFIG_DOWN_SAMPLING_RATE, "<value>"))
   val COORDINATE_CONFIG_RANDOM_EFFECT_OPTIONAL_ARGS = Map(
@@ -226,6 +228,8 @@ object ScoptParserHelpers extends Logging {
       .get(COORDINATE_OPT_CONFIG_REG_ALPHA_RANGE)
       .map(parseDoubleRange)
 
+    val incrementalWeight = input.get(COORDINATE_OPT_CONFIG_INCREMENTAL_WEIGHT).map(_.toDouble)
+
     val reTypeOpt = input.get(COORDINATE_DATA_CONFIG_RANDOM_EFFECT_TYPE)
     val config = reTypeOpt match {
       // Random effect coordinate
@@ -241,7 +245,8 @@ object ScoptParserHelpers extends Logging {
           optimizerConfig,
           regularizationContext,
           regularizationWeightRange = regularizationWeightRange,
-          elasticNetParamRange = elasticNetParamRange)
+          elasticNetParamRange = elasticNetParamRange,
+          incrementalWeight = incrementalWeight)
 
         // Log warnings for fixed effect coordinate settings found in random effect coordinate
         COORDINATE_CONFIG_FIXED_ONLY_ARGS.foreach { config =>
@@ -258,7 +263,8 @@ object ScoptParserHelpers extends Logging {
           optimizerConfig,
           regularizationContext,
           regularizationWeightRange = regularizationWeightRange,
-          elasticNetParamRange = elasticNetParamRange)
+          elasticNetParamRange = elasticNetParamRange,
+          incrementalWeight = incrementalWeight)
 
         // Log warnings for random effect coordinate settings found in fixed effect coordinate
         COORDINATE_CONFIG_RANDOM_ONLY_ARGS.foreach { config =>
@@ -474,6 +480,10 @@ object ScoptParserHelpers extends Logging {
           optConfig.elasticNetParamRange.foreach { range =>
             argsMap += (COORDINATE_OPT_CONFIG_REG_ALPHA_RANGE -> doubleRangeToString(range))
           }
+      }
+
+      optConfig.incrementalWeight.foreach { weight =>
+        argsMap += (COORDINATE_OPT_CONFIG_INCREMENTAL_WEIGHT -> weight.toString)
       }
 
       //

--- a/photon-client/src/main/scala/com/linkedin/photon/ml/io/scopt/game/ScoptGameTrainingParametersParser.scala
+++ b/photon-client/src/main/scala/com/linkedin/photon/ml/io/scopt/game/ScoptGameTrainingParametersParser.scala
@@ -164,7 +164,11 @@ object ScoptGameTrainingParametersParser extends ScoptGameParametersParser {
 
       // Ignore Threshold for New Models
       ScoptParameter[Boolean, Boolean](
-        GameTrainingDriver.ignoreThresholdForNewModels))
+        GameTrainingDriver.ignoreThresholdForNewModels),
+
+      // Incremental training
+      ScoptParameter[Boolean, Boolean](
+        GameTrainingDriver.incrementalTraining))
 
   override protected val parser: OptionParser[ParamMap] = new OptionParser[ParamMap]("GAME-Training") {
 

--- a/photon-client/src/test/scala/com/linkedin/photon/ml/io/scopt/ScoptParserHelpersTest.scala
+++ b/photon-client/src/test/scala/com/linkedin/photon/ml/io/scopt/ScoptParserHelpersTest.scala
@@ -116,6 +116,7 @@ class ScoptParserHelpersTest {
     val regWeights2Str =
       Seq("1", "10", "100", "100", "10").mkString(ScoptParserHelpers.SECONDARY_LIST_DELIMITER.toString)
     val regWeights2 = Set(1, 10, 100)
+    val incrementalWeight = Some(1.1D)
     val activeDataLowerBound1 = None
     val activeDataLowerBound2 = Some(5)
     val activeDataUpperBound1 = None
@@ -146,7 +147,8 @@ class ScoptParserHelpersTest {
       ScoptParserHelpers.COORDINATE_DATA_CONFIG_FEATURES_TO_SAMPLES_RATIO -> featuresSamplesRatio2.get.toString,
       ScoptParserHelpers.COORDINATE_OPT_CONFIG_REGULARIZATION -> regularizationType.toString,
       ScoptParserHelpers.COORDINATE_OPT_CONFIG_REG_WEIGHTS -> regWeights2Str,
-      ScoptParserHelpers.COORDINATE_OPT_CONFIG_REG_ALPHA -> alpha.toString)
+      ScoptParserHelpers.COORDINATE_OPT_CONFIG_REG_ALPHA -> alpha.toString,
+      ScoptParserHelpers.COORDINATE_OPT_CONFIG_INCREMENTAL_WEIGHT -> incrementalWeight.get.toString)
 
     val coordinateConfig1 = ScoptParserHelpers.parseCoordinateConfiguration(inputMap1)(coordinateId)
     coordinateConfig1 match {
@@ -202,6 +204,7 @@ class ScoptParserHelpersTest {
         assertEquals(reConfig.dataConfiguration.numFeaturesToSamplesRatioUpperBound, featuresSamplesRatio2)
         assertEquals(reConfig.optimizationConfiguration.regularizationContext, regularization2)
         assertEquals(reConfig.regularizationWeights, regWeights2)
+        assertEquals(reConfig.optimizationConfiguration.incrementalWeight, incrementalWeight)
 
       case _ =>
         throw new IllegalArgumentException("Expected random effect coordinate configuration.")
@@ -434,6 +437,7 @@ class ScoptParserHelpersTest {
     val featuresSamplesRatio = 6.0
     val regularizationType = RegularizationType.ELASTIC_NET
     val regularizationAlpha = 0.7
+    val incrementalWeight = 1.1
     val regularizationWeights = SortedSet[Double](8.8, 9.9).asInstanceOf[Set[Double]]
 
     val feDataConfig = FixedEffectDataConfiguration(featureShardId, minPartitions)
@@ -469,7 +473,8 @@ class ScoptParserHelpersTest {
       Some(featuresSamplesRatio))
     val optConfig4 = RandomEffectOptimizationConfiguration(
       optimizerConfig,
-      ElasticNetRegularizationContext(regularizationAlpha))
+      ElasticNetRegularizationContext(regularizationAlpha),
+      incrementalWeight = Some(incrementalWeight))
     val coordinateConfig4 = RandomEffectCoordinateConfiguration(dataConfig4, optConfig4, regularizationWeights)
 
     val coordinateConfigurations = ListMap[CoordinateId, CoordinateConfiguration](
@@ -512,7 +517,8 @@ class ScoptParserHelpersTest {
         ScoptParserHelpers.COORDINATE_OPT_CONFIG_REGULARIZATION -> regularizationType.toString,
         ScoptParserHelpers.COORDINATE_OPT_CONFIG_REG_ALPHA -> regularizationAlpha.toString,
         ScoptParserHelpers.COORDINATE_OPT_CONFIG_REG_WEIGHTS ->
-          regularizationWeights.mkString(ScoptParserHelpers.SECONDARY_LIST_DELIMITER.toString)))
+          regularizationWeights.mkString(ScoptParserHelpers.SECONDARY_LIST_DELIMITER.toString),
+        ScoptParserHelpers.COORDINATE_OPT_CONFIG_INCREMENTAL_WEIGHT -> incrementalWeight.toString))
       .map { case (arg, value) =>
         s"$arg${ScoptParserHelpers.KV_DELIMITER}$value"
       }

--- a/photon-lib/src/main/scala/com/linkedin/photon/ml/function/PriorDistribution.scala
+++ b/photon-lib/src/main/scala/com/linkedin/photon/ml/function/PriorDistribution.scala
@@ -20,9 +20,12 @@ import com.linkedin.photon.ml.model.{Coefficients => ModelCoefficients}
 import com.linkedin.photon.ml.util.{BroadcastWrapper, VectorUtils}
 
 /**
- * Trait for an incremental training objective function. It is assumed that the prior is a product of Gaussian and
- * Laplace distributions. The L1 regularization weight refers to the relative weight of the Laplace prior. The L2
- * regularization weight refers to the relative weight of the Gaussian prior.
+ * Trait for an incremental training objective function. It is assumed that the prior is Gaussian Distribution with mean
+ * as prior model's means and variance as prior model's variances. incrementalWeight controls importance of the prior
+ * distribution. The larger incrementalWeight is, the more important the prior distribution is. incrementalWeight has a
+ * default value of 1. l2RegWeight sets the L2 regularization term for any feature which is not included in the prior
+ * model. For any feature which is included in the prior model, the equivalent L2 regularization term is
+ * incrementalWeight / prior model's variance.
  */
 trait PriorDistribution extends ObjectiveFunction {
 

--- a/photon-lib/src/main/scala/com/linkedin/photon/ml/function/PriorDistribution.scala
+++ b/photon-lib/src/main/scala/com/linkedin/photon/ml/function/PriorDistribution.scala
@@ -1,0 +1,207 @@
+/*
+ * Copyright 2020 LinkedIn Corp. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linkedin.photon.ml.function
+
+import breeze.linalg.{DenseMatrix, DenseVector, Vector, diag, sum}
+import com.linkedin.photon.ml.normalization.NormalizationContext
+import com.linkedin.photon.ml.model.{Coefficients => ModelCoefficients}
+import com.linkedin.photon.ml.util.{BroadcastWrapper, VectorUtils}
+
+/**
+ * Trait for an incremental training objective function. It is assumed that the prior is a product of Gaussian and
+ * Laplace distributions. The L1 regularization weight refers to the relative weight of the Laplace prior. The L2
+ * regularization weight refers to the relative weight of the Gaussian prior.
+ */
+trait PriorDistribution extends ObjectiveFunction {
+
+  protected var l2RegWeight: Double = 0D
+  protected var incrementalWeight: Double = 1D
+
+  val priorCoefficients: ModelCoefficients = ModelCoefficients(DenseVector.zeros(1))
+
+  lazy protected val priorMeans: Vector[Double] = priorCoefficients.means
+  lazy protected val priorVariances: Vector[Double] = priorCoefficients.variancesOption.get
+  lazy protected val inversePriorVariances: DenseVector[Double] = VectorUtils.invertVectorWithZeroHandler(priorVariances, l2RegWeight).toDenseVector
+
+  require(l2RegWeight >= 0D, s"Invalid regularization weight '$l2RegWeight")
+
+  /**
+   * Compute the value of the function over the given data for the given model coefficients, with regularization towards
+   * the prior coefficients.
+   *
+   * @param input The data over which to compute the objective function value
+   * @param coefficients The model coefficients for which to compute the objective function's value
+   * @param normalizationContext The normalization context
+   * @return The value of the objective function and regularization terms
+   */
+  abstract override protected[ml] def value(
+      input: Data,
+      coefficients: Vector[Double],
+      normalizationContext: BroadcastWrapper[NormalizationContext]): Double =
+    super.value(input, coefficients, normalizationContext) + l2RegValue(coefficients)
+
+  /**
+   * Compute the Gaussian regularization term for the given model coefficients. L2 regularization term is
+   * incrementalWeight * sum(pow(coefficients - priorMeans, 2) :/ priorVariance) / 2.
+   *
+   * @param coefficients The model coefficients
+   * @return The Gaussian regularization term value
+   */
+  protected def l2RegValue(coefficients: Vector[Double]): Double = {
+
+    val normalizedSquaredCoefficients = (coefficients - priorMeans) *:* inversePriorVariances *:* (coefficients - priorMeans)
+
+    incrementalWeight * sum(normalizedSquaredCoefficients) / 2
+  }
+}
+
+trait PriorDistributionDiff extends DiffFunction with PriorDistribution {
+
+  /**
+   * Compute the value of the function over the given data for the given model coefficients, with regularization towards
+   * the prior coefficients.
+   *
+   * @param input The data over which to compute the objective function value
+   * @param coefficients The model coefficients for which to compute the objective function's value
+   * @param normalizationContext The normalization context
+   * @return The value of the objective function and regularization terms
+   */
+  abstract override protected[ml] def value(
+      input: Data,
+      coefficients: Vector[Double],
+      normalizationContext: BroadcastWrapper[NormalizationContext]): Double =
+    calculate(input, coefficients, normalizationContext)._1
+
+  /**
+   * Compute the gradient of the function over the given data for the given model coefficients, with regularization
+   * towards the prior coefficients.
+   *
+   * @param input The data over which to compute the objective function gradient
+   * @param coefficients The model coefficients for which to compute the objective function's gradient
+   * @param normalizationContext The normalization context
+   * @return The gradient of the objective function and regularization terms
+   */
+  abstract override protected[ml] def gradient(
+      input: Data,
+      coefficients: Vector[Double],
+      normalizationContext: BroadcastWrapper[NormalizationContext]): Vector[Double] =
+    calculate(input, coefficients, normalizationContext)._2
+
+  /**
+   * Compute both the value and the gradient of the function over the given data for the given model coefficients, with
+   * regularization towards the prior coefficients (computing value and gradient at once is more efficient than
+   * computing them sequentially).
+   *
+   * @param input The data over which to compute the objective function value and gradient
+   * @param coefficients The model coefficients for which to compute the objective function's value and gradient
+   * @param normalizationContext The normalization context
+   * @return The value and gradient of the objective function and regularization terms
+   */
+  abstract override protected[ml] def calculate(
+      input: Data,
+      coefficients: Vector[Double],
+      normalizationContext: BroadcastWrapper[NormalizationContext]): (Double, Vector[Double]) = {
+
+    val (baseValue, baseGradient) = super.calculate(input, coefficients, normalizationContext)
+    val valueWithRegularization = baseValue + l2RegValue(coefficients)
+    val gradientWithRegularization = baseGradient + l2RegGradient(coefficients)
+
+    (valueWithRegularization, gradientWithRegularization)
+  }
+
+  /**
+   * Compute the gradient of the Gaussian regularization term for the given model coefficients. Gradient is
+   * incrementalWeight * (coefficients - priorMeans) :/ priorVariance.
+   *
+   * @param coefficients The model coefficients
+   * @return The gradient of the Gaussian regularization term
+   */
+  protected def l2RegGradient(coefficients: Vector[Double]): Vector[Double] = {
+
+    val normalizedCoefficients = (coefficients - priorMeans) *:* inversePriorVariances
+
+    incrementalWeight * normalizedCoefficients
+  }
+}
+
+trait PriorDistributionTwiceDiff extends TwiceDiffFunction with PriorDistributionDiff {
+
+  /**
+   * Compute the Hessian diagonal of the objective function over the given data for the given model coefficients, * the
+   * gradient direction, with regularization towards the prior coefficients.
+   *
+   * @param input The data over which to compute the Hessian diagonal * gradient direction
+   * @param coefficients The model coefficients for which to compute the objective function's Hessian diagonal
+   *                     * gradient direction
+   * @param multiplyVector The gradient direction vector
+   * @param normalizationContext The normalization context
+   * @return The Hessian diagonal (multiplied by the gradient direction) of the objective function and regularization
+   *         terms
+   */
+  abstract override protected[ml] def hessianVector(
+      input: Data,
+      coefficients: Vector[Double],
+      multiplyVector: Vector[Double],
+      normalizationContext: BroadcastWrapper[NormalizationContext]): Vector[Double] =
+    super.hessianVector(input, coefficients, multiplyVector, normalizationContext) +
+      l2RegHessianVector(multiplyVector)
+
+  /**
+   * Compute the Hessian diagonal of the objective function over the given data for the given model coefficients, with
+   * regularization towards the prior coefficients.
+   *
+   * @param input The data over which to compute the Hessian diagonal
+   * @param coefficients The model coefficients for which to compute the objective function's Hessian diagonal
+   * @return The Hessian diagonal of the objective function and regularization terms
+   */
+  abstract override protected[ml] def hessianDiagonal(input: Data, coefficients: Vector[Double]): Vector[Double] =
+    super.hessianDiagonal(input, coefficients) :+ l2RegHessianDiagonal
+
+  /**
+   * Compute the Hessian matrix of the objective function over the given data for the given model coefficients, with
+   * regularization towards the prior coefficients.
+   *
+   * @param input The data over which to compute the Hessian matrix
+   * @param coefficients The model coefficients for which to compute the objective function's Hessian matrix
+   * @return The Hessian matrix of the objective function and regularization terms
+   */
+  abstract override protected[ml] def hessianMatrix(input: Data, coefficients: Vector[Double]): DenseMatrix[Double] =
+    super.hessianMatrix(input, coefficients) + l2RegHessianMatrix
+
+  /**
+   * Compute the Hessian diagonal * gradient direction of the Gaussian regularization term for the given model
+   * coefficients.
+   *
+   * @param multiplyVector The gradient direction vector
+   * @return The Hessian diagonal of the Gaussian regularization term, with gradient direction vector
+   */
+  protected def l2RegHessianVector(multiplyVector: Vector[Double]): Vector[Double] =
+    incrementalWeight * (multiplyVector *:* inversePriorVariances)
+
+  /**
+   * Compute the Hessian diagonal of the Gaussian regularization term for the given model coefficients. Hessian
+   * diagonal is incrementalWeight :/ priorVariance.
+   *
+   * @return The Hessian diagonal of the Gaussian regularization term
+   */
+  protected def l2RegHessianDiagonal: Vector[Double] = incrementalWeight * inversePriorVariances
+
+  /**
+   * Compute the Hessian matrix of the Gaussian regularization term for the given model coefficients.
+   *
+   * @return The Hessian matrix of the Gaussian regularization term
+   */
+  protected def l2RegHessianMatrix: DenseMatrix[Double] = incrementalWeight * diag(inversePriorVariances)
+}

--- a/photon-lib/src/main/scala/com/linkedin/photon/ml/model/Coefficients.scala
+++ b/photon-lib/src/main/scala/com/linkedin/photon/ml/model/Coefficients.scala
@@ -14,7 +14,7 @@
  */
 package com.linkedin.photon.ml.model
 
-import breeze.linalg.{DenseVector, SparseVector, Vector, norm}
+import breeze.linalg.{Vector, norm}
 import breeze.stats.meanAndVariance
 
 import com.linkedin.photon.ml.constants.MathConst
@@ -32,10 +32,12 @@ case class Coefficients(means: Vector[Double], variancesOption: Option[Vector[Do
   extends Summarizable {
 
   // GAME over if variances are given but don't have the same length as the vector of means
-  require(variancesOption.isEmpty || variancesOption.get.length == means.length,
+  require(
+    variancesOption.isEmpty || variancesOption.get.length == means.length,
     "Coefficients: Means and variances have different lengths")
 
   def length: Int = means.length
+
   lazy val meansL2Norm: Double = norm(means, 2)
   lazy val variancesL2NormOption: Option[Double] = variancesOption.map(variances => norm(variances, 2))
 
@@ -47,6 +49,7 @@ case class Coefficients(means: Vector[Double], variancesOption: Option[Vector[Do
    * @return The score
    */
   def computeScore(features: Vector[Double]): Double = {
+
     require(
       means.length == features.length,
       s"Coefficients length (${means.length}) != features length (${features.length})")
@@ -60,6 +63,7 @@ case class Coefficients(means: Vector[Double], variancesOption: Option[Vector[Do
    * @return A summary of the object in string representation
    */
   override def toSummaryString: String = {
+
     val sb = new StringBuilder()
     val isDense = means.getClass.getName.contains("Dense")
     val meanAndVar = meanAndVariance(means)
@@ -96,22 +100,22 @@ case class Coefficients(means: Vector[Double], variancesOption: Option[Vector[Do
    * @param that The other Coefficients to compare to
    * @return True if the Coefficients are equal, false otherwise
    */
-  override def equals(that: Any): Boolean =
-    that match {
-      case other: Coefficients =>
-        val (m1, v1, m2, v2) = (this.means, this.variancesOption, other.means, other.variancesOption)
-        val sameType = m1.getClass == m2.getClass && v1.map(_.getClass) == v2.map(_.getClass)
-        lazy val sameMeans = VectorUtils.areAlmostEqual(m1, m2)
-        lazy val sameVariance = (v1, v2) match {
-          case (None, None) => true
-          case (Some(val1), Some(val2)) => VectorUtils.areAlmostEqual(val1, val2)
-          case (_, _) => false
-        }
+  override def equals(that: Any): Boolean = that match {
+    case other: Coefficients =>
+      val (m1, v1, m2, v2) = (this.means, this.variancesOption, other.means, other.variancesOption)
+      val sameType = (m1.getClass == m2.getClass) && (v1.map(_.getClass) == v2.map(_.getClass))
+      lazy val sameMeans = VectorUtils.areAlmostEqual(m1, m2)
+      lazy val sameVariance = (v1, v2) match {
+        case (None, None) => true
 
-        sameType && sameMeans && sameVariance
+        case (Some(val1), Some(val2)) => VectorUtils.areAlmostEqual(val1, val2)
+        case (_, _) => false
+      }
 
-      case _ => false
-    }
+      sameType && sameMeans && sameVariance
+
+    case _ => false
+  }
 
   /**
    * Returns a hash code value for the object.
@@ -131,7 +135,6 @@ protected[ml] object Coefficients {
    * @param dimension Dimensionality of the coefficient vector
    * @return Zero coefficient vector
    */
-  def initializeZeroCoefficients(dimension: Int): Coefficients = {
+  def initializeZeroCoefficients(dimension: Int): Coefficients =
     Coefficients(Vector.zeros[Double](dimension), variancesOption = None)
-  }
 }

--- a/photon-lib/src/main/scala/com/linkedin/photon/ml/model/GameModel.scala
+++ b/photon-lib/src/main/scala/com/linkedin/photon/ml/model/GameModel.scala
@@ -40,8 +40,17 @@ class GameModel (private val gameModels: Map[CoordinateId, DatumScoringModel]) e
   /**
    * Get a sub-model by name.
    *
-   * @param name The model name
-   * @return An [[Option]] containing the sub-model associated with `name` in the GAME model, or `None` if none exists.
+   * @throws NoSuchElementException if no sub-model with key [[name]] exists
+   * @param name The sub-model name
+   * @return The sub-model associated with [[name]] in the GAME model
+   */
+  def apply(name: CoordinateId): DatumScoringModel = gameModels(name)
+
+  /**
+   * Get a sub-model by name.
+   *
+   * @param name The sub-model name
+   * @return [[Some]] sub-model associated with [[name]] in the GAME model, or [[None]] if none exists.
    */
   def getModel(name: CoordinateId): Option[DatumScoringModel] = gameModels.get(name)
 

--- a/photon-lib/src/main/scala/com/linkedin/photon/ml/util/MathUtils.scala
+++ b/photon-lib/src/main/scala/com/linkedin/photon/ml/util/MathUtils.scala
@@ -63,4 +63,14 @@ object MathUtils {
    * @return True if x1 is greater than x2, false otherwise
    */
   def greaterThan(x1: Double, x2: Double): Boolean = x1 > x2
+
+  /**
+   * Compute the symmetrical difference of two sets (i.e. A ∆ B = (A ⋃ B) - (A ⋂ B))
+   *
+   * @tparam T Some type
+   * @param a The first set
+   * @param b The second set
+   * @return A set containing of elements that are in the first set or the second set but not both sets
+   */
+  def symmetricDifference[T](a: Set[T], b: Set[T]): Set[T] = a.diff(b).union(b.diff(a))
 }

--- a/photon-lib/src/main/scala/com/linkedin/photon/ml/util/VectorUtils.scala
+++ b/photon-lib/src/main/scala/com/linkedin/photon/ml/util/VectorUtils.scala
@@ -20,6 +20,8 @@ import breeze.linalg.{DenseVector, SparseVector, Vector}
 import org.apache.spark.ml.linalg.{DenseVector => SparkMLDenseVector, SparseVector => SparkMLSparseVector, Vector => SparkMLVector}
 import org.apache.spark.mllib.linalg.{DenseVector => SparkDenseVector, SparseVector => SparkSparseVector, Vector => SparkVector}
 
+import com.linkedin.photon.ml.constants.MathConst
+
 /**
  * A utility object that contains operations to create, copy, compare, and convert [[Vector]] objects.
  */
@@ -284,4 +286,15 @@ object VectorUtils {
 
       set
   }
+
+  /**
+   * Element-wise inversion of a [[Vector]], if an element is smaller than MathConst.EPSILON, the inversion will be
+   * replaced by zeroReplacedVal.
+   *
+   * @param vector The [[Vector]] to invert
+   * @param zeroReplacedVal The replaced value when inverting an element close to 0
+   * @return The inverted [[Vector]]
+   */
+  def invertVectorWithZeroHandler(vector: Vector[Double], zeroReplacedVal: Double): Vector[Double] =
+    vector.map(v => if (v > MathConst.EPSILON) 1.0 / v else zeroReplacedVal)
 }

--- a/photon-lib/src/main/scala/com/linkedin/photon/ml/util/VectorUtils.scala
+++ b/photon-lib/src/main/scala/com/linkedin/photon/ml/util/VectorUtils.scala
@@ -296,5 +296,5 @@ object VectorUtils {
    * @return The inverted [[Vector]]
    */
   def invertVectorWithZeroHandler(vector: Vector[Double], zeroReplacedVal: Double): Vector[Double] =
-    vector.map(v => if (v > MathConst.EPSILON) 1.0 / v else zeroReplacedVal)
+    vector.map(v => if (math.abs(v) > MathConst.EPSILON) 1.0 / v else zeroReplacedVal)
 }

--- a/photon-lib/src/test/scala/com/linkedin/photon/ml/function/PriorDistributionTest.scala
+++ b/photon-lib/src/test/scala/com/linkedin/photon/ml/function/PriorDistributionTest.scala
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2019 LinkedIn Corp. All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linkedin.photon.ml.function
+
+import breeze.linalg.{DenseVector, diag}
+import org.testng.annotations.Test
+import org.testng.Assert.assertEquals
+import org.mockito.Mockito.mock
+
+import com.linkedin.photon.ml.model.{Coefficients => ModelCoefficients}
+import com.linkedin.photon.ml.normalization.NormalizationContext
+import com.linkedin.photon.ml.util.BroadcastWrapper
+
+/**
+ * Unit tests for [[PriorDistribution]], [[PriorDistributionDiff]], and [[PriorDistributionTwiceDiff]].
+ */
+class PriorDistributionTest {
+
+  import L2RegularizationTest._
+
+  private val DIMENSION = 4
+
+  /**
+   * Test that the prior distribution mixin traits can correctly modify the existing behaviour of an objective function.
+   */
+  @Test
+  def testAll(): Unit = {
+
+    val mockNormalization = mock(classOf[BroadcastWrapper[NormalizationContext]])
+
+    val coefficients = DenseVector.ones[Double](DIMENSION)
+    val priorMean = coefficients *:* 2D
+    val multiplyVector = coefficients *:* 3D
+    val priorVar = coefficients *:* 4D
+
+    val increWeight = 10D
+
+    val mockObjectiveFunction = new MockObjectiveFunction with PriorDistributionTwiceDiff {
+      override val priorCoefficients = ModelCoefficients(priorMean, Option(priorVar))
+      incrementalWeight = increWeight
+    }
+
+    /**
+     * Assume that coefficients = 1-vector, prior mean = 2-vector, multiply = 3-vector, prior variance = 4-vector for all expected values below
+     *
+     * l2RegValue = sum(DenseVector.fill(DIMENSION){pow(1 - 2, 2) / 4)}) * increWeight / 2 = 0.25 * increWeight * DIMENSION / 2;
+     * l2RegGradient = (1 - 2) / 4 * increWeight = (-0.25) * increWeight;
+     * l2RegHessianDiagonal = 1 / 4 * increWeight = 0.25 * increWeight;
+     * l2RegHessianVector = 3 / 4 * increWeight = 0.75 * increWeight.
+     */
+    val expectedValue = MockObjectiveFunction.VALUE + 0.25 * increWeight * DIMENSION / 2
+    val expectedGradient = DenseVector(Array.fill(DIMENSION)(MockObjectiveFunction.GRADIENT + (-0.25) * increWeight))
+    val expectedVector = DenseVector(Array.fill(DIMENSION)(MockObjectiveFunction.HESSIAN_VECTOR + 0.75 * increWeight))
+    val expectedDiagonal = DenseVector(Array.fill(DIMENSION)(MockObjectiveFunction.HESSIAN_DIAGONAL + 0.25 * increWeight))
+    val expectedMatrix = diag(DenseVector(Array.fill(DIMENSION)(MockObjectiveFunction.HESSIAN_MATRIX + 0.25 * increWeight)))
+
+    assertEquals(mockObjectiveFunction.value(Unit, coefficients, mockNormalization), expectedValue)
+    assertEquals(mockObjectiveFunction.gradient(Unit, coefficients, mockNormalization), expectedGradient)
+    assertEquals(
+      mockObjectiveFunction.hessianVector(Unit, coefficients, multiplyVector, mockNormalization),
+      expectedVector)
+    assertEquals(mockObjectiveFunction.hessianDiagonal(Unit, coefficients), expectedDiagonal)
+    assertEquals(mockObjectiveFunction.hessianMatrix(Unit, coefficients), expectedMatrix)
+  }
+}

--- a/photon-lib/src/test/scala/com/linkedin/photon/ml/function/PriorDistributionTest.scala
+++ b/photon-lib/src/test/scala/com/linkedin/photon/ml/function/PriorDistributionTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 LinkedIn Corp. All rights reserved.
+ * Copyright 2020 LinkedIn Corp. All rights reserved.
  * Licensed under the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License. You may obtain a
  * copy of the License at

--- a/photon-lib/src/test/scala/com/linkedin/photon/ml/util/VectorUtilsTest.scala
+++ b/photon-lib/src/test/scala/com/linkedin/photon/ml/util/VectorUtilsTest.scala
@@ -241,6 +241,19 @@ class VectorUtilsTest {
   @Test(expectedExceptions = Array(classOf[IllegalArgumentException]))
   def testInitializeZerosVectorOfSameTypeOfUnsupportedVectorType(): Unit =
     VectorUtils.zeroOfSameType(new MockVector[Double]())
+
+  @DataProvider
+  def invertVectorWithZeroHandlerProvider() = Array(
+    Array(DenseVector(1.0, 0.0, 2.0), 3.0, DenseVector(1.0, 3.0, 0.5)),
+    Array(new SparseVector(Array(1, 2), Array(1.0, 2.0), 3), 4.0, DenseVector(4.0, 1.0, 0.5))
+  )
+
+  /**
+   * Test inverting vectors with zero handler.
+   */
+  @Test(dataProvider = "invertVectorWithZeroHandlerProvider")
+  def testInvertVectorWithZeroHandler(vector: Vector[Double], replacedVal: Double, expectedVector: Vector[Double]): Unit =
+    assertEquals(VectorUtils.invertVectorWithZeroHandler(vector, replacedVal), expectedVector)
 }
 
 object VectorUtilsTest {


### PR DESCRIPTION
Changes are:
(1) Add `PriorDistribution` to implement incremental learning prior distribution loss function
(2) Enable photon-ml to read variance vectors
(3) Add 2 new parameters: i. Boolean `incrementalLearning` as the switch for incremental learning. ii. `incrementalWeight` to specify the importance of prior distribution.

Current implementation only covers diagonal prior variance. For Full Hessian implementation, see https://github.com/linkedin/photon-ml/pull/450