### PR TITLE
Union random effect prior model coefficients only for incremental tra…

### DIFF
--- a/photon-api/src/main/scala/com/linkedin/photon/ml/estimators/GameEstimator.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/estimators/GameEstimator.scala
@@ -595,7 +595,7 @@ class GameEstimator(val sc: SparkContext, implicit val logger: Logger) extends P
             None
           }
 
-          val randomEffectDataset = if(initialModelOpt.isDefined) {
+          val randomEffectDataset = if(initialModelOpt.isDefined && getOrDefault(incrementalTraining)) {
             val reModels = initialModelOpt.get.getModel(coordinateId).map {
               case reModel: RandomEffectModel =>
                 reModel

--- a/release-bintray.gradle
+++ b/release-bintray.gradle
@@ -56,7 +56,7 @@ ext {
   siteUrl = 'https://github.com/linkedin/photon-ml'
   gitUrl = 'https://github.com/linkedin/photon-ml.git'
 
-  libraryVersion = '20.0.1'
+  libraryVersion = '20.0.2'
 
   licenseName = 'Apache-2.0'
   licenseUrl = 'http://www.apache.org/licenses/LICENSE-2.0'


### PR DESCRIPTION
The prior models of random effect are used to join the random effect dataset and then to get the union of new features (in the dataset) and old features (in the prior model). This is useful in incremental training, but costs inefficiency in other jobs since "join" is expensive. In this PR, we change this join-and-union operation only for incremental training.