### PR TITLE
Fix a hyperparameter tuning dimension mismatch bug

### DIFF
--- a/photon-client/src/main/scala/com/linkedin/photon/ml/cli/game/training/GameTrainingDriver.scala
+++ b/photon-client/src/main/scala/com/linkedin/photon/ml/cli/game/training/GameTrainingDriver.scala
@@ -40,9 +40,9 @@ import com.linkedin.photon.ml.io.scopt.game.ScoptGameTrainingParametersParser
 import com.linkedin.photon.ml.model.{DatumScoringModel, FixedEffectModel, RandomEffectModel}
 import com.linkedin.photon.ml.normalization.NormalizationType.NormalizationType
 import com.linkedin.photon.ml.normalization.{NormalizationContext, NormalizationType}
-import com.linkedin.photon.ml.optimization.VarianceComputationType
+import com.linkedin.photon.ml.optimization.{RegularizationType, VarianceComputationType}
 import com.linkedin.photon.ml.optimization.VarianceComputationType.VarianceComputationType
-import com.linkedin.photon.ml.optimization.game.CoordinateOptimizationConfiguration
+import com.linkedin.photon.ml.optimization.game.{CoordinateOptimizationConfiguration, GLMOptimizationConfiguration}
 import com.linkedin.photon.ml.stat.FeatureDataStatistics
 import com.linkedin.photon.ml.util.Implicits._
 import com.linkedin.photon.ml.util.Utils
@@ -660,7 +660,18 @@ object GameTrainingDriver extends GameDriver {
         val (_, baseConfig, evaluationResults) = models.head
 
         val iteration = getOrDefault(hyperParameterTuningIter)
-        val dimension = baseConfig.toSeq.length
+
+        val dimension = baseConfig.toSeq.map {
+          case (_, config: GLMOptimizationConfiguration) =>
+            config.regularizationContext.regularizationType match {
+              case RegularizationType.ELASTIC_NET => 2
+              case RegularizationType.L2 => 1
+              case RegularizationType.L1 => 1
+              case RegularizationType.NONE => 0
+            }
+          case _ => throw new IllegalArgumentException(s"Unknown optimization config!")
+        }.sum
+
         val mode = getOrDefault(hyperParameterTuning)
 
         val evaluator = evaluationResults.get.primaryEvaluator


### PR DESCRIPTION
Fix a hyperparameter tuning dimension calculation bug. 
1. The dimension should be equal to the number of lambdas (magnitude) and alphas (mixing weights). 
2. Right now the dimension is equal to the number of coordinates. 