### PR TITLE
Construct projectors incorporating with prior models

### DIFF
--- a/photon-api/src/integTest/scala/com/linkedin/photon/ml/data/RandomEffectDatasetIntegTest.scala
+++ b/photon-api/src/integTest/scala/com/linkedin/photon/ml/data/RandomEffectDatasetIntegTest.scala
@@ -184,7 +184,7 @@ class RandomEffectDatasetIntegTest extends SparkTestUtils {
     val partitioner = new RandomEffectDatasetPartitioner(NUM_PARTITIONS, sc.broadcast(partitionMap))
 
     val projectorsMap = RandomEffectDataset
-      .generateLinearSubspaceProjectors(keyedGameDatasetRDD, partitioner)
+      .generateLinearSubspaceProjectors(keyedGameDatasetRDD, partitioner, None)
       .collect
       .toMap
 
@@ -381,6 +381,7 @@ class RandomEffectDatasetIntegTest extends SparkTestUtils {
       NUM_PARTITIONS)
     val randomEffectDataset = RandomEffectDataset(
       dataRDD,
+      None,
       randomEffectDataConfig,
       rePartitioner,
       None,
@@ -440,6 +441,7 @@ class RandomEffectDatasetIntegTest extends SparkTestUtils {
       Some(activeDataLowerBound))
     val randomEffectDataset = RandomEffectDataset(
       dataRDD,
+      None,
       randomEffectDataConfig,
       rePartitioner,
       None,


### PR DESCRIPTION
When constructing subspace linear projectors, prior model's active indices should be union with data's active indices, otherwise some of prior model's coefficients will be dropped in the training process. An union step is added in this PR.