### PR TITLE
Optimize per-group evaluation I/O

### DIFF
--- a/photon-client/src/main/scala/com/linkedin/photon/ml/util/IOUtils.scala
+++ b/photon-client/src/main/scala/com/linkedin/photon/ml/util/IOUtils.scala
@@ -391,7 +391,7 @@ object IOUtils {
           sparkSession
             .createDataFrame(groupEval)
             .toDF(evaluatorName(1), evaluatorName(0))
-            .coalesce(1)
+            .repartition(1)
             .write
             .mode(SaveMode.Overwrite)
             .format("com.databricks.spark.avro")

--- a/release-bintray.gradle
+++ b/release-bintray.gradle
@@ -56,7 +56,7 @@ ext {
   siteUrl = 'https://github.com/linkedin/photon-ml'
   gitUrl = 'https://github.com/linkedin/photon-ml.git'
 
-  libraryVersion = '20.0.0'
+  libraryVersion = '20.0.1'
 
   licenseName = 'Apache-2.0'
   licenseUrl = 'http://www.apache.org/licenses/LICENSE-2.0'


### PR DESCRIPTION
Change per-group evaluation output data frame `coalesce` to `repartition` to speed up the I/O.