### PR TITLE
Add per group evaluation output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [20.0.0] - 2020-05-04
+### Added
+- Added per-group evaluation result output
+### Changed
+- Changed data structure of EvaluationResults
+
 ## [19.0.1] - 2020-04-29
 ### Added
 - Added publish to bintray functionality

--- a/jcenter/bintray.gradle
+++ b/jcenter/bintray.gradle
@@ -43,6 +43,7 @@
  * */
 
 apply plugin: 'com.jfrog.bintray'
+apply plugin: 'maven-publish'
 
 version = libraryVersion
 
@@ -103,6 +104,23 @@ bintray {
         passphrase = properties.getProperty("bintray.gpg.password")
         //Optional. The passphrase for GPG signing'
       }
+    }
+  }
+}
+
+publishToMavenLocal.dependsOn assemble
+publishToMavenLocal.dependsOn sourcesJar
+
+publishing {
+  repositories {
+    maven {
+      url "file://~/.m2/repository"
+    }
+  }
+  publications {
+    testing(MavenPublication) {
+      from components.java
+      artifact sourcesJar
     }
   }
 }

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/estimators/GameEstimator.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/estimators/GameEstimator.scala
@@ -141,7 +141,6 @@ class GameEstimator(val sc: SparkContext, implicit val logger: Logger) extends P
     "use warm start",
     "Whether to train the current model with coefficients initialized by the previous model.")
 
-
   val savePerGroupEvaluationResult: Param[Boolean] = ParamUtils.createParam[Boolean](
     "save per-group evaluation result",
     "Flag to enable save per-group evaluation result."

--- a/photon-client/src/main/scala/com/linkedin/photon/ml/cli/game/training/GameTrainingDriver.scala
+++ b/photon-client/src/main/scala/com/linkedin/photon/ml/cli/game/training/GameTrainingDriver.scala
@@ -227,7 +227,7 @@ object GameTrainingDriver extends GameDriver {
     setDefault(timeZone, Constants.DEFAULT_TIME_ZONE)
     setDefault(ignoreThresholdForNewModels, false)
     setDefault(incrementalTraining, false)
-    setDefault(savePerGroupEvaluationResult, true) //TODO: Testing purpose, default to false before push
+    setDefault(savePerGroupEvaluationResult, false)
   }
 
   /**

--- a/photon-client/src/main/scala/com/linkedin/photon/ml/io/scopt/game/ScoptGameTrainingParametersParser.scala
+++ b/photon-client/src/main/scala/com/linkedin/photon/ml/io/scopt/game/ScoptGameTrainingParametersParser.scala
@@ -168,7 +168,11 @@ object ScoptGameTrainingParametersParser extends ScoptGameParametersParser {
 
       // Incremental training
       ScoptParameter[Boolean, Boolean](
-        GameTrainingDriver.incrementalTraining))
+        GameTrainingDriver.incrementalTraining),
+
+      // Save per-group evaluation result
+      ScoptParameter[Boolean, Boolean](
+        GameTrainingDriver.savePerGroupEvaluationResult))
 
   override protected val parser: OptionParser[ParamMap] = new OptionParser[ParamMap]("GAME-Training") {
 

--- a/photon-client/src/main/scala/com/linkedin/photon/ml/util/IOUtils.scala
+++ b/photon-client/src/main/scala/com/linkedin/photon/ml/util/IOUtils.scala
@@ -397,10 +397,15 @@ object IOUtils {
             .format("com.databricks.spark.avro")
             .save(evalOutputDir.toString)
         }
-        case (evaluatorType, (_, None)) =>
-          logger.debug(s"No per-group evaluation of ${evaluatorType.name}.")
+
+        // No per-group evaluation result be saved to HDFS.
+        case (_, (_, None)) =>
+
+        // Incorrect format of evaluation results.
         case _ => throw new IllegalArgumentException("Unknown format of evaluation result.")
       }
+
+      // No evaluation result to be saved to HDFS.
       case _ => logger.debug(s"No evaluation result to be saved to HDFS.")
     }
   }

--- a/photon-client/src/test/scala/com/linkedin/photon/ml/io/scopt/game/ScoptGameTrainingParametersParserTest.scala
+++ b/photon-client/src/test/scala/com/linkedin/photon/ml/io/scopt/game/ScoptGameTrainingParametersParserTest.scala
@@ -67,6 +67,7 @@ class ScoptGameTrainingParametersParserTest {
     val hyperparameterTuningIter = 6
     val varianceComputation = VarianceComputationType.SIMPLE
     val ignoreThreshold = true
+    val savePerGroupEvaluationResult = true
 
     val featureShard1 = "featureShard1"
     val featureBags1 = Set("bag1", "bag2")
@@ -170,6 +171,7 @@ class ScoptGameTrainingParametersParserTest {
       .put(GameTrainingDriver.hyperParameterTuningIter, hyperparameterTuningIter)
       .put(GameTrainingDriver.varianceComputationType, varianceComputation)
       .put(GameTrainingDriver.ignoreThresholdForNewModels, ignoreThreshold)
+      .put(GameTrainingDriver.savePerGroupEvaluationResult, savePerGroupEvaluationResult)
 
     val finalParamMap = ScoptGameTrainingParametersParser.parseFromCommandLine(
       ScoptGameTrainingParametersParser.printForCommandLine(initialParamMap).flatMap(_.split(" ")).toArray)

--- a/photon-lib/src/integTest/scala/com/linkedin/photon/ml/algorithm/CoordinateDescentIntegTest.scala
+++ b/photon-lib/src/integTest/scala/com/linkedin/photon/ml/algorithm/CoordinateDescentIntegTest.scala
@@ -151,7 +151,7 @@ class CoordinateDescentIntegTest extends SparkTestUtils {
     val evaluations = (0 until (coordinateCount - 1)).map(_ => Random.nextDouble()) :+ finalEvaluation
     val bestEvaluation = evaluations.min
     val evaluationResults = evaluations.map { evaluation =>
-      EvaluationResults(Map(evaluatorType -> evaluation), evaluatorType)
+      EvaluationResults(Map(evaluatorType -> (evaluation, None)), evaluatorType)
     }
     val evaluationResultsIterator = evaluationResults.iterator
 
@@ -244,7 +244,7 @@ class CoordinateDescentIntegTest extends SparkTestUtils {
     // Verify results
     //
 
-    assertEquals(result.get.evaluations(evaluatorType), finalEvaluation, MathConst.EPSILON)
+    assertEquals(result.get.evaluations(evaluatorType)._1, finalEvaluation, MathConst.EPSILON)
     assertNotEquals(result.get.evaluations(evaluatorType), bestEvaluation)
   }
 

--- a/photon-lib/src/main/scala/com/linkedin/photon/ml/algorithm/CoordinateDescent.scala
+++ b/photon-lib/src/main/scala/com/linkedin/photon/ml/algorithm/CoordinateDescent.scala
@@ -325,7 +325,7 @@ object CoordinateDescent {
       results
         .evaluations
         .foreach { case (evaluatorType, evaluation) =>
-          logger.info(s"${evaluatorType.name}: $evaluation")
+          logger.info(s"${evaluatorType.name}: ${evaluation._1}")
         }
 
       results

--- a/photon-lib/src/main/scala/com/linkedin/photon/ml/evaluation/EvaluationResults.scala
+++ b/photon-lib/src/main/scala/com/linkedin/photon/ml/evaluation/EvaluationResults.scala
@@ -14,6 +14,8 @@
  */
 package com.linkedin.photon.ml.evaluation
 
+import org.apache.spark.rdd.RDD
+
 /**
  * Helper object which wraps around a [[Map]] of [[EvaluatorType]] to evaluation metric, and tracks the primary
  * [[EvaluatorType]] / evaluation metric (e.g. used for model selection).
@@ -21,7 +23,9 @@ package com.linkedin.photon.ml.evaluation
  * @param evaluations A [[Map]] of [[EvaluatorType]] to evaluation metric
  * @param primaryEvaluator The primary [[EvaluatorType]]
  */
-case class EvaluationResults(evaluations: Map[EvaluatorType, Double], primaryEvaluator: EvaluatorType) {
+case class EvaluationResults(
+    evaluations: Map[EvaluatorType, (Double, Option[RDD[(String, Double)]])],
+    primaryEvaluator: EvaluatorType) {
 
   require(evaluations.contains(primaryEvaluator), "Primary evaluator not found in evaluations")
 
@@ -30,6 +34,6 @@ case class EvaluationResults(evaluations: Map[EvaluatorType, Double], primaryEva
    *
    * @return The primary evaluation metric
    */
-  def primaryEvaluation: Double = evaluations(primaryEvaluator)
+  def primaryEvaluation: Double = evaluations(primaryEvaluator)._1
 }
 

--- a/photon-lib/src/main/scala/com/linkedin/photon/ml/evaluation/MultiEvaluator.scala
+++ b/photon-lib/src/main/scala/com/linkedin/photon/ml/evaluation/MultiEvaluator.scala
@@ -68,7 +68,7 @@ abstract class MultiEvaluator(
    * Compute an evaluation metric on a per-group basis and save the per group results.
    *
    * @param scoresAndLabelsAndWeights A [[RDD]] of pairs (uniqueId, (score, label, weight))
-   * @return Evaluation metric value
+   * @return A tuple of evaluation metric mean value and per-group evaluation
    */
   def evaluatePerGroup(
       scoresAndLabelsAndWeights: RDD[(UniqueSampleId, (Double, Double, Double))]):

--- a/photon-lib/src/test/scala/com/linkedin/photon/ml/algorithm/CoordinateDescentTest.scala
+++ b/photon-lib/src/test/scala/com/linkedin/photon/ml/algorithm/CoordinateDescentTest.scala
@@ -233,7 +233,7 @@ class CoordinateDescentTest {
     val mockEvaluationResults = mock(classOf[EvaluationResults])
 
     val evaluatorType = EvaluatorType.AUC
-    val evaluation = 1D
+    val evaluation = (1D, None)
     val evaluations = Map(evaluatorType -> evaluation)
 
     doReturn(mockValidationScores).when(mockModel).scoreForCoordinateDescent(mockValidationData)

--- a/photon-lib/src/test/scala/com/linkedin/photon/ml/evaluation/EvaluationResultsTest.scala
+++ b/photon-lib/src/test/scala/com/linkedin/photon/ml/evaluation/EvaluationResultsTest.scala
@@ -14,6 +14,7 @@
  */
 package com.linkedin.photon.ml.evaluation
 
+import org.apache.spark.rdd.RDD
 import org.testng.Assert._
 import org.testng.annotations.Test
 
@@ -31,7 +32,7 @@ class EvaluationResultsTest {
   def testInvalidInput(): Unit = {
 
     val primaryEvaluator: EvaluatorType = EvaluatorType.AUC
-    val evaluations: Map[EvaluatorType, Double] = Map()
+    val evaluations: Map[EvaluatorType, (Double, Option[RDD[(String, Double)]])] = Map()
 
     EvaluationResults(evaluations, primaryEvaluator)
   }
@@ -44,7 +45,8 @@ class EvaluationResultsTest {
 
     val evaluation: Double = 1.23
     val primaryEvaluator: EvaluatorType = EvaluatorType.AUC
-    val evaluations: Map[EvaluatorType, Double] = Map(primaryEvaluator -> evaluation)
+    val evaluations: Map[EvaluatorType, (Double, Option[RDD[(String, Double)]])] =
+      Map(primaryEvaluator -> (evaluation, None))
     val evaluationResults: EvaluationResults = EvaluationResults(evaluations, primaryEvaluator)
 
     assertEquals(evaluation, evaluationResults.primaryEvaluation, MathConst.EPSILON)

--- a/release-bintray.gradle
+++ b/release-bintray.gradle
@@ -56,7 +56,7 @@ ext {
   siteUrl = 'https://github.com/linkedin/photon-ml'
   gitUrl = 'https://github.com/linkedin/photon-ml.git'
 
-  libraryVersion = '19.0.1'
+  libraryVersion = '20.0.0'
 
   licenseName = 'Apache-2.0'
   licenseUrl = 'http://www.apache.org/licenses/LICENSE-2.0'


### PR DESCRIPTION
When the number of random effect entities is small, e.g. in the cohort-based models, users would like to check the evaluations on each group (data grouped by member id, job id, cohort id etc) and analyze the importance of each group to overall evaluation. This PR aims to output the per group evaluation in separate output files. 