### PR TITLE
Fix bug which caused all per-entity data sent to a single partitioner before sampling

### DIFF
--- a/photon-api/src/main/scala/com/linkedin/photon/ml/algorithm/RandomEffectCoordinate.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/algorithm/RandomEffectCoordinate.scala
@@ -102,7 +102,15 @@ protected[ml] class RandomEffectCoordinate[Objective <: SingleNodeObjectiveFunct
   override protected[algorithm] def score(model: DatumScoringModel): CoordinateDataScores = model match {
 
     case randomEffectModel: RandomEffectModel =>
-      RandomEffectCoordinate.score(dataset, projectModelForward(randomEffectModel))
+      if (dataset.passiveDataREIds.value.nonEmpty) {
+        val activeScores = RandomEffectCoordinate.scoreActiveData(dataset, projectModelForward(randomEffectModel))
+        val passiveScores = RandomEffectCoordinate.scorePassiveData(dataset, randomEffectModel)
+
+        activeScores + passiveScores
+
+      } else {
+        RandomEffectCoordinate.scoreActiveData(dataset, projectModelForward(randomEffectModel))
+      }
 
     case _ =>
       throw new UnsupportedOperationException(
@@ -296,18 +304,18 @@ object RandomEffectCoordinate {
   }
 
   /**
-   * Score a [[RandomEffectDataset]] using a given [[RandomEffectModel]].
+   * Score the active data of a [[RandomEffectDataset]] using a given [[RandomEffectModel]].
    *
    * For information about the differences between active and passive data, see the [[RandomEffectDataset]]
    * documentation.
    *
    * @note The score is the raw dot product of the model coefficients and the feature values - it does not go through a
    *       non-linear link function.
-   * @param randomEffectDataset The [[RandomEffectDataset]] to score
-   * @param randomEffectModel The [[RandomEffectModel]] with which to score
-   * @return The computed scores
+   * @param randomEffectDataset The [[RandomEffectDataset]] whose active data will be scored
+   * @param randomEffectModel The [[RandomEffectModel]] with which to score the active data
+   * @return The computed active data scores
    */
-  protected[algorithm] def score(
+  protected[algorithm] def scoreActiveData(
       randomEffectDataset: RandomEffectDataset,
       randomEffectModel: RandomEffectModel): CoordinateDataScores = {
 
@@ -324,6 +332,25 @@ object RandomEffectCoordinate {
       }
       .partitionBy(randomEffectDataset.uniqueIdPartitioner)
 
+    new CoordinateDataScores(activeScores)
+  }
+
+  /**
+   * Score the passive data of a [[RandomEffectDataset]] using a given [[RandomEffectModel]].
+   *
+   * For information about the differences between active and passive data, see the [[RandomEffectDataset]]
+   * documentation.
+   *
+   * @note The score is the raw dot product of the model coefficients and the feature values - it does not go through a
+   *       non-linear link function.
+   * @param randomEffectDataset The [[RandomEffectDataset]] whose passive data will be scored
+   * @param randomEffectModel The [[RandomEffectModel]] with which to score the passive data
+   * @return The computed passive data scores
+   */
+  protected[algorithm] def scorePassiveData(
+      randomEffectDataset: RandomEffectDataset,
+      randomEffectModel: RandomEffectModel): CoordinateDataScores = {
+
     // Passive data already uses the GameDatum partitioner. Note that this code assumes few (if any) entities have a
     // passive dataset.
     val passiveDataREIds = randomEffectDataset.passiveDataREIds
@@ -339,6 +366,6 @@ object RandomEffectCoordinate {
         modelsForPassiveData(randomEffectId).computeScore(labeledPoint.features)
       }
 
-    new CoordinateDataScores(activeScores ++ passiveScores)
+    new CoordinateDataScores(passiveScores)
   }
 }

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/algorithm/RandomEffectModelCoordinate.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/algorithm/RandomEffectModelCoordinate.scala
@@ -36,7 +36,15 @@ class RandomEffectModelCoordinate(dataset: RandomEffectDataset)
   override protected[algorithm] def score(model: DatumScoringModel): CoordinateDataScores = {
     model match {
       case randomEffectModel: RandomEffectModel =>
-        RandomEffectCoordinate.score(dataset, projectModelForward(randomEffectModel))
+        if (dataset.passiveDataREIds.value.nonEmpty) {
+          val activeScores = RandomEffectCoordinate.scoreActiveData(dataset, projectModelForward(randomEffectModel))
+          val passiveScores = RandomEffectCoordinate.scorePassiveData(dataset, randomEffectModel)
+
+          activeScores + passiveScores
+
+        } else {
+          RandomEffectCoordinate.scoreActiveData(dataset, projectModelForward(randomEffectModel))
+        }
 
       case _ =>
         throw new UnsupportedOperationException(

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/data/RandomEffectDataset.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/data/RandomEffectDataset.scala
@@ -276,37 +276,38 @@ object RandomEffectDataset {
     //
 
     val keyedGameDataset = generateKeyedGameDataset(gameDataset, randomEffectDataConfiguration)
-    keyedGameDataset.persist(StorageLevel.MEMORY_ONLY_SER).count
+    keyedGameDataset.persist(StorageLevel.MEMORY_AND_DISK_SER).count
 
     // In this RDD, there is a projector for every entity (even those which may later be filtered by the lower bound)
     val unfilteredProjectors = generateLinearSubspaceProjectors(keyedGameDataset, randomEffectPartitioner, priorRandomEffectModelOpt)
     unfilteredProjectors.persist(storageLevel).count
 
-    val projectedKeyedGameDataset = generateProjectedDataset(keyedGameDataset, unfilteredProjectors, randomEffectPartitioner)
-    projectedKeyedGameDataset.persist(StorageLevel.MEMORY_ONLY_SER).count
-
     val unfilteredActiveData = generateGroupedActiveData(
-      projectedKeyedGameDataset,
+      keyedGameDataset,
       randomEffectDataConfiguration,
       randomEffectPartitioner)
+    val projectedGroupedActiveData = generateProjectedActiveData(unfilteredActiveData, unfilteredProjectors)
+    val projectedUnfilteredActiveData = featureSelectionOnActiveData(
+      projectedGroupedActiveData,
+      randomEffectDataConfiguration.numFeaturesToSamplesRatioUpperBound)
 
     val (activeData, passiveData, uniqueIdToRandomEffectIds, projectors) =
       randomEffectDataConfiguration.numActiveDataPointsLowerBound match {
 
         case Some(activeDataLowerBound) =>
 
-          unfilteredActiveData.persist(StorageLevel.MEMORY_ONLY_SER)
+          projectedUnfilteredActiveData.persist(StorageLevel.MEMORY_ONLY_SER)
 
           // Filter entities which do not meet active data lower bound threshold
           val filteredActiveData = filterActiveData(
-            unfilteredActiveData,
+            projectedUnfilteredActiveData,
             activeDataLowerBound,
             existingModelKeysRddOpt)
           filteredActiveData.persist(storageLevel).count
 
           val passiveData = generatePassiveData(
-            projectedKeyedGameDataset,
-            generateIdMap(unfilteredActiveData, uniqueIdPartitioner))
+            keyedGameDataset,
+            generateIdMap(projectedUnfilteredActiveData, uniqueIdPartitioner))
           passiveData.persist(storageLevel).count
 
           val uniqueIdToRandomEffectIds = generateIdMap(filteredActiveData, uniqueIdPartitioner)
@@ -315,22 +316,22 @@ object RandomEffectDataset {
           val filteredProjectors = filterProjectors(unfilteredProjectors, filteredActiveData)
           filteredProjectors.persist(storageLevel).count
 
-          unfilteredActiveData.unpersist()
+          projectedUnfilteredActiveData.unpersist()
           unfilteredProjectors.unpersist()
 
           (filteredActiveData, passiveData, uniqueIdToRandomEffectIds, filteredProjectors)
 
         case None =>
 
-          unfilteredActiveData.persist(storageLevel).count
+          projectedUnfilteredActiveData.persist(storageLevel).count
 
-          val uniqueIdToRandomEffectIds = generateIdMap(unfilteredActiveData, uniqueIdPartitioner)
+          val uniqueIdToRandomEffectIds = generateIdMap(projectedUnfilteredActiveData, uniqueIdPartitioner)
           uniqueIdToRandomEffectIds.persist(storageLevel).count
 
-          val passiveData = generatePassiveData(projectedKeyedGameDataset, uniqueIdToRandomEffectIds)
+          val passiveData = generatePassiveData(keyedGameDataset, uniqueIdToRandomEffectIds)
           passiveData.persist(storageLevel).count
 
-          (unfilteredActiveData, passiveData, uniqueIdToRandomEffectIds, unfilteredProjectors)
+          (projectedUnfilteredActiveData, passiveData, uniqueIdToRandomEffectIds, unfilteredProjectors)
     }
 
     //
@@ -338,7 +339,6 @@ object RandomEffectDataset {
     //
 
     keyedGameDataset.unpersist()
-    projectedKeyedGameDataset.unpersist()
 
     //
     // Return new dataset
@@ -380,7 +380,7 @@ object RandomEffectDataset {
   /**
    * Generate the [[LinearSubspaceProjector]] objects used to compress the feature vectors for each per-entity dataset.
    *
-   * @param keyedGameDataset The data for the given feature shard, keyed by the [[REId]]s for the given [[REType]]
+   * @param unfilteredActiveDataset The data for the given feature shard, keyed by the [[REId]]s for the given [[REType]]
    * @param randomEffectPartitioner A specialized partitioner to co-locate all data from a single entity, while keeping
    *                                the data distribution equal amongst partitions
    * @param priorRandomEffectModelOpt Optional initial random effect models, which will union with data to generate
@@ -388,12 +388,12 @@ object RandomEffectDataset {
    * @return An [[RDD]] of per-entity [[LinearSubspaceProjector]] objects
    */
   protected[data] def generateLinearSubspaceProjectors(
-      keyedGameDataset: RDD[(REId, (UniqueSampleId, LabeledPoint))],
+      unfilteredActiveDataset: RDD[(REId, (UniqueSampleId, LabeledPoint))],
       randomEffectPartitioner: RandomEffectDatasetPartitioner,
       priorRandomEffectModelOpt: Option[RandomEffectModel]): RDD[(REId, LinearSubspaceProjector)] = {
 
     val sc = SparkSession.builder().getOrCreate().sparkContext
-    val originalSpaceDimension = keyedGameDataset
+    val originalSpaceDimension = unfilteredActiveDataset
       .take(1)
       .head
       ._2
@@ -403,7 +403,7 @@ object RandomEffectDataset {
 
     val priorModels = priorRandomEffectModelOpt.map(_.modelsRDD).getOrElse(sc.emptyRDD[(REId, GeneralizedLinearModel)])
 
-    keyedGameDataset
+    unfilteredActiveDataset
       .leftOuterJoin(priorModels)
       .mapValues { case ((_, labeledPoint), priorModelOpt) =>
         val dataActiveIndices = VectorUtils.getActiveIndices(labeledPoint.features)
@@ -417,68 +417,30 @@ object RandomEffectDataset {
   }
 
   /**
-   * Project the per-entity datasets to a linear subspace - thus reducing the size of their feature vectors (for faster
-   * optimization).
-   *
-   * @param keyedGameDataset The data for the given feature shard, keyed by the [[REId]]s for the given [[REType]]
-   * @param projectors An [[RDD]] of per-entity [[LinearSubspaceProjector]] objects
-   * @param randomEffectPartitioner A specialized partitioner to co-locate all data from a single entity, while keeping
-   *                                the data distribution equal amongst partitions
-   * @return The data for the given feature shard, keyed by the [[REId]]s for the given [[REType]], with feature vectors
-   *         reduced to the smallest linear subspace possible without loss
-   */
-  protected[data] def generateProjectedDataset(
-      keyedGameDataset: RDD[(REId, (UniqueSampleId, LabeledPoint))],
-      projectors: RDD[(REId, LinearSubspaceProjector)],
-      randomEffectPartitioner: RandomEffectDatasetPartitioner): RDD[(REId, (UniqueSampleId, LabeledPoint))] =
-
-    keyedGameDataset
-      .partitionBy(randomEffectPartitioner)
-      .zipPartitions(projectors) { case (dataIt, projectorsIt) =>
-
-        val projectorLookupTable = projectorsIt.toMap
-
-        dataIt.map { case (rEID, (uID, LabeledPoint(label, features, offset, weight))) =>
-
-          val projector = projectorLookupTable(rEID)
-          val projectedFeatures = projector.projectForward(features)
-
-          (rEID, (uID, LabeledPoint(label, projectedFeatures, offset, weight)))
-        }
-      }
-
-  /**
    * Generate active data, down-sampling using reservoir sampling if the data for any entity exceeds the upper bound.
    *
-   * @param projectedKeyedDataset The input data, keyed by entity ID
+   * @param keyedGameDataset The input data, keyed by entity ID
    * @param randomEffectDataConfiguration The random effect data configuration
    * @param randomEffectPartitioner A specialized partitioner to co-locate all data from a single entity, while keeping
    *                                the data distribution equal amongst partitions
    * @return The input data, grouped by entity ID, and down-sampled if necessary
    */
   protected[data] def generateGroupedActiveData(
-      projectedKeyedDataset: RDD[(REId, (UniqueSampleId, LabeledPoint))],
-      randomEffectDataConfiguration: RandomEffectDataConfiguration,
-      randomEffectPartitioner: Partitioner): RDD[(REId, LocalDataset)] = {
+    keyedGameDataset: RDD[(REId, (UniqueSampleId, LabeledPoint))],
+    randomEffectDataConfiguration: RandomEffectDataConfiguration,
+    randomEffectPartitioner: Partitioner): RDD[(REId, Iterable[(UniqueSampleId, LabeledPoint)])] =
 
-    // Filter data using reservoir sampling if active data size is bounded
-    val groupedActiveData = randomEffectDataConfiguration
+  // Filter data using reservoir sampling if active data size is bounded
+    randomEffectDataConfiguration
       .numActiveDataPointsUpperBound
       .map { activeDataUpperBound =>
         groupDataByKeyAndSample(
-          projectedKeyedDataset,
+          keyedGameDataset,
           randomEffectPartitioner,
           activeDataUpperBound,
           randomEffectDataConfiguration.randomEffectType)
       }
-      .getOrElse(projectedKeyedDataset.groupByKey(randomEffectPartitioner))
-      .mapValues { iterable =>
-        LocalDataset(iterable.toArray, isSortedByFirstIndex = false)
-      }
-
-    // Filter features if feature dimension of active data is bounded
-    featureSelectionOnActiveData(groupedActiveData, randomEffectDataConfiguration.numFeaturesToSamplesRatioUpperBound)
-  }
+      .getOrElse(keyedGameDataset.groupByKey(randomEffectPartitioner))
 
   /**
    * Generate a dataset grouped by random effect ID and limited to a maximum number of samples selected via reservoir
@@ -495,10 +457,10 @@ object RandomEffectDataset {
    * @return An [[RDD]] of data grouped by individual ID
    */
   private def groupDataByKeyAndSample(
-      projectedKeyedDataset: RDD[(REId, (UniqueSampleId, LabeledPoint))],
-      partitioner: Partitioner,
-      sampleCap: Int,
-      randomEffectType: REType): RDD[(REId, Iterable[(UniqueSampleId, LabeledPoint)])] = {
+    projectedKeyedDataset: RDD[(REId, (UniqueSampleId, LabeledPoint))],
+    partitioner: Partitioner,
+    sampleCap: Int,
+    randomEffectType: REType): RDD[(REId, Iterable[(UniqueSampleId, LabeledPoint)])] = {
 
     // Helper class for defining a constant ordering between data samples (necessary for RDD re-computation)
     case class ComparableLabeledPointWithId(comparableKey: Int, uniqueId: UniqueSampleId, labeledPoint: LabeledPoint)
@@ -519,14 +481,14 @@ object RandomEffectDataset {
       }
 
     val mergeValue = (
-        minHeapWithFixedCapacity: MinHeapWithFixedCapacity[ComparableLabeledPointWithId],
-        comparableLabeledPointWithId: ComparableLabeledPointWithId) => {
+      minHeapWithFixedCapacity: MinHeapWithFixedCapacity[ComparableLabeledPointWithId],
+      comparableLabeledPointWithId: ComparableLabeledPointWithId) => {
       minHeapWithFixedCapacity += comparableLabeledPointWithId
     }
 
     val mergeCombiners = (
-        minHeapWithFixedCapacity1: MinHeapWithFixedCapacity[ComparableLabeledPointWithId],
-        minHeapWithFixedCapacity2: MinHeapWithFixedCapacity[ComparableLabeledPointWithId]) => {
+      minHeapWithFixedCapacity1: MinHeapWithFixedCapacity[ComparableLabeledPointWithId],
+      minHeapWithFixedCapacity2: MinHeapWithFixedCapacity[ComparableLabeledPointWithId]) => {
       minHeapWithFixedCapacity1 ++= minHeapWithFixedCapacity2
     }
 
@@ -540,10 +502,10 @@ object RandomEffectDataset {
         ComparableLabeledPointWithId(comparableKey, uniqueId, labeledPoint)
       }
       .combineByKey[MinHeapWithFixedCapacity[ComparableLabeledPointWithId]](
-        createCombiner,
-        mergeValue,
-        mergeCombiners,
-        partitioner)
+      createCombiner,
+      mergeValue,
+      mergeCombiners,
+      partitioner)
       .mapValues { minHeapWithFixedCapacity =>
         val count = minHeapWithFixedCapacity.getCount
         val data = minHeapWithFixedCapacity.getData
@@ -554,6 +516,55 @@ object RandomEffectDataset {
         }
       }
   }
+
+  /**
+   * Project the per-entity datasets to a linear subspace - thus reducing the size of their feature vectors (for faster
+   * optimization).
+   *
+   * @param keyedGameDataset Per-entity datasets, keyed by the [[REId]]s for the given [[REType]]
+   * @param projectors A [[RDD]] of per-entity [[LinearSubspaceProjector]] objects
+   * @return The per-entity datasets, keyed by the [[REId]]s for the given [[REType]], with feature vectors reduced to
+   *         the smallest linear subspace possible without loss
+   */
+  protected[data] def generateProjectedActiveData(
+      keyedGameDataset: RDD[(REId, Iterable[(UniqueSampleId, LabeledPoint)])],
+      projectors: RDD[(REId, LinearSubspaceProjector)]): RDD[(REId, LocalDataset)] =
+
+    keyedGameDataset
+      .join(projectors)
+      .mapValues { case (localData, projector) =>
+        val projectedData = localData.map { case (uid, LabeledPoint(label, features, offset, weight)) =>
+          (uid, LabeledPoint(label, projector.projectForward(features), offset, weight))
+        }
+
+        LocalDataset(projectedData.toArray, isSortedByFirstIndex = false)
+      }
+
+  /**
+   * Reduce active data feature dimension for entities with few samples. The maximum feature dimension is limited to
+   * the number of samples multiplied by the feature dimension ratio. Features are chosen by greatest Pearson
+   * correlation score.
+   *
+   * @param activeData An [[RDD]] of data grouped by entity ID
+   * @param numFeaturesToSamplesRatioUpperBoundOpt Optional ratio of samples to feature dimension
+   * @return The input data with feature dimension reduced for entities whose feature dimension greatly exceeded the
+   *         number of available samples
+   */
+  private def featureSelectionOnActiveData(
+    activeData: RDD[(REId, LocalDataset)],
+    numFeaturesToSamplesRatioUpperBoundOpt: Option[Double]): RDD[(REId, LocalDataset)] =
+    numFeaturesToSamplesRatioUpperBoundOpt
+      .map { numFeaturesToSamplesRatioUpperBound =>
+        activeData.mapValues { localDataset =>
+
+          var numFeaturesToKeep = math.ceil(numFeaturesToSamplesRatioUpperBound * localDataset.numDataPoints).toInt
+          // In case the above product overflows
+          if (numFeaturesToKeep < 0) numFeaturesToKeep = Int.MaxValue
+
+          localDataset.filterFeaturesByPearsonCorrelationScore(numFeaturesToKeep)
+        }
+      }
+      .getOrElse(activeData)
 
   /**
    * Filter out entities with less data than a given threshold.
@@ -584,32 +595,6 @@ object RandomEffectDataset {
           data.numDataPoints >= numActiveDataPointsLowerBound
         }
     }
-
-  /**
-   * Reduce active data feature dimension for entities with few samples. The maximum feature dimension is limited to
-   * the number of samples multiplied by the feature dimension ratio. Features are chosen by greatest Pearson
-   * correlation score.
-   *
-   * @param activeData An [[RDD]] of data grouped by entity ID
-   * @param numFeaturesToSamplesRatioUpperBoundOpt Optional ratio of samples to feature dimension
-   * @return The input data with feature dimension reduced for entities whose feature dimension greatly exceeded the
-   *         number of available samples
-   */
-  private def featureSelectionOnActiveData(
-      activeData: RDD[(REId, LocalDataset)],
-      numFeaturesToSamplesRatioUpperBoundOpt: Option[Double]): RDD[(REId, LocalDataset)] =
-    numFeaturesToSamplesRatioUpperBoundOpt
-      .map { numFeaturesToSamplesRatioUpperBound =>
-        activeData.mapValues { localDataset =>
-
-          var numFeaturesToKeep = math.ceil(numFeaturesToSamplesRatioUpperBound * localDataset.numDataPoints).toInt
-          // In case the above product overflows
-          if (numFeaturesToKeep < 0) numFeaturesToKeep = Int.MaxValue
-
-          localDataset.filterFeaturesByPearsonCorrelationScore(numFeaturesToKeep)
-        }
-      }
-      .getOrElse(activeData)
 
   /**
    * Generate a map of unique sample id to random effect id for active data samples.


### PR DESCRIPTION
This PR merges conflicts for https://github.com/linkedin/photon-ml/pull/453 by changing `generateLinearSubspaceProjectors` function in `RandomEffectDataset.scala`