### PR TITLE
Remove mean and variance type consistency check

### DIFF
--- a/photon-lib/src/main/scala/com/linkedin/photon/ml/model/Coefficients.scala
+++ b/photon-lib/src/main/scala/com/linkedin/photon/ml/model/Coefficients.scala
@@ -31,10 +31,6 @@ import com.linkedin.photon.ml.util.{MathUtils, Summarizable, VectorUtils}
 case class Coefficients(means: Vector[Double], variancesOption: Option[Vector[Double]] = None)
   extends Summarizable {
 
-  // Force means and variances to be of the same type (dense or sparse). This seems reasonable
-  // and greatly reduces the number of combinations to check in unit testing.
-  require(variancesOption.isEmpty || variancesOption.get.getClass == means.getClass,
-    "Coefficients: If variances are provided, must be of the same vector type as means")
   // GAME over if variances are given but don't have the same length as the vector of means
   require(variancesOption.isEmpty || variancesOption.get.length == means.length,
     "Coefficients: Means and variances have different lengths")

--- a/photon-lib/src/test/scala/com/linkedin/photon/ml/model/CoefficientsTest.scala
+++ b/photon-lib/src/test/scala/com/linkedin/photon/ml/model/CoefficientsTest.scala
@@ -30,8 +30,6 @@ class CoefficientsTest {
   @DataProvider(name = "invalidVectorProvider")
   def makeInvalidVectors(): Array[Array[Vector[Double]]] =
     Array(
-      Array(dense(0,0,3,0), sparse(4)(0,2)(0,3)),
-      Array(sparse(4)(0,2)(0,3), dense(0,0,3,0)),
       Array(dense(1,2,3), dense(1,2)),
       Array(sparse(2)(1,3)(0,2), sparse(3)(4,5)(0,2))
     )


### PR DESCRIPTION
`Coefficients` case class requires means and variances should be of the same type (both are `SparseVector` or `DenseVector`). However this requirement is not needed. 