### PR TITLE
Minor Feature Normalization Refactor

### DIFF
--- a/photon-api/src/main/scala/com/linkedin/photon/ml/function/glm/GLMLossFunction.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/function/glm/GLMLossFunction.scala
@@ -30,7 +30,6 @@ object GLMLossFunction {
    * @param lossFunction A [[PointwiseLossFunction]] for training a generalized linear model
    * @param treeAggregateDepth The tree-aggregate depth to use during aggregation
    * @param config Optimization problem configuration
-   * @param isIncrementalTraining Is this an objective function for incremental training?
    * @return A function which builds the appropriate type of [[ObjectiveFunction]] for a given [[Coordinate]] type and
    *         optimization settings.
    */

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/optimization/DistributedOptimizationProblem.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/optimization/DistributedOptimizationProblem.scala
@@ -125,9 +125,10 @@ protected[ml] class DistributedOptimizationProblem[Objective <: DistributedObjec
 
     val normalizationContext = optimizer.getNormalizationContext
     val (optimizedCoefficients, stateTracker, _) = optimizer.optimize(objectiveFunction, initialModel.coefficients.means)(input)
-    val optimizedVariances = computeVariances(input, optimizedCoefficients)
+    val origOptimizedCoef = normalizationContext.value.coefToOriginalSpace(optimizedCoefficients)
+    val origOptimizedVar = computeVariances(input, origOptimizedCoef)
 
-    (createModel(normalizationContext, optimizedCoefficients, optimizedVariances), stateTracker)
+    (createModel(origOptimizedCoef, origOptimizedVar), stateTracker)
   }
 
   /**

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/optimization/GeneralizedLinearOptimizationProblem.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/optimization/GeneralizedLinearOptimizationProblem.scala
@@ -68,22 +68,6 @@ protected[ml] abstract class GeneralizedLinearOptimizationProblem[Objective <: O
     glmConstructor(Coefficients(coefficients, variances))
 
   /**
-   * Create a GLM from given normalized coefficients (potentially including intercept)
-   *
-   * @param normalizationContext The normalization context
-   * @param coefficients The feature coefficients means
-   * @param variances The feature coefficient variances
-   * @return A GLM with the provided feature coefficients
-   */
-  protected def createModel(
-      normalizationContext: BroadcastWrapper[NormalizationContext],
-      coefficients: Vector[Double],
-      variances: Option[Vector[Double]]): GeneralizedLinearModel =
-    createModel(
-      normalizationContext.value.modelToOriginalSpace(coefficients),
-      variances.map(normalizationContext.value.modelToOriginalSpace))
-
-  /**
    * Compute coefficient variances
    *
    * @param input The training data

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/optimization/SingleNodeOptimizationProblem.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/optimization/SingleNodeOptimizationProblem.scala
@@ -91,9 +91,10 @@ protected[ml] class SingleNodeOptimizationProblem[Objective <: SingleNodeObjecti
 
     val normalizationContext = optimizer.getNormalizationContext
     val (optimizedCoefficients, stateTracker, _) = optimizer.optimize(objectiveFunction, initialModel.coefficients.means)(input)
-    val optimizedVariances = computeVariances(input, optimizedCoefficients)
+    val origOptimizedCoef = normalizationContext.value.coefToOriginalSpace(optimizedCoefficients)
+    val origOptimizedVar = computeVariances(input, origOptimizedCoef)
 
-    (createModel(normalizationContext, optimizedCoefficients, optimizedVariances), stateTracker)
+    (createModel(origOptimizedCoef, origOptimizedVar), stateTracker)
   }
 }
 

--- a/photon-lib/src/main/scala/com/linkedin/photon/ml/normalization/NormalizationContext.scala
+++ b/photon-lib/src/main/scala/com/linkedin/photon/ml/normalization/NormalizationContext.scala
@@ -69,12 +69,12 @@ protected[ml] class NormalizationContext(
    * have:
    *
    * w = w' .* factor
-   * b = - w'^T^ shift + b'
+   * b = - w ^T^ shift + b'
    *
    * @param inputCoef The coefficients + the intercept (if present) in the transformed space
    * @return The coefficients + the intercept (if present) in the original space
    */
-  def modelToOriginalSpace(inputCoef: Vector[Double]): Vector[Double] =
+  def coefToOriginalSpace(inputCoef: Vector[Double]): Vector[Double] =
     if (size == 0) {
       inputCoef
     } else {
@@ -108,7 +108,7 @@ protected[ml] class NormalizationContext(
    * @param inputCoef The coefficients + the intercept (if present) in the original space
    * @return The coefficients + the intercept (if present) in the transformed space
    */
-  def modelToTransformedSpace(inputCoef: Vector[Double]): Vector[Double] =
+  def coefToTransformedSpace(inputCoef: Vector[Double]): Vector[Double] =
     if (size == 0) {
       inputCoef
     } else {
@@ -125,6 +125,36 @@ protected[ml] class NormalizationContext(
       }
 
       outputCoef
+    }
+
+  /**
+   * Transform the variance of the model coefficients of the original space to the transformed space. Will be used in
+   * constructing the prior.
+   *
+   * w' = w ./ factor
+   * b' = w^T^ shift + b
+   *
+   * Then variance transformation formula is
+   *
+   * Var(w') = Var(w) ./ (factor .* factor)
+   * Var(b') = Var(b)
+   *
+   * @param inputVar The variance of coefficients + the intercept (if present) in the transformed space
+   * @return The variance of coefficients + the intercept (if present) in the original space
+   */
+  def varToTransformedSpace(inputVar: Vector[Double]): Vector[Double] =
+    if (size == 0) {
+      inputVar
+    } else {
+      require(size == inputVar.size, "Vector size and the scaling factor size are different.")
+
+      val outputVar = inputVar.copy
+
+      factorsOpt.foreach { factors =>
+        // Factors of intercept is 1
+        outputVar :/= (factors *:* factors)
+      }
+      outputVar
     }
 }
 

--- a/photon-lib/src/main/scala/com/linkedin/photon/ml/optimization/Optimizer.scala
+++ b/photon-lib/src/main/scala/com/linkedin/photon/ml/optimization/Optimizer.scala
@@ -164,7 +164,7 @@ abstract class Optimizer[-Function <: ObjectiveFunction](
       initialCoefficients: Vector[Double])(
       data: objectiveFunction.Data): (Vector[Double], OptimizationStatesTracker, Double) = {
 
-    val normalizedInitialCoefficients = normalizationContext.value.modelToTransformedSpace(initialCoefficients)
+    val normalizedInitialCoefficients = normalizationContext.value.coefToTransformedSpace(initialCoefficients)
 
     // Reset Optimizer inner state
     clearOptimizerInnerState()


### PR DESCRIPTION
Had a minor refactor of feature normalization related code. Changes are:

1. Fixed a bug in calculating variance when feature normalization is enabled. Previous variance calculation function `createModel` was wrong because means and variance cannot share the same transformation. The correct way of calculating variance when feature normalization is enabled is: first transform the means back to the original space, and then call `computeVariances` function. 

2. Added `normalizationContext` in `PriorDistribution.scala` to enable mean and variance normalization in incremental learning.