### PR TITLE
Use Path to create Hadoop FileSystem to support fully qualified HDFS path

### DIFF
--- a/photon-api/src/main/scala/com/linkedin/photon/ml/index/PalDBIndexMapBuilder.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/index/PalDBIndexMapBuilder.scala
@@ -68,7 +68,7 @@ class PalDBIndexMapBuilder extends IndexMapBuilder with Serializable {
    */
   override def close(): Unit = {
     _storeWriter.close()
-    val fs = FileSystem.get(new Configuration())
+    val fs = _dstFilePath.getFileSystem(new Configuration())
     fs.copyFromLocalFile(new Path(_tmpFile.toString), _dstFilePath)
   }
 

--- a/photon-api/src/main/scala/com/linkedin/photon/ml/index/PalDBIndexMapLoader.scala
+++ b/photon-api/src/main/scala/com/linkedin/photon/ml/index/PalDBIndexMapLoader.scala
@@ -89,7 +89,7 @@ object PalDBIndexMapLoader {
       numPartitions: Int,
       namespace: String = IndexMap.GLOBAL_NS): PalDBIndexMapLoader = {
 
-    val hadoopFS = FileSystem.get(sc.hadoopConfiguration)
+    val hadoopFS = offHeapIndexMapDir.getFileSystem(sc.hadoopConfiguration)
 
     //
     // Pre-conditions

--- a/photon-client/src/main/scala/com/linkedin/photon/ml/data/avro/AvroDataWriter.scala
+++ b/photon-client/src/main/scala/com/linkedin/photon/ml/data/avro/AvroDataWriter.scala
@@ -81,8 +81,8 @@ class AvroDataWriter {
 
     // Write the converted dataset back to HDFS
     if (overwrite) {
-      val fs = FileSystem.get(sc.hadoopConfiguration)
       val output = new Path(outputPath)
+      val fs = output.getFileSystem(sc.hadoopConfiguration)
       if (fs.exists(output)) {
         fs.delete(output, true)
       }

--- a/photon-client/src/main/scala/com/linkedin/photon/ml/data/avro/AvroUtils.scala
+++ b/photon-client/src/main/scala/com/linkedin/photon/ml/data/avro/AvroUtils.scala
@@ -137,8 +137,8 @@ object AvroUtils {
     } else {
       new GenericDatumReader[T](schema)
     }
-    val fs = FileSystem.get(sc.hadoopConfiguration)
     val inputPath = new Path(path)
+    val fs = inputPath.getFileSystem(sc.hadoopConfiguration)
     val fileSize = fs.getContentSummary(inputPath).getLength
 
     require(fileSize < READ_SINGLE_AVRO_FILE_SIZE_LIMIT,

--- a/photon-client/src/main/scala/com/linkedin/photon/ml/data/avro/NameAndTermFeatureMapUtils.scala
+++ b/photon-client/src/main/scala/com/linkedin/photon/ml/data/avro/NameAndTermFeatureMapUtils.scala
@@ -84,7 +84,7 @@ object NameAndTermFeatureMapUtils {
       outputPath: Path,
       sc: SparkContext): Unit = {
 
-    val hadoopFS = FileSystem.get(sc.hadoopConfiguration)
+    val hadoopFS = outputPath.getFileSystem(sc.hadoopConfiguration)
     val tmpPath = new Path(outputPath.getParent, s"${outputPath.getName}-tmp")
 
     // saveAsTextFile in a temporary folder

--- a/photon-client/src/main/scala/com/linkedin/photon/ml/util/IOUtils.scala
+++ b/photon-client/src/main/scala/com/linkedin/photon/ml/util/IOUtils.scala
@@ -330,8 +330,8 @@ object IOUtils {
   def toHDFSFile(sc: SparkContext, fileName: String)(writeOp: PrintWriter => Unit): Try[Unit] = {
 
     val cf = sc.hadoopConfiguration
-    val (fs, fc) = (org.apache.hadoop.fs.FileSystem.get(cf), FileContext.getFileContext(cf))
     val (file, tmpFile, bkpFile) = (new Path(fileName), new Path(fileName + "-tmp"), new Path(fileName + ".prev"))
+    val (fs, fc) = (file.getFileSystem(cf), FileContext.getFileContext(cf))
 
     toStream(fs.create(tmpFile))(writeOp)
       .map(_ => if (fs.exists(file)) fc.rename(file, bkpFile, Options.Rename.OVERWRITE))

--- a/release-bintray.gradle
+++ b/release-bintray.gradle
@@ -56,7 +56,7 @@ ext {
   siteUrl = 'https://github.com/linkedin/photon-ml'
   gitUrl = 'https://github.com/linkedin/photon-ml.git'
 
-  libraryVersion = '20.0.2'
+  libraryVersion = '20.1.0'
 
   licenseName = 'Apache-2.0'
   licenseUrl = 'http://www.apache.org/licenses/LICENSE-2.0'


### PR DESCRIPTION
The FileSystem object should be created from Path object so the URI is captured to support fully qualified HDFS path across the cluster.